### PR TITLE
Fix bench sorting

### DIFF
--- a/util/process-criterion-csv.rs
+++ b/util/process-criterion-csv.rs
@@ -278,6 +278,8 @@ fn test_numerical_end_string_compare() {
     let h987 = "Hello256-987";
     assert_eq!(Ordering::Less, numerical_string_compare(h123, h987));
     assert_eq!(Ordering::Greater, numerical_string_compare(h987, h123));
+    assert_eq!(Ordering::Equal, numerical_string_compare(h123, h123));
+    assert_eq!(Ordering::Equal, numerical_string_compare(h987, h987));
 }
 
 fn main() {


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
I noticed that the keys "Agreement-P384" and "Agreement-P256" were not being sorted properly. After looking at the logic, the bug was clear.



### Call-outs:
N/A

### Testing:
I added a unit test to avoid a regression.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
