### PR TITLE
Fix bugs in HMAC, PBKDF2

### DIFF
--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -119,6 +119,7 @@ use crate::error::Unspecified;
 use crate::{constant_time, digest, hmac};
 use aws_lc::PKCS5_PBKDF2_HMAC;
 use core::num::NonZeroU32;
+use zeroize::Zeroize;
 
 /// A PBKDF2 algorithm.
 ///
@@ -274,7 +275,9 @@ pub fn verify(
         };
     }
 
-    constant_time::verify_slices_are_equal(&derived_buf, previously_derived)
+    let result = constant_time::verify_slices_are_equal(&derived_buf, previously_derived);
+    derived_buf.zeroize();
+    result
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Check and panic on LcHmacCtx::clone failure.
* Zeroize potentially sensitive intermediate value used in pbkdf2::verify.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
