### PR TITLE
Add updates to fix CI

### DIFF
--- a/aws-lc-fips-sys/builder/main.rs
+++ b/aws-lc-fips-sys/builder/main.rs
@@ -359,7 +359,7 @@ fn main() {
         RustWrapper.libname(Some(&prefix))
     );
 
-    for include_path in vec![
+    for include_path in [
         get_rust_include_path(&manifest_dir),
         get_generated_include_path(&manifest_dir),
         get_aws_lc_include_path(&manifest_dir),

--- a/aws-lc-rs/build.rs
+++ b/aws-lc-rs/build.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 fn main() {
-    let mutually_exclusives_count = vec![cfg!(feature = "non-fips"), cfg!(feature = "fips")]
+    let mutually_exclusives_count = [cfg!(feature = "non-fips"), cfg!(feature = "fips")]
         .iter()
         .filter(|x| **x)
         .count();
@@ -14,7 +14,7 @@ fn main() {
 
     // This appears asymmetric, but it reflects the `cfg` statements in lib.rs that
     // require `aws-lc-sys` to be present when "fips" is not enabled.
-    let at_least_one_count = vec![cfg!(feature = "aws-lc-sys"), cfg!(feature = "fips")]
+    let at_least_one_count = [cfg!(feature = "aws-lc-sys"), cfg!(feature = "fips")]
         .iter()
         .filter(|x| **x)
         .count();

--- a/aws-lc-rs/src/digest.rs
+++ b/aws-lc-rs/src/digest.rs
@@ -118,7 +118,7 @@ impl Context {
     ///
     /// `finish` consumes the context so it cannot be (mis-)used after `finish`
     /// has been called.
-    /// 
+    ///
     /// # Panics
     /// Panics if the digest is unable to be finalized
     #[inline]

--- a/aws-lc-rs/src/digest.rs
+++ b/aws-lc-rs/src/digest.rs
@@ -83,7 +83,7 @@ impl Context {
 
     /// Updates the message to digest with all the data in `data`.
     ///
-    /// # Panic
+    /// # Panics
     /// Panics if update causes total input length to exceed maximum allowed (`u64::MAX`).
     #[inline]
     pub fn update(&mut self, data: &[u8]) {
@@ -118,6 +118,9 @@ impl Context {
     ///
     /// `finish` consumes the context so it cannot be (mis-)used after `finish`
     /// has been called.
+    /// 
+    /// # Panics
+    /// Panics if the digest is unable to be finalized
     #[inline]
     #[must_use]
     pub fn finish(self) -> Digest {

--- a/aws-lc-rs/src/ed25519.rs
+++ b/aws-lc-rs/src/ed25519.rs
@@ -284,7 +284,7 @@ impl Ed25519KeyPair {
     }
 
     /// Returns the signature of the message msg.
-    /// 
+    ///
     /// # Panics
     /// Panics if the message is unable to be signed
     #[inline]

--- a/aws-lc-rs/src/ed25519.rs
+++ b/aws-lc-rs/src/ed25519.rs
@@ -284,6 +284,9 @@ impl Ed25519KeyPair {
     }
 
     /// Returns the signature of the message msg.
+    /// 
+    /// # Panics
+    /// Panics if the message is unable to be signed
     #[inline]
     #[must_use]
     pub fn sign(&self, msg: &[u8]) -> Signature {
@@ -338,7 +341,7 @@ mod tests {
             expected_public: &'static str,
         }
 
-        for case in vec![
+        for case in [
             TestCase {
                 key: "302e020100300506032b6570042204209d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
                 expected_public: "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",

--- a/aws-lc-rs/src/hkdf.rs
+++ b/aws-lc-rs/src/hkdf.rs
@@ -113,6 +113,9 @@ impl Salt {
     ///
     /// Constructing a `Salt` is relatively expensive so it is good to reuse a
     /// `Salt` object instead of re-constructing `Salt`s with the same value.
+    /// 
+    /// # Panics
+    /// `new` panics if the salt length exceeds the limit
     #[must_use]
     pub fn new(algorithm: Algorithm, value: &[u8]) -> Self {
         Salt::try_new(algorithm, value).expect("Salt length limit exceeded.")
@@ -135,6 +138,9 @@ impl Salt {
     /// The [HKDF-Extract] operation.
     ///
     /// [HKDF-Extract]: https://tools.ietf.org/html/rfc5869#section-2.2
+    /// 
+    /// # Panics
+    /// Panics if the extract operation is unable to be performed
     #[inline]
     #[must_use]
     pub fn extract(&self, secret: &[u8]) -> Prk {
@@ -229,6 +235,9 @@ impl Prk {
     /// Usually one can avoid using this. It is useful when the application
     /// intentionally wants to leak the PRK secret, e.g. to implement
     /// `SSLKEYLOGFILE` functionality.
+    /// 
+    /// # Panics
+    /// Panics if the given Prk length exceeds the limit
     #[must_use]
     pub fn new_less_safe(algorithm: Algorithm, value: &[u8]) -> Self {
         Prk::try_new_less_safe(algorithm, value).expect("Prk length limit exceeded.")

--- a/aws-lc-rs/src/hkdf.rs
+++ b/aws-lc-rs/src/hkdf.rs
@@ -113,7 +113,7 @@ impl Salt {
     ///
     /// Constructing a `Salt` is relatively expensive so it is good to reuse a
     /// `Salt` object instead of re-constructing `Salt`s with the same value.
-    /// 
+    ///
     /// # Panics
     /// `new` panics if the salt length exceeds the limit
     #[must_use]
@@ -138,7 +138,7 @@ impl Salt {
     /// The [HKDF-Extract] operation.
     ///
     /// [HKDF-Extract]: https://tools.ietf.org/html/rfc5869#section-2.2
-    /// 
+    ///
     /// # Panics
     /// Panics if the extract operation is unable to be performed
     #[inline]
@@ -235,7 +235,7 @@ impl Prk {
     /// Usually one can avoid using this. It is useful when the application
     /// intentionally wants to leak the PRK secret, e.g. to implement
     /// `SSLKEYLOGFILE` functionality.
-    /// 
+    ///
     /// # Panics
     /// Panics if the given Prk length exceeds the limit
     #[must_use]

--- a/aws-lc-rs/src/hmac.rs
+++ b/aws-lc-rs/src/hmac.rs
@@ -262,6 +262,9 @@ impl Key {
     /// You should not use keys larger than the `digest_alg.block_len` because
     /// the truncation described above reduces their strength to only
     /// `digest_alg.output_len * 8` bits.
+    /// 
+    /// # Panics
+    /// Panics if the HMAC context cannot be constructed
     #[inline]
     #[must_use]
     pub fn new(algorithm: Algorithm, key_value: &[u8]) -> Self {
@@ -353,6 +356,9 @@ impl Context {
 
     /// Updates the HMAC with all the data in `data`. `update` may be called
     /// zero or more times until `finish` is called.
+    /// 
+    /// # Panics
+    /// Panics if the HMAC cannot be updated
     #[inline]
     pub fn update(&mut self, data: &[u8]) {
         Self::try_update(self, data).expect("HMAC_Update failed");
@@ -379,6 +385,9 @@ impl Context {
     /// It is generally not safe to implement HMAC verification by comparing
     /// the return value of `sign` to a tag. Use `verify` for verification
     /// instead.
+    /// 
+    /// # Panics
+    /// Panics if the HMAC calculation cannot be finalized
     #[inline]
     #[must_use]
     pub fn sign(self) -> Tag {

--- a/aws-lc-rs/src/hmac.rs
+++ b/aws-lc-rs/src/hmac.rs
@@ -262,7 +262,7 @@ impl Key {
     /// You should not use keys larger than the `digest_alg.block_len` because
     /// the truncation described above reduces their strength to only
     /// `digest_alg.output_len * 8` bits.
-    /// 
+    ///
     /// # Panics
     /// Panics if the HMAC context cannot be constructed
     #[inline]
@@ -356,7 +356,7 @@ impl Context {
 
     /// Updates the HMAC with all the data in `data`. `update` may be called
     /// zero or more times until `finish` is called.
-    /// 
+    ///
     /// # Panics
     /// Panics if the HMAC cannot be updated
     #[inline]
@@ -385,7 +385,7 @@ impl Context {
     /// It is generally not safe to implement HMAC verification by comparing
     /// the return value of `sign` to a tag. Use `verify` for verification
     /// instead.
-    /// 
+    ///
     /// # Panics
     /// Panics if the HMAC calculation cannot be finalized
     #[inline]

--- a/aws-lc-rs/src/io/der.rs
+++ b/aws-lc-rs/src/io/der.rs
@@ -269,13 +269,13 @@ mod tests {
             assert_eq!(small_nonnegative_integer(input)?, 0x00);
             Ok(())
         });
-        for &(test_in, test_out) in GOOD_POSITIVE_INTEGERS.iter() {
+        for &(test_in, test_out) in GOOD_POSITIVE_INTEGERS {
             with_good_i(test_in, |input| {
                 assert_eq!(small_nonnegative_integer(input)?, test_out);
                 Ok(())
             });
         }
-        for &test_in in BAD_NONNEGATIVE_INTEGERS.iter() {
+        for &test_in in BAD_NONNEGATIVE_INTEGERS {
             with_bad_i(test_in, |input| {
                 let _: u8 = small_nonnegative_integer(input)?;
                 Ok(())
@@ -289,7 +289,7 @@ mod tests {
             let _: Positive<'_> = positive_integer(input)?;
             Ok(())
         });
-        for &(test_in, test_out) in GOOD_POSITIVE_INTEGERS.iter() {
+        for &(test_in, test_out) in GOOD_POSITIVE_INTEGERS {
             with_good_i(test_in, |input| {
                 let test_out = [test_out];
                 assert_eq!(
@@ -301,7 +301,7 @@ mod tests {
                 Ok(())
             });
         }
-        for &test_in in BAD_NONNEGATIVE_INTEGERS.iter() {
+        for &test_in in BAD_NONNEGATIVE_INTEGERS {
             with_bad_i(test_in, |input| {
                 let _: Positive<'_> = positive_integer(input)?;
                 Ok(())
@@ -323,9 +323,7 @@ mod tests {
 
     #[test]
     fn test_big() {
-        for &((bytes_in_a, bytes_in_b), (bytes_out_a, bytes_out_b)) in
-            GOOD_BIG_POSITIVE_INTEGERS.iter()
-        {
+        for &((bytes_in_a, bytes_in_b), (bytes_out_a, bytes_out_b)) in GOOD_BIG_POSITIVE_INTEGERS {
             let mut bytes_in = Vec::new();
             bytes_in.extend(bytes_in_a);
             bytes_in.extend(bytes_in_b);

--- a/aws-lc-rs/tests/aead_test.rs
+++ b/aws-lc-rs/tests/aead_test.rs
@@ -181,7 +181,7 @@ fn test_aead<Seal, Open>(
         };
         let mut o_in_out = vec![123u8; 4096];
 
-        for &in_prefix_len in in_prefix_lengths.iter() {
+        for &in_prefix_len in in_prefix_lengths {
             o_in_out.truncate(0);
             o_in_out.resize(in_prefix_len, 123);
             o_in_out.extend_from_slice(&ct[..]);

--- a/aws-lc-sys/builder/main.rs
+++ b/aws-lc-sys/builder/main.rs
@@ -350,7 +350,7 @@ fn main() {
         RustWrapper.libname(Some(&prefix))
     );
 
-    for include_path in vec![
+    for include_path in [
         get_rust_include_path(&manifest_dir),
         get_generated_include_path(&manifest_dir),
         get_aws_lc_include_path(&manifest_dir),


### PR DESCRIPTION
### Issues:
Resolves failures in the CI related to `clippy` tests

### Description of changes: 
- Added # Panics section to functions that panic
- Remove unnecessary `vec!` constructs
- Remove unnecessary `iter()` calls

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
