### PR TITLE
Only benchmark our library by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Install cargo-udeps
         uses: actions-rs/cargo@v1.0.3
         with:
-          command: install 
+          command: install
           args: cargo-udeps
 
       - name: Run cargo udeps
@@ -185,7 +185,8 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
         target: [native, aarch64-unknown-linux-gnu, i686-unknown-linux-gnu]
         args:
-          - --release --all-targets
+          - --all-targets
+          - --release --all-targets --features ring-benchmarks
           - --no-default-features --features non-fips
           - --no-default-features --features non-fips,ring-io
           - --no-default-features --features non-fips,ring-sig-verify
@@ -268,10 +269,10 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: actions-rs/cargo@v1.0.3
         with:
-          command: install 
+          command: install
           args: cargo-llvm-cov
 
-      # TODO: add bot to post coverage details to PR, or upload results to AWS 
+      # TODO: add bot to post coverage details to PR, or upload results to AWS
       # account. Using --html can give us more insight which regions are missing
       # coverage immediately.
       - name: Run coverage
@@ -334,7 +335,7 @@ jobs:
           RUSTFLAGS: -Zsanitizer=address
           RUSTDOCFLAGS: -Zsanitizer=address
         with:
-          command: test 
+          command: test
           args: --lib --bins --tests --examples --target x86_64-unknown-linux-gnu --features asan
 
   asan-release:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ alloc = []
 default = ["aws-lc-sys", "alloc", "ring-io", "ring-sig-verify"]
 ring-io = ["dep:untrusted"]
 ring-sig-verify = ["dep:untrusted"]
+ring-benchmarks = []
 bindgen = ["aws-lc-sys?/bindgen", "aws-lc-fips-sys?/bindgen"]
 asan = ["aws-lc-sys?/asan", "aws-lc-fips-sys?/asan"]
 

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ coverage:
 
 ci:
 	cargo fmt --check --verbose
+	cargo test --all-targets --features ring-benchmarks
 	cargo test --release --all-targets
 ifeq ($(UNAME_S),Linux)
 	cargo test --release --all-targets --features fips

--- a/README.md
+++ b/README.md
@@ -12,7 +12,14 @@ Allows implementation to allocate values of unbounded size. (The meaning of this
 feature of *ring*.) Currently, this is only required by the `io::writer` module.
 
 * `ring-io` (*default*)
-Enable feature to access the io module.
+This feature enables the `io` module. Requires `untrusted = "0.7.1"`.
+
+* `ring-sig-verify` (*default*)
+This feature enables Trait method `signature::VerificationAlgorithm::verify`. This method is deprecated,
+use `signature::VerificationAlgorithm::verify_sig` instead. Requires `untrusted = "0.7.1"`.
+
+* `ring-benchmarks`
+This feature enables benchmarks to run against `ring`.
 
 * `asan`
 Performs an “address sanitizer” build of *AWS-LC*. This can be used to help detect memory leaks. See the

--- a/benches/aead_benchmark.rs
+++ b/benches/aead_benchmark.rs
@@ -44,10 +44,7 @@ macro_rules! benchmark_aead
 mod [<$pkg _benchmarks>]  {
 
     use $pkg::{aead, error};
-/*
-mod ring_benchmarks {
-    use ring::{aead, error, test};
- */
+
     use criterion::black_box;
     use crate::AeadConfig;
     use aead::{
@@ -122,8 +119,9 @@ mod ring_benchmarks {
 }
 }}}
 
-benchmark_aead!(ring);
 benchmark_aead!(aws_lc_rust);
+#[cfg(feature = "ring-benchmarks")]
+benchmark_aead!(ring);
 
 fn test_aes_128_gcm(c: &mut Criterion) {
     test::run(
@@ -201,13 +199,17 @@ fn test_aead_separate(c: &mut Criterion, config: &AeadConfig) {
         });
     });
 
-    let mut ring_sealing_key = ring_benchmarks::create_sealing_key(config);
-    group.bench_function("Ring", |b| {
-        b.iter(|| {
-            let ring_aad = ring_benchmarks::aad(config);
-            let _tag = ring_benchmarks::seal_separate(&mut ring_sealing_key, ring_aad, &mut in_out);
+    #[cfg(feature = "ring-benchmarks")]
+    {
+        let mut ring_sealing_key = ring_benchmarks::create_sealing_key(config);
+        group.bench_function("Ring", |b| {
+            b.iter(|| {
+                let ring_aad = ring_benchmarks::aad(config);
+                let _tag =
+                    ring_benchmarks::seal_separate(&mut ring_sealing_key, ring_aad, &mut in_out);
+            });
         });
-    });
+    }
 }
 
 fn test_aead_append(c: &mut Criterion, config: &AeadConfig) {
@@ -225,14 +227,17 @@ fn test_aead_append(c: &mut Criterion, config: &AeadConfig) {
         });
     });
 
