### PR TITLE
bindgen and asan features work with either fips or non-fips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,7 @@ jobs:
           - --no-default-features --features fips
           - --no-default-features --features fips,ring-io
           - --no-default-features --features fips,alloc
+          - --no-default-features --features fips,bindgen
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1.0.7
@@ -292,6 +293,25 @@ jobs:
         with:
           command: test
           args: --release --lib --bins --tests --examples --target x86_64-unknown-linux-gnu --features asan
+
+  asan-fips:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1.0.7
+        id: toolchain
+        with:
+          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
+          override: true
+      - name: Run address sanitizers
+        uses: actions-rs/cargo@v1.0.3
+        env:
+          ASAN_OPTIONS: detect_leaks=1
+          RUSTFLAGS: -Zsanitizer=address
+          RUSTDOCFLAGS: -Zsanitizer=address
+        with:
+          command: test
+          args: --lib --bins --tests --examples --target x86_64-unknown-linux-gnu --no-default-features --features fips,asan
 
   s2n-quic-integration:
     name: s2n-quic-integration

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,14 @@ rust-version = "1.60"
 alloc = []
 default = ["aws-lc-sys", "alloc", "ring-io"]
 ring-io = []
+bindgen = ["aws-lc-sys?/bindgen", "aws-lc-fips-sys?/bindgen"]
+asan = ["aws-lc-sys?/asan", "aws-lc-fips-sys?/asan"]
 
 # require non-FIPS
 non-fips = ["aws-lc-sys"]
-bindgen = ["non-fips", "aws-lc-sys/bindgen"]
-asan = ["non-fips", "aws-lc-sys/asan"]
 
 # require FIPS
-fips = ["aws-lc-fips-sys"]
-bindgen-fips = ["fips", "aws-lc-fips-sys/bindgen"]
+fips = ["dep:aws-lc-fips-sys"]
 
 [dependencies]
 untrusted = { version = "0.7.1" }

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,14 @@ asan:
 asan-release:
 # TODO: This build target produces linker error on Mac.
 # Run specific tests:
-#	RUST_BACKTRACE=1 ASAN_OPTIONS=detect_leaks=1 RUSTFLAGS=-Zsanitizer=address RUSTDOCFLAGS=-Zsanitizer=address cargo +nightly test --release --test basic_rsa_test              --target `rustc -vV | sed -n 's|host: ||p'`  --features asan
+#	RUST_BACKTRACE=1 ASAN_OPTIONS=detect_leaks=1 RUSTFLAGS=-Zsanitizer=address RUSTDOCFLAGS=-Zsanitizer=address cargo +nightly test --release --test basic_rsa_test           --target `rustc -vV | sed -n 's|host: ||p'`  --features asan
 	RUST_BACKTRACE=1 ASAN_OPTIONS=detect_leaks=1 RUSTFLAGS=-Zsanitizer=address RUSTDOCFLAGS=-Zsanitizer=address cargo +nightly test --release --lib --bins --tests --examples --target `rustc -vV | sed -n 's|host: ||p'`  --features asan
+
+asan-fips:
+# TODO: This build target produces linker error on Mac.
+# Run specific tests:
+#	RUST_BACKTRACE=1 ASAN_OPTIONS=detect_leaks=1 RUSTFLAGS=-Zsanitizer=address RUSTDOCFLAGS=-Zsanitizer=address cargo +nightly test --test ecdsa_tests          --target `rustc -vV | sed -n 's|host: ||p'` --no-default-features --features fips,asan
+	RUST_BACKTRACE=1 ASAN_OPTIONS=detect_leaks=1 RUSTFLAGS=-Zsanitizer=address RUSTDOCFLAGS=-Zsanitizer=address cargo +nightly test --lib --bins --tests --examples --target `rustc -vV | sed -n 's|host: ||p'` --no-default-features --features fips,asan
 
 coverage:
 	cargo llvm-cov --open --hide-instantiations

--- a/build.rs
+++ b/build.rs
@@ -23,15 +23,4 @@ fn main() {
         );
         std::process::exit(1);
     }
-
-    // "aws-lc-fips-sys" should not be specified w/o fips
-    let xnor_count = vec![cfg!(feature = "fips"), cfg!(feature = "aws-lc-fips-sys")]
-        .iter()
-        .filter(|x| **x)
-        .count();
-
-    if xnor_count == 1 {
-        eprint!("For a FIPS build specify the fips feature.");
-        std::process::exit(1);
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,8 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "fips")]
+    // FIPS mode is disabled for an ASAN build
+    #[cfg(all(feature = "fips", not(feature = "asan")))]
     fn test_fips() {
         crate::fips_mode();
     }


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* The "bindgen" and "asan" features can be used for either fips or non-fips builds.
* Added an ASAN+FIPS build to our CI.


### Call-outs:
* With ASAN+FIPS, the `FIPS_mode` function indicates that [FIPS is disabled](https://github.com/awslabs/aws-lc/blob/610e2f58a8596a84be3207d433a2ca3b0c2cb63b/crypto/fipsmodule/self_check/fips.c#L21-L27). So our `test_fips` test does not run for an ASAN build.

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
