### PR TITLE
Fix documentation issues

### DIFF
--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -119,7 +119,7 @@
 //!
 //! ## Getting an immutable reference to the IV slice.
 //!
-//! `DecryptionContext` implements `TryFrom<&DecryptionContext>` for `&[u8]` allowing immutable references
+//! `TryFrom<&DecryptionContext>` is implemented for `&[u8]` allowing immutable references
 //! to IV bytes returned from cipher encryption operations. Note this is implemented as a `TryFrom` as it
 //! may fail for future enum variants that aren't representable as a single slice.
 //!


### PR DESCRIPTION
Fixes some documentation that got dropped off from the enum macro change. Unfortunately using macro variables in documentation is not simple, so I have moved these examples to the module level documentation and simplified them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
