### PR TITLE
turn on all warnings in clippy CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      # TODO: fail on warnings, turn on when clippy warnings are resolved.
-      # matrix:
+      matrix:
         # fail on warnings
-        # args: ["-D warnings"]
+        args: ["-D warnings"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1.0.7


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Turn on fail on all warnings for clippy CI

### Call-outs:
N/A

### Testing:
CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