-    let mut ring_sealing_key = ring_benchmarks::create_sealing_key(config);
-    group.bench_function("Ring", |b| {
-        b.iter(|| {
-            let mut ring_in_out = in_out.clone();
-            let ring_aad = ring_benchmarks::aad(config);
-            ring_benchmarks::seal_append(&mut ring_sealing_key, ring_aad, &mut ring_in_out);
+    #[cfg(feature = "ring-benchmarks")]
+    {
+        let mut ring_sealing_key = ring_benchmarks::create_sealing_key(config);
+        group.bench_function("Ring", |b| {
+            b.iter(|| {
+                let mut ring_in_out = in_out.clone();
+                let ring_aad = ring_benchmarks::aad(config);
+                ring_benchmarks::seal_append(&mut ring_sealing_key, ring_aad, &mut ring_in_out);
+            });
         });
-    });
+    }
 }
 
 fn test_aead_open(c: &mut Criterion, config: &AeadConfig) {
@@ -254,14 +259,17 @@ fn test_aead_open(c: &mut Criterion, config: &AeadConfig) {
         });
     });
 
-    let mut ring_opening_key = ring_benchmarks::create_opening_key(config);
-    group.bench_function("Ring", |b| {
-        b.iter(|| {
-            let mut ring_in_out = in_out.clone();
-            let ring_aad = ring_benchmarks::aad(config);
-            ring_benchmarks::open(&mut ring_opening_key, ring_aad, &mut ring_in_out);
+    #[cfg(feature = "ring-benchmarks")]
+    {
+        let mut ring_opening_key = ring_benchmarks::create_opening_key(config);
+        group.bench_function("Ring", |b| {
+            b.iter(|| {
+                let mut ring_in_out = in_out.clone();
+                let ring_aad = ring_benchmarks::aad(config);
+                ring_benchmarks::open(&mut ring_opening_key, ring_aad, &mut ring_in_out);
+            });
         });
-    });
+    }
 }
 
 criterion_group!(benches, test_aes_128_gcm, test_aes_256_gcm, test_chacha20,);

--- a/benches/agreement_benchmark.rs
+++ b/benches/agreement_benchmark.rs
@@ -45,10 +45,6 @@ macro_rules! benchmark_agreement {
 
             use $pkg::{agreement, test};
 
-/*
-mod ring_benchmarks {
-    use ring::{agreement, test};
-*/
     use crate::{AgreementConfig, Curve};
     use agreement::{
         agree_ephemeral, Algorithm, EphemeralPrivateKey, UnparsedPublicKey, ECDH_P256, ECDH_P384,
@@ -86,6 +82,7 @@ mod ring_benchmarks {
 }
 
 benchmark_agreement!(aws_lc_rust);
+#[cfg(feature = "ring-benchmarks")]
 benchmark_agreement!(ring);
 
 fn test_agree_ephemeral(c: &mut Criterion, config: &AgreementConfig) {
@@ -100,14 +97,16 @@ fn test_agree_ephemeral(c: &mut Criterion, config: &AgreementConfig) {
             aws_lc_rust_benchmarks::agreement(private_key, &aws_peer_public_key);
         });
     });
-
-    let ring_peer_public_key = ring_benchmarks::peer_public_key(config);
-    group.bench_function("Ring", |b| {
-        b.iter(|| {
-            let private_key = ring_benchmarks::private_key(config);
-            ring_benchmarks::agreement(private_key, &ring_peer_public_key);
+    #[cfg(feature = "ring-benchmarks")]
+    {
+        let ring_peer_public_key = ring_benchmarks::peer_public_key(config);
+        group.bench_function("Ring", |b| {
+            b.iter(|| {
+                let private_key = ring_benchmarks::private_key(config);
+                ring_benchmarks::agreement(private_key, &ring_peer_public_key);
+            });
         });
-    });
+    }
 }
 
 fn test_agreement(c: &mut Criterion) {

--- a/benches/digest_benchmark.rs
+++ b/benches/digest_benchmark.rs
@@ -59,8 +59,9 @@ macro_rules! benchmark_digest {
     };
 }
 
-benchmark_digest!(ring);
 benchmark_digest!(aws_lc_rust);
+#[cfg(feature = "ring-benchmarks")]
+benchmark_digest!(ring);
 
 fn bench_sha1(c: &mut Criterion) {
     let config = DigestConfig::new(DigestAlgorithm::SHA1);
@@ -110,12 +111,14 @@ fn bench_digest_one_shot(c: &mut Criterion, config: &DigestConfig) {
                 aws_lc_rust_benchmarks::run_digest_one_shot(config, &chunk);
             });
         });
