### PR TITLE
RSA_sign param type changed

### DIFF
--- a/src/rsa.rs
+++ b/src/rsa.rs
@@ -242,7 +242,7 @@ impl RsaKeyPair {
                 RsaPadding::RSA_PKCS1_PADDING => aws_lc_sys::RSA_sign(
                     digest_alg.hash_nid,
                     digest.as_ptr(),
-                    digest.len() as c_uint,
+                    digest.len(),
                     signature.as_mut_ptr(),
                     &mut (output_len as c_uint),
                     *self.rsa_key,


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
A parameter for RSA_sign (in `aws-lc-sys`) changed types from `c_uint` to `usize`, causing our build to fail. The reflects the change made here: https://github.com/awslabs/aws-lc/commit/da59eeb9ea33c24abab7af35c1fb2b75d7462d3a#diff-84c54f8fa91eb51d2ac9af4ce982834fb185ada6aee788c39d611cf71ca64e9bR597

### Call-outs:
Type changes like this are effectively breaking API changes for consumers of `aws-lc-sys` packages. We need a better way of detecting impactful changes like this.

### Testing:
I ran tests and clippy.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
