### PR TITLE
Fix mirai warnings from tests

### DIFF
--- a/tests/aead_test.rs
+++ b/tests/aead_test.rs
@@ -488,8 +488,11 @@ fn aead_chacha20_poly1305_openssh() {
             }
             {
                 let mut cipher_text_clone = Vec::from(&s_in_out[..]);
-                let o_result =
-                    o_key.open_in_place(sequence_num + 1, &mut cipher_text_clone[..], &tag);
+                let o_result = o_key.open_in_place(
+                    sequence_num.checked_add(1).unwrap(),
+                    &mut cipher_text_clone[..],
+                    &tag,
+                );
                 assert!(o_result.is_err());
             }
             {

--- a/tests/digest_test.rs
+++ b/tests/digest_test.rs
@@ -45,7 +45,6 @@ fn digest_misc() {
 
 mod digest_shavs {
     use aws_lc_ring::{digest, test};
-    use mirai_annotations::checked_assume;
 
     fn run_known_answer_test(digest_alg: &'static digest::Algorithm, test_file: test::File) {
         let section_name = &format!("L = {}", digest_alg.output_len);
@@ -60,8 +59,7 @@ mod digest_shavs {
                 assert_eq!(msg, &[0u8]);
                 msg.truncate(0);
             }
-            checked_assume!(msg.len() < usize::MAX / 8);
-            assert_eq!(msg.len() * 8, len_bits);
+            assert_eq!(msg.len().checked_mul(8).unwrap(), len_bits);
             let expected = test_case.consume_bytes("MD");
             let actual = digest::digest(digest_alg, &msg);
             assert_eq!(&expected, &actual.as_ref());


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Addresses a [couple of mirai warnings](https://github.com/awslabs/aws-lc-ring/actions/runs/3998568322/jobs/6861390655#step:6:81) that I saw on a previous CI run.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
