### PR TITLE
Provide LessSafeSystemRandom

### DIFF
--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -39,6 +39,7 @@ non-fips = ["aws-lc-sys"]
 fips = ["dep:aws-lc-fips-sys"]
 
 [dependencies]
+getrandom = "0.2.10"
 untrusted = { version = "0.7.1", optional = true }
 aws-lc-sys = { version = "0.8.0", path = "../aws-lc-sys", optional = true }
 aws-lc-fips-sys = { version = "0.9.0", path = "../aws-lc-fips-sys", optional = true }

--- a/aws-lc-rs/src/io/der_writer.rs
+++ b/aws-lc-rs/src/io/der_writer.rs
@@ -71,12 +71,13 @@ mod tests {
     use crate::io::der_writer::{write_all, write_positive_integer};
     use crate::io::writer::{Accumulator, LengthMeasurement};
     use crate::io::Positive;
-    use crate::rand::{generate, SystemRandom};
+    use crate::rand::{generate, LessSafeSystemRandom, SystemRandom};
 
     const TEST_DATA_SIZE: usize = 100;
     #[test]
     fn test_write_positive_integer() {
-        let mut data: [u8; TEST_DATA_SIZE] = generate(&SystemRandom::new()).unwrap().expose();
+        let mut data: [u8; TEST_DATA_SIZE] =
+            generate(&LessSafeSystemRandom::new()).unwrap().expose();
         data[0] |= 0x80; //negative
         let positive = Positive::new_non_empty_without_leading_zeros(untrusted::Input::from(&data));
         let mut length_measurement = LengthMeasurement::zero();


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Add the `rand::LessSafeSystemRandom` type and `rand::less_safe_fill` which expose "random" bytes provided by the host operating system.

### Call-outs:
* These bytes should not be used for key generation.  All of our current key generation mechanisms that accept a `SecureRandom` parameter ignore its value and obtain random bytes through the appropriate function.

### Testing:
Updated/added tests for this new type.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
