### PR TITLE
Run CI on PR opens to all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,9 @@
 name: ci
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
-      - main
+      - '*'
 
 jobs:
   test:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
CR runs aren't showing up on PRs. This is an attempt to fix that

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
