### PR TITLE
Add GitHub CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Add core contributors to all PRs by default
+* @awslabs/aws-lc-dev


### PR DESCRIPTION

### Description of changes: 
Adds GitHub [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file, with this in place we can enable the branch protection mode that will ensure that someone in the group will be required to approve pull requests before a merge can happen.
