### PR TITLE
Use nightly cargo feature for scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,11 +90,6 @@ jobs:
         with:
           command: install
           args: cargo-public-api
-      - name: Install rust-script
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: install
-          args: rust-script
       - name: Perform API Diff (Target Branch)
         if: matrix.diff_target == 'branch'
         working-directory: ${{ matrix.crate_dir }}
@@ -104,7 +99,7 @@ jobs:
         working-directory: ${{ matrix.crate_dir }}
         shell: bash
         run: |
-          CRATE_NAME=$("${GITHUB_WORKSPACE}"/scripts/tools/cargo-dig.rs -n)
+          CRATE_NAME="${{ matrix.crate_dir }}"
           CRATE_VERSION=$(cargo search --limit 1 ${CRATE_NAME} | head -n 1 | sed -e 's/[^"]*"\([^"]*\)".*/\1/')
           cargo public-api diff --deny changed --deny removed "${CRATE_VERSION}"
 

--- a/scripts/tools/cargo-dig.rs
+++ b/scripts/tools/cargo-dig.rs
@@ -1,4 +1,4 @@
-#!/usr/bin/env rust-script
+#!/usr/bin/env -S cargo +nightly -Zscript
 //! Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //! SPDX-License-Identifier: Apache-2.0 OR ISC
 //! ```cargo

--- a/scripts/tools/semver.rs
+++ b/scripts/tools/semver.rs
@@ -1,4 +1,4 @@
-#!/usr/bin/env rust-script
+#!/usr/bin/env -S cargo +nightly -Zscript
 //! Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //! SPDX-License-Identifier: Apache-2.0 OR ISC
 //! ```cargo

--- a/scripts/tools/target-platform.rs
+++ b/scripts/tools/target-platform.rs
@@ -1,4 +1,4 @@
-#!/usr/bin/env rust-script
+#!/usr/bin/env -S cargo +nightly -Zscript
 
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC


### PR DESCRIPTION
Migrate from `rust-script` to Cargo's nightly script feature.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
