### PR TITLE
Simplify Vec usage in serialize_RSA_pubkey

### DIFF
--- a/src/rsa.rs
+++ b/src/rsa.rs
@@ -318,9 +318,7 @@ unsafe fn serialize_RSA_pubkey(pubkey: &ConstPointer<RSA>) -> Result<Box<[u8]>, 
     let pubkey_bytes = LcPtr::new(pubkey_bytes.assume_init())?;
     let outlen = outlen.assume_init();
     let pubkey_slice = slice::from_raw_parts(*pubkey_bytes, outlen);
-    let mut pubkey_vec = Vec::<u8>::new();
-    pubkey_vec.extend_from_slice(pubkey_slice);
-
+    let pubkey_vec = Vec::from(pubkey_slice);
     Ok(pubkey_vec.into_boxed_slice())
 }
 


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Initialize Vec with its contents, instead of adding it after.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