-
-        group.bench_function("Ring", |b| {
-            b.iter(|| {
-                ring_benchmarks::run_digest_one_shot(config, &chunk);
+        #[cfg(feature = "ring-benchmarks")]
+        {
+            group.bench_function("Ring", |b| {
+                b.iter(|| {
+                    ring_benchmarks::run_digest_one_shot(config, &chunk);
+                });
             });
-        });
+        }
     }
 }
 
@@ -144,12 +147,14 @@ fn bench_digest_incremental(c: &mut Criterion, config: &DigestConfig) {
                 aws_lc_rust_benchmarks::run_digest_incremental(config, &chunk);
             });
         });
-
-        group.bench_function("Ring", |b| {
-            b.iter(|| {
-                ring_benchmarks::run_digest_incremental(config, &chunk);
+        #[cfg(feature = "ring-benchmarks")]
+        {
+            group.bench_function("Ring", |b| {
+                b.iter(|| {
+                    ring_benchmarks::run_digest_incremental(config, &chunk);
+                });
             });
-        });
+        }
     }
 }
 

--- a/benches/hkdf_benchmark.rs
+++ b/benches/hkdf_benchmark.rs
@@ -80,8 +80,9 @@ macro_rules! benchmark_hkdf {
     };
 }
 
-benchmark_hkdf!(ring);
 benchmark_hkdf!(aws_lc_rust);
+#[cfg(feature = "ring-benchmarks")]
+benchmark_hkdf!(ring);
 
 fn bench_hkdf_sha1(c: &mut Criterion) {
     let config = HKDFConfig::new(HKDFAlgorithm::SHA1);
@@ -118,13 +119,15 @@ fn bench_hkdf(c: &mut Criterion, config: &HKDFConfig) {
                 aws_lc_rust_benchmarks::run_hkdf_expand(&aws_prk, info_chunk);
             });
         });
-
-        let ring_prk = ring_benchmarks::run_hkdf_extract(config);
-        group.bench_function("Ring", |b| {
-            b.iter(|| {
-                ring_benchmarks::run_hkdf_expand(&ring_prk, info_chunk);
+        #[cfg(feature = "ring-benchmarks")]
+        {
+            let ring_prk = ring_benchmarks::run_hkdf_extract(config);
+            group.bench_function("Ring", |b| {
+                b.iter(|| {
+                    ring_benchmarks::run_hkdf_expand(&ring_prk, info_chunk);
+                });
             });
-        });
+        }
     }
 }
 

--- a/benches/hmac_benchmark.rs
+++ b/benches/hmac_benchmark.rs
@@ -79,8 +79,9 @@ macro_rules! benchmark_hmac {
     };
 }
 
-benchmark_hmac!(ring);
 benchmark_hmac!(aws_lc_rust);
+#[cfg(feature = "ring-benchmarks")]
+benchmark_hmac!(ring);
 
 fn bench_hmac_sha1(c: &mut Criterion) {
     let config = HMACConfig::new(HMACAlgorithm::SHA1);
@@ -127,12 +128,15 @@ fn bench_hmac_one_shot(c: &mut Criterion, config: &HMACConfig) {
             });
         });
 
-        group.bench_function("Ring", |b| {
-            b.iter(|| {
-                let ring_key = ring_benchmarks::create_hmac_key(config);
-                ring_benchmarks::run_hmac_one_shot(&ring_key, &chunk);
+        #[cfg(feature = "ring-benchmarks")]
+        {
+            group.bench_function("Ring", |b| {
+                b.iter(|| {
+                    let ring_key = ring_benchmarks::create_hmac_key(config);
+                    ring_benchmarks::run_hmac_one_shot(&ring_key, &chunk);
+                });
             });
-        });
+        }
     }
 }
 
