### PR TITLE
Add ephemeral key exchange end-to-end test

### DIFF
--- a/tests/agreement_tests.rs
+++ b/tests/agreement_tests.rs
@@ -217,6 +217,59 @@ fn test_agreement_ecdh_x25519_rfc_iterated() {
     }
 }
 
+#[test]
+fn agree_ephemeral_e2e() {
+    let rng = rand::SystemRandom::new();
+
+    for algorithm in [
+        &agreement::ECDH_P256,
+        &agreement::ECDH_P384,
+        &agreement::X25519,
+    ] {
+        let alice_private_key = agreement::EphemeralPrivateKey::generate(algorithm, &rng).unwrap();
+        let alice_public_key = alice_private_key.compute_public_key().unwrap();
+
+        let bob_private_key = agreement::EphemeralPrivateKey::generate(algorithm, &rng).unwrap();
+        let bob_public_key = bob_private_key.compute_public_key().unwrap();
+
+        let alice_shared_secret = {
+            let mut secret: Vec<u8> = vec![];
+
+            agreement::agree_ephemeral(
+                alice_private_key,
+                &agreement::UnparsedPublicKey::new(algorithm, bob_public_key),
+                ring::error::Unspecified,
+                |value| {
+                    secret.extend_from_slice(value);
+                    Ok(())
+                },
+            )
+            .unwrap();
+
+            secret
+        };
+
+        let bob_shared_secret = {
+            let mut secret: Vec<u8> = vec![];
+
+            agreement::agree_ephemeral(
+                bob_private_key,
+                &agreement::UnparsedPublicKey::new(algorithm, alice_public_key),
+                ring::error::Unspecified,
+                |value| {
+                    secret.extend_from_slice(value);
+                    Ok(())
+                },
+            )
+            .unwrap();
+
+            secret
+        };
+
+        assert_eq!(alice_shared_secret.as_slice(), bob_shared_secret.as_slice());
+    }
+}
+
 fn x25519(private_key: &[u8], public_key: &[u8]) -> Vec<u8> {
     x25519_(private_key, public_key).unwrap()
 }


### PR DESCRIPTION
### Issues:
Addresses V789531504

### Description of changes: 
Adds a complete end-to-end test for ephemeral key agreement algorithms showing the entire lifecycle of a shared secret derivation for both Alice and Bob's keys.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
