### PR TITLE
Migrate RSA to FIPS Approved Functions

### DIFF
--- a/aws-lc-rs/src/digest.rs
+++ b/aws-lc-rs/src/digest.rs
@@ -245,8 +245,6 @@ pub struct Algorithm {
     one_shot_hash: fn(msg: &[u8], output: &mut [u8]),
 
     pub(crate) id: AlgorithmID,
-
-    pub(crate) hash_nid: i32,
 }
 
 unsafe impl Send for Algorithm {}

--- a/aws-lc-rs/src/digest/sha.rs
+++ b/aws-lc-rs/src/digest/sha.rs
@@ -4,10 +4,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 use crate::digest::{Algorithm, AlgorithmID, Context};
-use aws_lc::{
-    NID_sha1, NID_sha256, NID_sha384, NID_sha3_256, NID_sha3_384, NID_sha3_512, NID_sha512,
-    NID_sha512_256,
-};
 
 pub const BLOCK_LEN: usize = 512 / 8;
 pub const CHAINING_LEN: usize = 160 / 8;
@@ -80,8 +76,6 @@ pub static SHA1_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm {
     one_shot_hash: sha1_digest,
 
     id: AlgorithmID::SHA1,
-
-    hash_nid: NID_sha1,
 };
 
 /// SHA-256 as specified in [FIPS 180-4].
@@ -97,8 +91,6 @@ pub static SHA256: Algorithm = Algorithm {
     one_shot_hash: sha256_digest,
 
     id: AlgorithmID::SHA256,
-
-    hash_nid: NID_sha256,
 };
 
 /// SHA-384 as specified in [FIPS 180-4].
@@ -114,7 +106,6 @@ pub static SHA384: Algorithm = Algorithm {
     one_shot_hash: sha384_digest,
 
     id: AlgorithmID::SHA384,
-    hash_nid: NID_sha384,
 };
 
 /// SHA-512 as specified in [FIPS 180-4].
@@ -130,7 +121,6 @@ pub static SHA512: Algorithm = Algorithm {
     one_shot_hash: sha512_digest,
 
     id: AlgorithmID::SHA512,
-    hash_nid: NID_sha512,
 };
 
 /// SHA-512/256 as specified in [FIPS 180-4].
@@ -146,7 +136,6 @@ pub static SHA512_256: Algorithm = Algorithm {
     one_shot_hash: sha512_256_digest,
 
     id: AlgorithmID::SHA512_256,
-    hash_nid: NID_sha512_256,
 };
 
 /// SHA3-256 as specified in [FIPS 202].
@@ -162,7 +151,6 @@ pub static SHA3_256: Algorithm = Algorithm {
     one_shot_hash: sha3_256_digest,
 
     id: AlgorithmID::SHA3_256,
-    hash_nid: NID_sha3_256,
 };
 
 /// SHA3-384 as specified in [FIPS 202].
@@ -178,7 +166,6 @@ pub static SHA3_384: Algorithm = Algorithm {
     one_shot_hash: sha3_384_digest,
 
     id: AlgorithmID::SHA3_384,
-    hash_nid: NID_sha3_384,
 };
 
 /// SHA3-512 as specified in [FIPS 202].