@@ -155,12 +159,15 @@ fn bench_hmac_longer_key(c: &mut Criterion, config: &HMACConfig) {
             });
         });
 
-        group.bench_function("Ring", |b| {
-            b.iter(|| {
-                let ring_key = ring_benchmarks::create_longer_hmac_key(config);
-                ring_benchmarks::run_hmac_one_shot(&ring_key, &chunk);
+        #[cfg(feature = "ring-benchmarks")]
+        {
+            group.bench_function("Ring", |b| {
+                b.iter(|| {
+                    let ring_key = ring_benchmarks::create_longer_hmac_key(config);
+                    ring_benchmarks::run_hmac_one_shot(&ring_key, &chunk);
+                });
             });
-        });
+        }
     }
 }
 
@@ -181,13 +188,15 @@ fn bench_hmac_incremental(c: &mut Criterion, config: &HMACConfig) {
                 aws_lc_rust_benchmarks::run_hmac_incremental(&aws_key, &chunk);
             });
         });
-
-        group.bench_function("Ring", |b| {
-            b.iter(|| {
-                let ring_key = ring_benchmarks::create_hmac_key(config);
-                ring_benchmarks::run_hmac_incremental(&ring_key, &chunk);
+        #[cfg(feature = "ring-benchmarks")]
+        {
+            group.bench_function("Ring", |b| {
+                b.iter(|| {
+                    let ring_key = ring_benchmarks::create_hmac_key(config);
+                    ring_benchmarks::run_hmac_incremental(&ring_key, &chunk);
+                });
             });
-        });
+        }
     }
 }
 

--- a/benches/pbkdf2_benchmark.rs
+++ b/benches/pbkdf2_benchmark.rs
@@ -62,8 +62,9 @@ macro_rules! benchmark_pbkdf2 {
     };
 }
 
-benchmark_pbkdf2!(ring);
 benchmark_pbkdf2!(aws_lc_rust);
+#[cfg(feature = "ring-benchmarks")]
+benchmark_pbkdf2!(ring);
 
 fn bench_pbkdf2_sha1(c: &mut Criterion) {
     let config = PBKDF2Config::new(PBKDF2Algorithm::SHA1);
@@ -102,13 +103,15 @@ fn bench_pbkdf2(c: &mut Criterion, config: &PBKDF2Config) {
                 aws_lc_rust_benchmarks::run_pbkdf2_derive(config, iter, &mut aws_out);
             });
         });
-
-        let mut ring_out = vec![0u8; 64];
-        group.bench_function("Ring", |b| {
-            b.iter(|| {
-                ring_benchmarks::run_pbkdf2_derive(config, iter, &mut ring_out);
+        #[cfg(feature = "ring-benchmarks")]
+        {
+            let mut ring_out = vec![0u8; 64];
+            group.bench_function("Ring", |b| {
+                b.iter(|| {
+                    ring_benchmarks::run_pbkdf2_derive(config, iter, &mut ring_out);
+                });
             });
-        });
+        }
     }
 }
 

--- a/benches/quic_benchmark.rs
+++ b/benches/quic_benchmark.rs
@@ -63,8 +63,9 @@ macro_rules! benchmark_quic
         }
 }}}
 
-benchmark_quic!(ring);
 benchmark_quic!(aws_lc_rust);
+#[cfg(feature = "ring-benchmarks")]
+benchmark_quic!(ring);
 
 fn test_new_mask(c: &mut Criterion, config: &QuicConfig) {
     let sample = config.sample.as_slice();
@@ -84,12 +85,15 @@ fn test_new_mask(c: &mut Criterion, config: &QuicConfig) {
         });
     });
 
-    let ring_key = ring_benchmarks::header_protection_key(config);
-    group.bench_function("Ring", |b| {
-        b.iter(|| {
-            ring_benchmarks::new_mask(&ring_key, sample);
+    #[cfg(feature = "ring-benchmarks")]
+    {
+        let ring_key = ring_benchmarks::header_protection_key(config);
+        group.bench_function("Ring", |b| {
+            b.iter(|| {
+                ring_benchmarks::new_mask(&ring_key, sample);
+            });
         });
-    });
+    }
 }
 
 fn test_aes_128(c: &mut Criterion) {


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Change the default to only run benchmarks against our library.
* Benchmarks can be run against `ring` by enabling the `ring-benchmarks` feature.

### Call-outs:
N/A

### Testing:
* I added a test of this feature to our CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
