### PR TITLE
Support for Windows/aarch64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ deps/aws-lc-sys/src/bindings.rs
 
 **/target
 /Cargo.lock
+
+/.idea

--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -45,10 +45,13 @@ aws-lc-fips-sys = { version = "0.9.0", path = "../aws-lc-fips-sys", optional = t
 zeroize = "1"
 mirai-annotations = "1.12.0"
 
+[target.'cfg(not(all(target_os = "windows", target_arch = "aarch64")))'.dev-dependencies]
+# ring does not currently support Windows/aarch64: https://github.com/briansmith/ring/issues/1167
+ring = "0.16"
+
 [dev-dependencies]
 paste = "1.0"
 criterion = { version = "0.5.0", features = ["csv_output"] }
-ring = "0.16"
 regex = "1.6.0"
 lazy_static = "1.4.0"
 clap = { version = "4.1.8", features = ["derive"] }

--- a/aws-lc-rs/src/aead/quic.rs
+++ b/aws-lc-rs/src/aead/quic.rs
@@ -177,10 +177,12 @@ fn cipher_new_mask(
 
 #[cfg(test)]
 mod test {
-    use crate::aead::quic::{Algorithm, HeaderProtectionKey, AES_128, AES_256, CHACHA20};
-    use crate::{hkdf, test};
+    use crate::{test, aead::quic::{Algorithm, HeaderProtectionKey}};
+    #[cfg(not(all(target_os = "windows", target_arch = "aarch64")))]
+    use crate::{hkdf, aead::quic::{AES_128, AES_256, CHACHA20}};
 
     #[test]
+    #[cfg(not(all(target_os = "windows", target_arch = "aarch64")))]
     fn test_key_type_header_protection_key() {
         let key_bytes = test::from_dirty_hex(r#"d480429666d48b400633921c5407d1d1"#);
         let info = test::from_dirty_hex(r#"f0f1f2f3f4f5f6f7f8f9"#);

--- a/aws-lc-rs/src/aead/quic.rs
+++ b/aws-lc-rs/src/aead/quic.rs
@@ -177,9 +177,15 @@ fn cipher_new_mask(
 
 #[cfg(test)]
 mod test {
-    use crate::{test, aead::quic::{Algorithm, HeaderProtectionKey}};
+    use crate::{
+        aead::quic::{Algorithm, HeaderProtectionKey},
+        test,
+    };
     #[cfg(not(all(target_os = "windows", target_arch = "aarch64")))]
-    use crate::{hkdf, aead::quic::{AES_128, AES_256, CHACHA20}};
+    use crate::{
+        aead::quic::{AES_128, AES_256, CHACHA20},
+        hkdf,
+    };
 
     #[test]
     #[cfg(not(all(target_os = "windows", target_arch = "aarch64")))]

--- a/aws-lc-rs/src/hkdf.rs
+++ b/aws-lc-rs/src/hkdf.rs
@@ -369,8 +369,9 @@ impl<L: KeyType> Okm<'_, L> {
 
 #[cfg(test)]
 mod tests {
-    use crate::hkdf;
-    use crate::hkdf::{Prk, Salt, HKDF_SHA256};
+    use crate::hkdf::{self, Salt, HKDF_SHA256};
+    #[cfg(not(all(target_os = "windows", target_arch = "aarch64")))]
+    use crate::hkdf::Prk;
 
     #[test]
     fn hkdf_coverage() {
@@ -384,6 +385,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(all(target_os = "windows", target_arch = "aarch64")))]
     fn rustls_test() {
         const INFO1: &[&[u8]] = &[
             &[0, 32],
@@ -450,6 +452,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(all(target_os = "windows", target_arch = "aarch64")))]
     fn okm_to_salt() {
         const SALT: &[u8; 32] = &[
             29, 113, 120, 243, 11, 202, 39, 222, 206, 81, 163, 184, 122, 153, 52, 192, 98, 195,
@@ -515,6 +518,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(all(target_os = "windows", target_arch = "aarch64")))]
     fn okm_to_prk() {
         const SALT: &[u8; 32] = &[
             29, 113, 120, 243, 11, 202, 39, 222, 206, 81, 163, 184, 122, 153, 52, 192, 98, 195,

--- a/aws-lc-rs/src/hkdf.rs
+++ b/aws-lc-rs/src/hkdf.rs
@@ -369,9 +369,9 @@ impl<L: KeyType> Okm<'_, L> {
 
 #[cfg(test)]
 mod tests {
-    use crate::hkdf::{self, Salt, HKDF_SHA256};
     #[cfg(not(all(target_os = "windows", target_arch = "aarch64")))]
     use crate::hkdf::Prk;
+    use crate::hkdf::{self, Salt, HKDF_SHA256};
 
     #[test]
     fn hkdf_coverage() {

--- a/aws-lc-rs/tests/aead_test.rs
+++ b/aws-lc-rs/tests/aead_test.rs
@@ -577,6 +577,7 @@ fn test_aead_key_debug() {
 // Specifically related to tls12 API tests: https://github.com/rustls/rustls/blob/main/rustls/tests/api.rs
 #[test]
 #[allow(clippy::unit_cmp)]
+#[cfg(not(all(target_os = "windows", target_arch = "aarch64")))]
 fn rustls_bug() {
     const KEY: &[u8] = &[
         239, 90, 253, 140, 117, 97, 1, 139, 56, 128, 152, 217, 106, 97, 87, 101, 79, 81, 29, 233,

--- a/aws-lc-rs/tests/agreement_tests.rs
+++ b/aws-lc-rs/tests/agreement_tests.rs
@@ -4,10 +4,11 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 extern crate alloc;
-
+#[cfg(not(all(target_os = "windows", target_arch = "aarch64")))]
 use aws_lc_rs::{agreement, rand};
 
 #[test]
+#[cfg(not(all(target_os = "windows", target_arch = "aarch64")))]
 fn agree_ephemeral_e2e() {
     let rng = rand::SystemRandom::new();
 

--- a/aws-lc-sys/builder/main.rs
+++ b/aws-lc-sys/builder/main.rs
@@ -167,6 +167,10 @@ fn prepare_cmake_build(manifest_dir: &PathBuf, build_prefix: Option<&str>) -> cm
         );
     }
 
+    if target_os() == "windows" && target_arch() == "aarch64" {
+        cmake_cfg.define("OPENSSL_NO_ASM", "1");
+    }
+
     // Build flags that minimize our crate size.
     cmake_cfg.define("BUILD_TESTING", "OFF");
     if cfg!(feature = "ssl") {
@@ -247,12 +251,18 @@ fn emit_rustc_cfg(cfg: &str) {
     println!("cargo:rustc-cfg={cfg}");
 }
 
+fn target_os() -> String {
+    env::var("CARGO_CFG_TARGET_OS").unwrap()
+}
+
+fn target_arch() -> String {
+    env::var("CARGO_CFG_TARGET_ARCH").unwrap()
+}
+
 macro_rules! cfg_bindgen_platform {
     ($binding:ident, $os:literal, $arch:literal, $additional:expr) => {
-        let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-        let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
         let $binding = {
-            (target_os == $os && target_arch == $arch && $additional)
+            (target_os() == $os && target_arch() == $arch && $additional)
                 .then(|| {
                     emit_rustc_cfg(concat!($os, "_", $arch));
                     true


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* A few of our tests compare results between ring and aws-lc-rs -- however, ring currently does not support Windows/aarch64: https://github.com/briansmith/ring/issues/1167
* Disables assembly-language implementations in AWS-LC when compiling on Windows/aarch64. (The AWS-LC build fails unless `-DOPENSSL_NO_ASM=1` is used.) The performance will be slower for users on Windows/aarch64, but it unblocks developers using that platform.

### Call-outs:
N/A

### Testing:
I tested locally in Windows via Parallels Desktop on an M1 Mac.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