@@ -194,7 +181,6 @@ pub static SHA3_512: Algorithm = Algorithm {
     one_shot_hash: sha3_512_digest,
 
     id: AlgorithmID::SHA3_512,
-    hash_nid: NID_sha3_512,
 };
 
 fn sha1_digest(msg: &[u8], output: &mut [u8]) {

--- a/aws-lc-rs/src/ec.rs
+++ b/aws-lc-rs/src/ec.rs
@@ -174,19 +174,15 @@ fn verify_fixed_signature(
     msg: &[u8],
     signature: &[u8],
 ) -> Result<(), Unspecified> {
-    let mut out_bytes = MaybeUninit::<*mut u8>::uninit();
+    let mut out_bytes = null_mut::<u8>();
     let mut out_bytes_len = MaybeUninit::<usize>::uninit();
     let sig = unsafe { ecdsa_sig_from_fixed(alg, signature)? };
     if 1 != unsafe {
-        ECDSA_SIG_to_bytes(
-            out_bytes.as_mut_ptr(),
-            out_bytes_len.as_mut_ptr(),
-            *sig.as_const(),
-        )
+        ECDSA_SIG_to_bytes(&mut out_bytes, out_bytes_len.as_mut_ptr(), *sig.as_const())
     } {
         return Err(Unspecified);
     }
-    let out_bytes = LcPtr::new(unsafe { out_bytes.assume_init() })?;
+    let out_bytes = LcPtr::new(out_bytes)?;
     let signature = unsafe { out_bytes.as_slice::<u8>(out_bytes_len.assume_init()) };
     verify_asn1_signature(alg, digest, public_key, msg, signature)
 }

--- a/aws-lc-rs/src/evp_pkey.rs
+++ b/aws-lc-rs/src/evp_pkey.rs
@@ -13,6 +13,7 @@ use aws_lc::{
 };
 use std::mem::MaybeUninit;
 use std::os::raw::c_int;
+use std::ptr::null_mut;
 
 impl TryFrom<&[u8]> for LcPtr<*mut EVP_PKEY> {
     type Error = KeyRejected;
@@ -96,16 +97,12 @@ impl LcPtr<*mut EVP_PKEY> {
                 }
             }
 
-            let mut pkcs8_bytes_ptr = MaybeUninit::<*mut u8>::uninit();
+            let mut pkcs8_bytes_ptr = null_mut::<u8>();
             let mut out_len = MaybeUninit::<usize>::uninit();
-            if 1 != CBB_finish(
-                cbb.as_mut_ptr(),
-                pkcs8_bytes_ptr.as_mut_ptr(),
-                out_len.as_mut_ptr(),
-            ) {
+            if 1 != CBB_finish(cbb.as_mut_ptr(), &mut pkcs8_bytes_ptr, out_len.as_mut_ptr()) {
                 return Err(Unspecified);
             }
-            let pkcs8_bytes_ptr = LcPtr::new(pkcs8_bytes_ptr.assume_init())?;
+            let pkcs8_bytes_ptr = LcPtr::new(pkcs8_bytes_ptr)?;
             let out_len = out_len.assume_init();
 
             let bytes_slice = std::slice::from_raw_parts(*pkcs8_bytes_ptr, out_len);

--- a/aws-lc-rs/src/evp_pkey.rs
+++ b/aws-lc-rs/src/evp_pkey.rs
@@ -105,7 +105,7 @@ impl LcPtr<*mut EVP_PKEY> {
             let pkcs8_bytes_ptr = LcPtr::new(pkcs8_bytes_ptr)?;
             let out_len = out_len.assume_init();
 
-            let bytes_slice = std::slice::from_raw_parts(*pkcs8_bytes_ptr, out_len);
+            let bytes_slice = pkcs8_bytes_ptr.as_slice(out_len);
             let mut pkcs8_bytes = [0u8; PKCS8_DOCUMENT_MAX_LEN];
             pkcs8_bytes[0..out_len].copy_from_slice(bytes_slice);
 


### PR DESCRIPTION
### Before
```
RSA-1192-PKCS1-SHA256-sign-128-bytes/AWS-LC
                        time:   [607.64 µs 607.89 µs 608.15 µs]
Found 15 outliers among 100 measurements (15.00%)
  7 (7.00%) low severe
  1 (1.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe

RSA-1192-PKCS1-SHA256-verify-128-bytes/AWS-LC
                        time:   [27.770 µs 27.771 µs 27.773 µs]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild

Benchmarking RSA-1768-PKCS1-SHA256-sign-128-bytes/AWS-LC: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.4s, enable flat sampling, or reduce sample count to 50.
RSA-1768-PKCS1-SHA256-sign-128-bytes/AWS-LC
                        time:   [1.8436 ms 1.8476 ms 1.8528 ms]
Found 14 outliers among 100 measurements (14.00%)
  3 (3.00%) high mild
  11 (11.00%) high severe

RSA-1768-PKCS1-SHA256-verify-128-bytes/AWS-LC
                        time:   [67.400 µs 67.402 µs 67.404 µs]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe

RSA-1192-PKCS1-SHA384-sign-128-bytes/AWS-LC
                        time:   [607.59 µs 607.82 µs 608.04 µs]
Found 15 outliers among 100 measurements (15.00%)
  7 (7.00%) low severe
  1 (1.00%) low mild
  4 (4.00%) high mild
  3 (3.00%) high severe

RSA-1192-PKCS1-SHA384-verify-128-bytes/AWS-LC
                        time:   [28.051 µs 28.073 µs 28.111 µs]
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe

RSA-2347-PKCS1-SHA512-sign-128-bytes/AWS-LC
                        time:   [4.0656 ms 4.0720 ms 4.0789 ms]

RSA-2347-PKCS1-SHA512-verify-128-bytes/AWS-LC
                        time:   [65.898 µs 65.900 µs 65.902 µs]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe

RSA-1192-PKCS1-SHA512-sign-128-bytes/AWS-LC
                        time:   [607.34 µs 607.55 µs 607.77 µs]
Found 15 outliers among 100 measurements (15.00%)
  7 (7.00%) low severe
  1 (1.00%) low mild
  4 (4.00%) high mild
  3 (3.00%) high severe

RSA-1192-PKCS1-SHA512-verify-128-bytes/AWS-LC
                        time:   [28.053 µs 28.055 µs 28.056 µs]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low mild
  1 (1.00%) high severe
```

### After
```
RSA-1192-PKCS1-SHA256-sign-128-bytes/AWS-LC
                        time:   [607.10 µs 607.32 µs 607.53 µs]
                        change: [-0.7713% -0.1069% +0.5047%] (p = 0.80 > 0.05)
                        No change in performance detected.
Found 15 outliers among 100 measurements (15.00%)
  7 (7.00%) low severe
  1 (1.00%) low mild
  4 (4.00%) high mild
  3 (3.00%) high severe

RSA-1192-PKCS1-SHA256-verify-128-bytes/AWS-LC
                        time:   [28.356 µs 28.357 µs 28.358 µs]
                        change: [+2.1055% +2.1136% +2.1218%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) low mild
  4 (4.00%) high mild
  4 (4.00%) high severe

Benchmarking RSA-1768-PKCS1-SHA256-sign-128-bytes/AWS-LC: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.5s, enable flat sampling, or reduce sample count to 50.
RSA-1768-PKCS1-SHA256-sign-128-bytes/AWS-LC
                        time:   [1.8459 ms 1.8466 ms 1.8474 ms]
                        change: [-1.5243% -0.7902% -0.0895%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 19 outliers among 100 measurements (19.00%)
  14 (14.00%) low mild
  2 (2.00%) high mild
  3 (3.00%) high severe

RSA-1768-PKCS1-SHA256-verify-128-bytes/AWS-LC
                        time:   [67.624 µs 67.625 µs 67.626 µs]
                        change: [+0.3265% +0.3344% +0.3454%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe

RSA-1192-PKCS1-SHA384-sign-128-bytes/AWS-LC
                        time:   [607.45 µs 607.66 µs 607.88 µs]
                        change: [-0.6655% -0.0244% +0.6128%] (p = 0.94 > 0.05)
                        No change in performance detected.
Found 14 outliers among 100 measurements (14.00%)
  7 (7.00%) low severe
  1 (1.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe

RSA-1192-PKCS1-SHA384-verify-128-bytes/AWS-LC
                        time:   [28.594 µs 28.595 µs 28.596 µs]
                        change: [+1.8223% +1.8933% +1.9426%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe

RSA-2347-PKCS1-SHA512-sign-128-bytes/AWS-LC
                        time:   [4.0656 ms 4.0717 ms 4.0782 ms]
                        change: [-0.2449% -0.0078% +0.2187%] (p = 0.94 > 0.05)
                        No change in performance detected.

RSA-2347-PKCS1-SHA512-verify-128-bytes/AWS-LC
                        time:   [66.269 µs 66.271 µs 66.274 µs]
                        change: [+0.5530% +0.5622% +0.5707%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe

RSA-1192-PKCS1-SHA512-sign-128-bytes/AWS-LC
                        time:   [607.17 µs 607.39 µs 607.61 µs]
                        change: [-0.6500% -0.0177% +0.6796%] (p = 0.96 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  7 (7.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high mild
  3 (3.00%) high severe

RSA-1192-PKCS1-SHA512-verify-128-bytes/AWS-LC
                        time:   [28.496 µs 28.498 µs 28.499 µs]
                        change: [+1.5693% +1.5844% +1.5964%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) low mild
  3 (3.00%) high mild
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
