### PR TITLE
Add overflow check to prevent failures on 32-bit

### DIFF
--- a/tests/pbkdf2_test.rs
+++ b/tests/pbkdf2_test.rs
@@ -89,7 +89,7 @@ mod tests {
         ] {
             let output_len = match_pbkdf2_digest(&alg).output_len;
             assume!(output_len < 2048);
-            let mut out = vec![0u8; (max_usize32 - 1) * output_len + 1];
+            let mut out = vec![0u8; max_usize32 * output_len + 1];
             pbkdf2::derive(alg, iterations, b"salt", b"password", &mut out);
         }
     }
@@ -105,7 +105,7 @@ mod tests {
             pbkdf2::PBKDF2_HMAC_SHA384,
             pbkdf2::PBKDF2_HMAC_SHA512,
         ] {
-            let out = vec![0u8; (max_usize32 - 1) * match_pbkdf2_digest(&alg).output_len + 1];
+            let out = vec![0u8; max_usize32 * match_pbkdf2_digest(&alg).output_len + 1];
             pbkdf2::verify(alg, iterations, b"salt", b"password", &out).unwrap();
         }
     }


### PR DESCRIPTION
### Issues:
Addresses `CryptoAlg-1422`

### Description of changes: 
Cross compiling aws-lc-ring with the changes in https://github.com/awslabs/aws-lc/pull/689 showed errors when running pbkdf2 on 32-bit systems

### Call-outs:
```
 failures:
 
---- pbkdf2::tests::pbkdf2_coverage stdout ----
thread 'pbkdf2::tests::pbkdf2_coverage' panicked at 'attempt to multiply with overflow', src/pbkdf2.rs:182:22
 
 
failures:
    pbkdf2::tests::pbkdf2_coverage
 
test result: FAILED. 70 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.15s
 
error: test failed, to rerun pass `--lib`
```

### Testing:
Ran locally with the `aws-lc-sys` produced from https://github.com/awslabs/aws-lc/pull/689. 
Command: `cross test --target i686-unknown-linux-gnu`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
