### PR TITLE
Integrate MIRAI for static analysis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ aws-lc-sys = { version = "0.1.0" }
 zeroize = "1"
 libc = "0.2"
 thread_local = { version ="1.1.4", optional = true }
+mirai-annotations = "1.12.0"
 
 [dev-dependencies]
 paste = "1.0"

--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -5,6 +5,8 @@ use std::ops::Deref;
 
 use aws_lc_sys::OPENSSL_free;
 
+use mirai_annotations::verify_unreachable;
+
 #[derive(Debug)]
 pub(crate) struct LcPtr<P: Pointer> {
     pointer: P,
@@ -57,10 +59,10 @@ impl<P: Pointer> Deref for DetachableLcPtr<P> {
     fn deref(&self) -> &Self::Target {
         match &self.pointer {
             Some(pointer) => pointer,
-            None => unsafe {
+            None => {
                 // Safety: pointer is only None when DetachableLcPtr is detached or dropped
-                core::hint::unreachable_unchecked()
-            },
+                verify_unreachable!()
+            }
         }
     }
 }
@@ -80,10 +82,10 @@ impl<P: Pointer> DetachableLcPtr<P> {
     pub fn detach(mut self) -> NonNullPtr<P> {
         match self.pointer.take() {
             Some(pointer) => NonNullPtr { pointer },
-            None => unsafe {
+            None => {
                 // Safety: pointer is only None when DetachableLcPtr is detached or dropped
-                core::hint::unreachable_unchecked()
-            },
+                verify_unreachable!()
+            }
         }
     }
 }
@@ -93,10 +95,10 @@ impl<P: Pointer + Copy> DetachableLcPtr<P> {
     pub fn as_non_null(&self) -> NonNullPtr<P> {
         match self.pointer {
             Some(pointer) => NonNullPtr { pointer },
-            None => unsafe {
+            None => {
                 // Safety: pointer is only None when DetachableLcPtr is detached or dropped
-                core::hint::unreachable_unchecked()
-            },
+                verify_unreachable!()
+            }
         }
     }
 }
@@ -106,10 +108,10 @@ impl<P: Pointer> From<DetachableLcPtr<P>> for LcPtr<P> {
     fn from(mut dptr: DetachableLcPtr<P>) -> Self {
         match dptr.pointer.take() {
             Some(pointer) => LcPtr { pointer },
-            None => unsafe {
+            None => {
                 // Safety: pointer is only None when DetachableLcPtr is detached or dropped
-                core::hint::unreachable_unchecked()
-            },
+                verify_unreachable!()
+            }
         }
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -127,6 +127,7 @@
 extern crate alloc;
 
 use alloc::{string::String, vec::Vec};
+use mirai_annotations::unrecoverable;
 
 use crate::{digest, error};
 
@@ -173,7 +174,7 @@ impl TestCase {
         match self.consume_string(key).as_ref() {
             "true" => true,
             "false" => false,
-            s => panic!("Invalid bool value: {}", s),
+            s => unrecoverable!("Invalid bool value: {}", s),
         }
     }
 
@@ -191,7 +192,7 @@ impl TestCase {
             "SHA384" => Some(&digest::SHA384),
             "SHA512" => Some(&digest::SHA512),
             "SHA512_256" => Some(&digest::SHA512_256),
-            _ => panic!("Unsupported digest algorithm: {}", name),
+            _ => unrecoverable!("Unsupported digest algorithm: {}", name),
         }
     }
 
@@ -210,7 +211,7 @@ impl TestCase {
         let result = if s.starts_with('\"') {
             // The value is a quoted UTF-8 string.
 
-            let mut bytes = Vec::with_capacity(s.as_bytes().len() - 2);
+            let mut bytes = Vec::with_capacity(s.as_bytes().len());
             let mut s = s.as_bytes().iter().skip(1);
             loop {
                 let b = match s.next() {
@@ -228,23 +229,24 @@ impl TestCase {
                                 {
                                     (hi << 4) | lo
                                 } else {
-                                    panic!("Invalid hex escape sequence in string.");
+                                    unrecoverable!("Invalid hex escape sequence in string.");
                                 }
                             }
                             _ => {
-                                panic!("Invalid hex escape sequence in string.");
+                                unrecoverable!("Invalid hex escape sequence in string.");
                             }
                         }
                     }
                     Some(b'"') => {
-                        assert!(
-                            s.next().is_none(),
-                            "characters after the closing quote of a quoted string."
-                        );
+                        if s.next().is_some() {
+                            unrecoverable!(
+                                "characters after the closing quote of a quoted string."
+                            );
+                        }
                         break;
                     }
                     Some(b) => *b,
-                    None => panic!("Missing terminating '\"' in string literal."),
+                    None => unrecoverable!("Missing terminating '\"' in string literal."),
                 };
                 bytes.push(b);
             }
@@ -254,7 +256,7 @@ impl TestCase {
             match from_hex(&s) {
                 Ok(s) => s,
                 Err(err_str) => {
-                    panic!("{} in {}", err_str, s);
+                    unrecoverable!("{} in {}", err_str, s);
                 }
             }
         };

--- a/tests/digest_test.rs
+++ b/tests/digest_test.rs
@@ -45,6 +45,7 @@ fn digest_misc() {
 
 mod digest_shavs {
     use aws_lc_ring::{digest, test};
+    use mirai_annotations::checked_assume;
 
     fn run_known_answer_test(digest_alg: &'static digest::Algorithm, test_file: test::File) {
         let section_name = &format!("L = {}", digest_alg.output_len);
@@ -59,7 +60,7 @@ mod digest_shavs {
                 assert_eq!(msg, &[0u8]);
                 msg.truncate(0);
             }
-
+            checked_assume!(msg.len() < usize::MAX / 8);
             assert_eq!(msg.len() * 8, len_bits);
             let expected = test_case.consume_bytes("MD");
             let actual = digest::digest(digest_alg, &msg);

--- a/tests/ecdsa_tests.rs
+++ b/tests/ecdsa_tests.rs
@@ -20,6 +20,7 @@ use aws_lc_ring::{
     signature::{self, KeyPair},
     test, test_file,
 };
+use mirai_annotations::unrecoverable;
 
 #[test]
 fn ecdsa_traits() {
@@ -97,8 +98,10 @@ fn ecdsa_from_pkcs8_test() {
                 error,
             ) {
                 (Ok(_), None) => (),
-                (Err(e), None) => panic!("Failed with error \"{}\", but expected to succeed", e),
-                (Ok(_), Some(e)) => panic!("Succeeded, but expected error \"{}\"", e),
+                (Err(e), None) => {
+                    unrecoverable!("Failed with error \"{}\", but expected to succeed", e)
+                }
+                (Ok(_), Some(e)) => unrecoverable!("Succeeded, but expected error \"{}\"", e),
                 (Err(actual), Some(expected)) => assert_eq!(format!("{}", actual), expected),
             };
 
@@ -193,7 +196,7 @@ fn signature_ecdsa_verify_fixed_test() {
                 ("P-256", "SHA256") => &signature::ECDSA_P256_SHA256_FIXED,
                 ("P-384", "SHA384") => &signature::ECDSA_P384_SHA384_FIXED,
                 _ => {
-                    panic!("Unsupported curve+digest: {}+{}", curve_name, digest_name);
+                    unrecoverable!("Unsupported curve+digest: {}+{}", curve_name, digest_name);
                 }
             };
 

--- a/tests/pbkdf2_test.rs
+++ b/tests/pbkdf2_test.rs
@@ -74,6 +74,7 @@ fn pbkdf2_tests() {
 mod tests {
     use aws_lc_ring::{digest, pbkdf2};
     use core::num::NonZeroU32;
+    use mirai_annotations::assume;
 
     #[test]
     #[should_panic(expected = "derived key too long")]
@@ -86,7 +87,9 @@ mod tests {
             pbkdf2::PBKDF2_HMAC_SHA384,
             pbkdf2::PBKDF2_HMAC_SHA512,
         ] {
-            let mut out = vec![0u8; (max_usize32 - 1) * match_pbkdf2_digest(&alg).output_len + 1];
+            let output_len = match_pbkdf2_digest(&alg).output_len;
+            assume!(output_len < 2048);
+            let mut out = vec![0u8; (max_usize32 - 1) * output_len + 1];
             pbkdf2::derive(alg, iterations, b"salt", b"password", &mut out);
         }
     }


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Add support for static analysis with [MIRAI](https://github.com/facebookexperimental/MIRAI). This change adds a dependency on `mirai-annotations` and resolves all warning when running `cargo mirai`.

### Call-outs:
N/A

### Testing:
```
➜ cargo mirai                                        
    Finished dev [unoptimized + debuginfo] target(s) in 0.72s
    Finished test [unoptimized + debuginfo] target(s) in 0.20s
  Executable tests/rsa_test.rs (target/debug/deps/rsa_test-f971837fe9bfb889)
    Finished test [unoptimized + debuginfo] target(s) in 0.14s
  Executable tests/ed25519_tests.rs (target/debug/deps/ed25519_tests-c5ce041332797b7f)
    Finished test [unoptimized + debuginfo] target(s) in 0.12s
  Executable tests/basic_aead_test.rs (target/debug/deps/basic_aead_test-3a78407f85be5051)
    Finished test [unoptimized + debuginfo] target(s) in 0.13s
  Executable tests/rand_test.rs (target/debug/deps/rand_test-7c846ad75202f290)
    Finished test [unoptimized + debuginfo] target(s) in 0.14s
  Executable tests/ecdsa_tests.rs (target/debug/deps/ecdsa_tests-0be0671726527260)
    Finished test [unoptimized + debuginfo] target(s) in 0.14s
  Executable tests/basic_quic_test.rs (target/debug/deps/basic_quic_test-0b0ab1195977b582)
    Finished test [unoptimized + debuginfo] target(s) in 0.14s
  Executable tests/basic_rsa_test.rs (target/debug/deps/basic_rsa_test-a01c9c7d0d8827b0)
    Finished test [unoptimized + debuginfo] target(s) in 0.12s
  Executable tests/aead_test.rs (target/debug/deps/aead_test-3e9994bdbb68cb06)
    Finished test [unoptimized + debuginfo] target(s) in 0.13s
  Executable tests/quic_test.rs (target/debug/deps/quic_test-3557b0ff998aff2b)
    Finished test [unoptimized + debuginfo] target(s) in 0.14s
  Executable tests/basic_openssh_test.rs (target/debug/deps/basic_openssh_test-f87fa493f58c76f6)
    Finished test [unoptimized + debuginfo] target(s) in 0.13s
  Executable tests/agreement_tests.rs (target/debug/deps/agreement_tests-94ca73b2336368f7)
    Finished test [unoptimized + debuginfo] target(s) in 0.14s
  Executable tests/hkdf_test.rs (target/debug/deps/hkdf_test-8922bd6a6b87ee94)
    Finished test [unoptimized + debuginfo] target(s) in 0.13s
  Executable tests/hmac_test.rs (target/debug/deps/hmac_test-0147751b51971442)
    Finished test [unoptimized + debuginfo] target(s) in 0.13s
  Executable tests/digest_test.rs (target/debug/deps/digest_test-9e26812c47cf368f)
    Finished test [unoptimized + debuginfo] target(s) in 0.15s
  Executable tests/pbkdf2_test.rs (target/debug/deps/pbkdf2_test-811e92e4386546db)

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
