### PR TITLE
CI for cross-compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
         run: cross test --target ${{ matrix.target }}
       - name: Cross-compilation w/ bindgen
         working-directory: ./aws-lc-rs
-        run: cross build --release --features bindgen --target ${{ matrix.target }}
+        run: cross test --release --features bindgen --target ${{ matrix.target }}
 
 
   aws-lc-rs-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,29 +147,15 @@ jobs:
         env:
           RUSTC_WRAPPER: ""
 
-  aws-lc-rs-test:
-    name: aws-lc-rs tests
+  aws-lc-rs-cross-test:
+    name: aws-lc-rs cross tests
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         rust: [ stable ]
-        os: [ ubuntu-latest, macOS-latest ]
-        target: [ native, aarch64-unknown-linux-gnu, i686-unknown-linux-gnu ]
-        args:
-          - --all-targets
-          - --release --all-targets
-          - --no-default-features --features non-fips
-          - --no-default-features --features non-fips,ring-io
-          - --no-default-features --features non-fips,ring-sig-verify
-          - --no-default-features --features non-fips,alloc
-        exclude:
-          - rust: stable
-            os: macOS-latest
-            target: aarch64-unknown-linux-gnu
-          - rust: stable
-            os: macOS-latest
-            target: i686-unknown-linux-gnu
+        os: [ ubuntu-latest ]
+        target: [ aarch64-unknown-linux-gnu, i686-unknown-linux-gnu,  powerpc64le-unknown-linux-gnu, riscv64gc-unknown-linux-gnu ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -179,28 +165,50 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
-          target: ${{ matrix.target != 'native' && matrix.target || '' }}
-
+          target: ${{ matrix.target }}
       - name: Install cross
-        if: ${{ matrix.target != 'native' }}
         uses: actions-rs/cargo@v1.0.3
         with:
           command: install
-          args: cross
+          args: cross --git https://github.com/cross-rs/cross
+      - name: Cross-compilation
+        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'i686-unknown-linux-gnu' }}
+        working-directory: ./aws-lc-rs
+        run: cross test --target ${{ matrix.target }}
+      - name: Cross-compilation w/ bindgen
+        working-directory: ./aws-lc-rs
+        run: cross build --release --features bindgen --target ${{ matrix.target }}
 
+
+  aws-lc-rs-test:
+    name: aws-lc-rs tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [ stable ]
+        os: [ ubuntu-latest, macOS-latest ]
+        args:
+          - --all-targets
+          - --release --all-targets
+          - --no-default-features --features non-fips
+          - --no-default-features --features non-fips,ring-io
+          - --no-default-features --features non-fips,ring-sig-verify
+          - --no-default-features --features non-fips,alloc
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - uses: actions-rs/toolchain@v1.0.7
+        id: toolchain
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
       - name: Run cargo test
         working-directory: ./aws-lc-rs
-        if: ${{ matrix.target == 'native' }}
-        run: cargo test ${{ matrix.args }} ${{ matrix.target != 'native' && format('--target {0}', matrix.target) || '' }}
-
-      - name: Run cargo cross test
-        working-directory: ./aws-lc-rs
-        if: ${{ matrix.target != 'native' }}
-        run: cross test ${{ matrix.args }} ${{ matrix.target != 'native' && format('--target {0}', matrix.target) || '' }}
-
+        run: cargo test ${{ matrix.args }}
       - name: Run extra tests
         working-directory: ./aws-lc-rs-testing
-        if: ${{ matrix.target == 'native' }}
         run: cargo test --all-targets
 
   fips-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,9 @@ jobs:
         os: [ ubuntu-latest ]
         target: [ aarch64-unknown-linux-gnu, i686-unknown-linux-gnu,  powerpc64le-unknown-linux-gnu, riscv64gc-unknown-linux-gnu ]
     steps:
+      - name: Set CROSS_CMAKE_SYSTEM_PROCESSOR
+        if: ${{ matrix.target == 'powerpc64le-unknown-linux-gnu' }}
+        run: echo CROSS_CMAKE_SYSTEM_PROCESSOR=ppc64le >> $GITHUB_ENV
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'

--- a/aws-lc-rs/Cross.toml
+++ b/aws-lc-rs/Cross.toml
@@ -1,2 +1,9 @@
 [build]
 dockerfile = "../docker/linux-cross/Dockerfile"
+
+[build.env]
+passthrough = [
+    "CROSS_CMAKE_SYSTEM_PROCESSOR",
+    "RUST_BACKTRACE",
+    "RUST_LOG"
+]

--- a/aws-lc-rs/Cross.toml
+++ b/aws-lc-rs/Cross.toml
@@ -1,0 +1,2 @@
+[build]
+dockerfile = "../docker/linux-cross/Dockerfile"

--- a/aws-lc-sys/builder/main.rs
+++ b/aws-lc-sys/builder/main.rs
@@ -247,12 +247,18 @@ fn emit_rustc_cfg(cfg: &str) {
     println!("cargo:rustc-cfg={cfg}");
 }
 
+fn target_os() -> String {
+    env::var("CARGO_CFG_TARGET_OS").unwrap()
+}
+
+fn target_arch() -> String {
+    env::var("CARGO_CFG_TARGET_ARCH").unwrap()
+}
+
 macro_rules! cfg_bindgen_platform {
     ($binding:ident, $os:literal, $arch:literal, $additional:expr) => {
-        let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-        let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
         let $binding = {
-            (target_os == $os && target_arch == $arch && $additional)
+            (target_os() == $os && target_arch() == $arch && $additional)
                 .then(|| {
                     emit_rustc_cfg(concat!($os, "_", $arch));
                     true

--- a/docker/linux-cross/Dockerfile
+++ b/docker/linux-cross/Dockerfile
@@ -1,0 +1,5 @@
+ARG CROSS_BASE_IMAGE
+FROM $CROSS_BASE_IMAGE
+
+RUN apt-get update && \
+    apt-get install --assume-yes --no-install-recommends libclang-dev clang


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* CI to cross-compile to 4 platforms: `aarch64-unknown-linux-gnu`, `i686-unknown-linux-gnu`, `powerpc64le-unknown-linux-gnu`, `riscv64gc-unknown-linux-gnu`

### Call-outs:
* We have a dev-dependency on `ring`, which doesn't support "powerpc64le" and "riscv64gc", so we're currently unable to run our tests on those platforms.
* We were already cross-compiling to `aarch64-unknown-linux-gnu` and `i686-unknown-linux-gnu` as part of the "aws-lc-rs tests" job.  I refactored the jobs so that all cross-compiling is done in "aws-lc-rs cross tests".

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
