### PR TITLE
Migrate Agreement to FIPS Approved Functions

### DIFF
--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -29,6 +29,7 @@ ring-io = ["dep:untrusted"]
 ring-sig-verify = ["dep:untrusted"]
 bindgen = ["aws-lc-sys?/bindgen", "aws-lc-fips-sys?/bindgen"]
 asan = ["aws-lc-sys?/asan", "aws-lc-fips-sys?/asan"]
+test_logging = []
 
 # require non-FIPS
 non-fips = ["aws-lc-sys"]

--- a/aws-lc-rs/src/agreement.rs
+++ b/aws-lc-rs/src/agreement.rs
@@ -53,21 +53,19 @@ use crate::ec::{
     ec_group_from_nid, ec_key_from_public_point, ec_key_generate, ec_point_from_bytes,
 };
 use crate::error::Unspecified;
-#[cfg(test)]
-use crate::ptr::DetachableLcPtr;
-use crate::ptr::{ConstPointer, LcPtr};
+use crate::ptr::{DetachableLcPtr, LcPtr};
 use crate::rand::SecureRandom;
 use crate::{ec, test};
 use aws_lc::{
-    ECDH_compute_key, EC_GROUP_cmp, EC_GROUP_get_curve_name, EC_GROUP_get_degree,
-    EC_KEY_get0_group, EC_KEY_get0_public_key, NID_X9_62_prime256v1, NID_secp384r1, NID_secp521r1,
-    X25519_keypair, X25519_public_from_private, EC_KEY, NID_X25519,
+    EVP_PKEY_CTX_new, EVP_PKEY_CTX_new_id, EVP_PKEY_assign_EC_KEY, EVP_PKEY_derive,
+    EVP_PKEY_derive_init, EVP_PKEY_derive_set_peer, EVP_PKEY_get_raw_public_key, EVP_PKEY_keygen,
+    EVP_PKEY_keygen_init, EVP_PKEY_new, EVP_PKEY_new_raw_public_key, NID_X9_62_prime256v1,
+    NID_secp384r1, NID_secp521r1, EVP_PKEY, EVP_PKEY_X25519, NID_X25519,
 };
 
 use core::fmt;
 use std::fmt::{Debug, Formatter};
 use std::ptr::null_mut;
-use zeroize::Zeroize;
 
 #[allow(non_camel_case_types)]
 #[derive(PartialEq, Eq)]
@@ -150,28 +148,25 @@ pub static ECDH_P521: Algorithm = Algorithm {
 pub static X25519: Algorithm = Algorithm {
     id: AlgorithmID::X25519,
 };
+#[cfg(test)]
 const X25519_PRIVATE_KEY_LEN: usize = aws_lc::X25519_PRIVATE_KEY_LEN as usize;
 #[cfg(test)]
 const ECDH_P256_PRIVATE_KEY_LEN: usize = 32;
 #[cfg(test)]
 const ECDH_P384_PRIVATE_KEY_LEN: usize = 48;
 const ECDH_P521_PRIVATE_KEY_LEN: usize = 66;
-const X25519_PUBLIC_VALUE_LEN: usize = aws_lc::X25519_PUBLIC_VALUE_LEN as usize;
 const X25519_SHARED_KEY_LEN: usize = aws_lc::X25519_SHARED_KEY_LEN as usize;
 #[allow(non_camel_case_types)]
 enum KeyInner {
-    ECDH_P256(LcPtr<*mut EC_KEY>),
-    ECDH_P384(LcPtr<*mut EC_KEY>),
-    ECDH_P521(LcPtr<*mut EC_KEY>),
-    X25519([u8; X25519_PRIVATE_KEY_LEN]),
+    ECDH_P256(LcPtr<*mut EVP_PKEY>),
+    ECDH_P384(LcPtr<*mut EVP_PKEY>),
+    ECDH_P521(LcPtr<*mut EVP_PKEY>),
+    X25519(LcPtr<*mut EVP_PKEY>),
 }
 
 impl Drop for KeyInner {
     fn drop(&mut self) {
-        if let KeyInner::X25519(private) = self {
-            private.zeroize();
-        }
-        // LcPtr's Drop implementation will call EC_KEY_free
+        // LcPtr's Drop implementation will call EVP_PKEY_free
     }
 }
 
@@ -226,33 +221,29 @@ impl EphemeralPrivateKey {
     pub fn generate(alg: &'static Algorithm, _rng: &dyn SecureRandom) -> Result<Self, Unspecified> {
         match alg.id {
             AlgorithmID::X25519 => {
-                let mut priv_key = [0u8; X25519_PRIVATE_KEY_LEN];
-                let mut pub_key = [0u8; X25519_PUBLIC_VALUE_LEN];
-                unsafe {
-                    X25519_keypair(pub_key.as_mut_ptr(), priv_key.as_mut_ptr());
-                }
+                let priv_key = generate_x25519()?;
                 Ok(EphemeralPrivateKey {
-                    inner_key: KeyInner::X25519(priv_key),
+                    inner_key: KeyInner::X25519(LcPtr::from(priv_key)),
                 })
             }
-            AlgorithmID::ECDH_P256 => unsafe {
+            AlgorithmID::ECDH_P256 => {
                 let ec_key = ec_key_generate(ECDH_P256.id.nid())?;
                 Ok(EphemeralPrivateKey {
                     inner_key: KeyInner::ECDH_P256(LcPtr::from(ec_key)),
                 })
-            },
-            AlgorithmID::ECDH_P384 => unsafe {
+            }
+            AlgorithmID::ECDH_P384 => {
                 let ec_key = ec_key_generate(ECDH_P384.id.nid())?;
                 Ok(EphemeralPrivateKey {
                     inner_key: KeyInner::ECDH_P384(LcPtr::from(ec_key)),
                 })
-            },
-            AlgorithmID::ECDH_P521 => unsafe {
+            }
+            AlgorithmID::ECDH_P521 => {
                 let ec_key = ec_key_generate(ECDH_P521.id.nid())?;
                 Ok(EphemeralPrivateKey {
                     inner_key: KeyInner::ECDH_P521(LcPtr::from(ec_key)),
                 })
-            },
+            }
         }
     }
 
@@ -266,7 +257,7 @@ impl EphemeralPrivateKey {
             AlgorithmID::X25519 => {
                 let mut priv_key = [0u8; X25519_PRIVATE_KEY_LEN];
                 rng.fill(&mut priv_key)?;
-                Ok(Self::from_x25519_private_key(&priv_key))
+                Self::from_x25519_private_key(&priv_key)
             }
             AlgorithmID::ECDH_P256 => {
                 let mut priv_key = [0u8; ECDH_P256_PRIVATE_KEY_LEN];
@@ -287,51 +278,47 @@ impl EphemeralPrivateKey {
     }
 
     #[cfg(test)]
-    fn from_x25519_private_key(priv_key: &[u8; X25519_PRIVATE_KEY_LEN]) -> Self {
-        let inner_key = KeyInner::X25519(*priv_key);
-        EphemeralPrivateKey { inner_key }
+    fn from_x25519_private_key(
+        priv_key: &[u8; X25519_PRIVATE_KEY_LEN],
+    ) -> Result<Self, Unspecified> {
+        use aws_lc::EVP_PKEY_new_raw_private_key;
+
+        let pkey = LcPtr::new(unsafe {
+            EVP_PKEY_new_raw_private_key(
+                EVP_PKEY_X25519,
+                null_mut(),
+                priv_key.as_ptr(),
+                priv_key.len(),
+            )
+        })?;
+
+        Ok(EphemeralPrivateKey {
+            inner_key: KeyInner::X25519(pkey),
+        })
     }
 
     #[cfg(test)]
     fn from_p256_private_key(priv_key: &[u8]) -> Result<Self, Unspecified> {
-        unsafe {
-            let ec_group = ec_group_from_nid(ECDH_P256.id.nid())?;
-            let priv_key = DetachableLcPtr::try_from(priv_key)?;
-
-            let ec_key = ec::ec_key_from_private(&ec_group.as_const(), &priv_key.as_const())?;
-            let ec_key = LcPtr::from(ec_key);
-            Ok(EphemeralPrivateKey {
-                inner_key: KeyInner::ECDH_P256(ec_key),
-            })
-        }
+        let pkey = from_ec_private_key(priv_key, ECDH_P256.id.nid())?;
+        Ok(EphemeralPrivateKey {
+            inner_key: KeyInner::ECDH_P256(pkey),
+        })
     }
 
     #[cfg(test)]
     fn from_p384_private_key(priv_key: &[u8]) -> Result<Self, Unspecified> {
-        unsafe {
-            let ec_group = ec_group_from_nid(ECDH_P384.id.nid())?;
-            let priv_key = DetachableLcPtr::try_from(priv_key)?;
-
-            let ec_key = ec::ec_key_from_private(&ec_group.as_const(), &priv_key.as_const())?;
-            let ec_key = LcPtr::from(ec_key);
-            Ok(EphemeralPrivateKey {
-                inner_key: KeyInner::ECDH_P384(ec_key),
-            })
-        }
+        let pkey = from_ec_private_key(priv_key, ECDH_P384.id.nid())?;
+        Ok(EphemeralPrivateKey {
+            inner_key: KeyInner::ECDH_P384(pkey),
+        })
     }
 
     #[cfg(test)]
     fn from_p521_private_key(priv_key: &[u8]) -> Result<Self, Unspecified> {
-        unsafe {
-            let ec_group = ec_group_from_nid(ECDH_P521.id.nid())?;
-            let priv_key = DetachableLcPtr::try_from(priv_key)?;
-
-            let ec_key = ec::ec_key_from_private(&ec_group.as_const(), &priv_key.as_const())?;
-            let ec_key = LcPtr::from(ec_key);
-            Ok(EphemeralPrivateKey {
-                inner_key: KeyInner::ECDH_P521(ec_key),
-            })
-        }
+        let pkey = from_ec_private_key(priv_key, ECDH_P521.id.nid())?;
+        Ok(EphemeralPrivateKey {
+            inner_key: KeyInner::ECDH_P521(pkey),
+        })
     }
 
     /// Computes the public key from the private key.
@@ -341,13 +328,13 @@ impl EphemeralPrivateKey {
     ///
     pub fn compute_public_key(&self) -> Result<PublicKey, Unspecified> {
         match &self.inner_key {
-            KeyInner::ECDH_P256(ec_key)
-            | KeyInner::ECDH_P384(ec_key)
-            | KeyInner::ECDH_P521(ec_key) => {
+            KeyInner::ECDH_P256(evp_pkey)
+            | KeyInner::ECDH_P384(evp_pkey)
+            | KeyInner::ECDH_P521(evp_pkey) => {
                 let mut buffer = [0u8; MAX_PUBLIC_KEY_LEN];
                 unsafe {
                     let key_len =
-                        ec::marshal_public_key_to_buffer(&mut buffer, &ec_key.as_const())?;
+                        ec::marshal_public_key_to_buffer(&mut buffer, &evp_pkey.as_const())?;
                     Ok(PublicKey {
                         alg: self.algorithm(),
                         public_key: buffer,
@@ -357,14 +344,18 @@ impl EphemeralPrivateKey {
             }
             KeyInner::X25519(priv_key) => {
                 let mut buffer = [0u8; MAX_PUBLIC_KEY_LEN];
-                unsafe {
-                    X25519_public_from_private(buffer.as_mut_ptr().cast(), priv_key.as_ptr());
+                let mut out_len = buffer.len();
+
+                if 1 != unsafe {
+                    EVP_PKEY_get_raw_public_key(**priv_key, buffer.as_mut_ptr(), &mut out_len)
+                } {
+                    return Err(Unspecified);
                 }
 
                 Ok(PublicKey {
                     alg: self.algorithm(),
                     public_key: buffer,
-                    len: X25519_PUBLIC_VALUE_LEN,
+                    len: out_len,
                 })
             }
         }
@@ -376,6 +367,34 @@ impl EphemeralPrivateKey {
     pub fn algorithm(&self) -> &'static Algorithm {
         self.inner_key.algorithm()
     }
+}
+
+#[cfg(test)]
+fn from_ec_private_key(priv_key: &[u8], nid: i32) -> Result<LcPtr<*mut EVP_PKEY>, Unspecified> {
+    let ec_group = unsafe { ec_group_from_nid(nid)? };
+    let priv_key = DetachableLcPtr::try_from(priv_key)?;
+
+    let pkey = unsafe { ec::ec_key_from_private(&ec_group.as_const(), &priv_key.as_const())? };
+
+    Ok(pkey)
+}
+
+pub(crate) fn generate_x25519() -> Result<DetachableLcPtr<*mut EVP_PKEY>, Unspecified> {
+    let pkey_ctx = LcPtr::new(unsafe { EVP_PKEY_CTX_new_id(EVP_PKEY_X25519, null_mut()) })?;
+
+    if 1 != unsafe { EVP_PKEY_keygen_init(*pkey_ctx) } {
+        return Err(Unspecified);
+    }
+
+    let mut pkey: *mut EVP_PKEY = null_mut();
+
+    if 1 != unsafe { EVP_PKEY_keygen(*pkey_ctx, &mut pkey) } {
+        return Err(Unspecified);
+    }
+
+    let pkey = DetachableLcPtr::new(pkey)?;
+
+    Ok(pkey)
 }
 
 const MAX_PUBLIC_KEY_LEN: usize = ec::PUBLIC_KEY_MAX_LEN;
@@ -512,23 +531,13 @@ where
     let mut buffer = [0u8; MAX_AGREEMENT_SECRET_LEN];
 
     let secret: &[u8] = match &my_private_key.inner_key {
-        KeyInner::X25519(priv_key, ..) => {
-            let mut pub_key = [0u8; X25519_PUBLIC_VALUE_LEN];
-            pub_key.copy_from_slice(peer_pub_bytes);
-            unsafe {
-                let result = x25519_diffie_hellman(&mut buffer, priv_key, &pub_key);
-                if result.is_err() {
-                    return Err(error_value);
-                }
-                &buffer[0..X25519_SHARED_KEY_LEN]
-            }
+        KeyInner::X25519(priv_key) => {
+            x25519_diffie_hellman(&mut buffer, priv_key, peer_pub_bytes).or(Err(error_value))?
         }
-        KeyInner::ECDH_P256(ec_key) | KeyInner::ECDH_P384(ec_key) | KeyInner::ECDH_P521(ec_key) => {
-            let pub_key_bytes = peer_public_key.bytes.as_ref();
-            unsafe {
-                ec_key_ecdh(&mut buffer, ec_key.as_const(), pub_key_bytes, expected_nid)
-                    .or(Err(error_value))?
-            }
+        KeyInner::ECDH_P256(priv_key)
+        | KeyInner::ECDH_P384(priv_key)
+        | KeyInner::ECDH_P521(priv_key) => {
+            ec_key_ecdh(&mut buffer, priv_key, peer_pub_bytes, expected_nid).or(Err(error_value))?
         }
     };
     kdf(secret)
@@ -539,65 +548,79 @@ const MAX_AGREEMENT_SECRET_LEN: usize = ECDH_P521_PRIVATE_KEY_LEN;
 
 #[inline]
 #[allow(clippy::needless_pass_by_value)]
-unsafe fn ec_key_ecdh<'a>(
+fn ec_key_ecdh<'a>(
     buffer: &'a mut [u8; MAX_AGREEMENT_SECRET_LEN],
-    priv_ec_key: ConstPointer<EC_KEY>,
+    priv_key: &LcPtr<*mut EVP_PKEY>,
     peer_pub_key_bytes: &[u8],
     nid: i32,
 ) -> Result<&'a [u8], ()> {
-    let ec_group = ec_group_from_nid(nid)?;
-    let pub_key_point = ec_point_from_bytes(&ec_group, peer_pub_key_bytes)?;
-    let peer_ec_key = ec_key_from_public_point(&ec_group, &pub_key_point)?;
+    let ec_group = unsafe { ec_group_from_nid(nid)? };
+    let pub_key_point = unsafe { ec_point_from_bytes(&ec_group, peer_pub_key_bytes) }?;
+    let peer_ec_key = unsafe { ec_key_from_public_point(&ec_group, &pub_key_point) }?;
 
-    let priv_group = ConstPointer::new(EC_KEY_get0_group(*priv_ec_key))?;
-    let priv_nid = EC_GROUP_get_curve_name(*priv_group);
+    let pkey_ctx = LcPtr::new(unsafe { EVP_PKEY_CTX_new(**priv_key, null_mut()) })?;
 
-    let supported_curves = [NID_X9_62_prime256v1, NID_secp384r1, NID_secp521r1];
-    if !supported_curves.contains(&priv_nid as &i32) {
+    if 1 != unsafe { EVP_PKEY_derive_init(*pkey_ctx) } {
+        return Err(());
+    };
+
+    let pub_key = LcPtr::new(unsafe { EVP_PKEY_new() })?;
+    if 1 != unsafe { EVP_PKEY_assign_EC_KEY(*pub_key, *peer_ec_key) } {
+        return Err(());
+    }
+    peer_ec_key.detach();
+
+    if 1 != unsafe { EVP_PKEY_derive_set_peer(*pkey_ctx, *pub_key) } {
         return Err(());
     }
 
-    let peer_group = ConstPointer::new(EC_KEY_get0_group(*peer_ec_key))?;
-    if 0 != EC_GROUP_cmp(*priv_group, *peer_group, null_mut()) {
+    let mut out_key_len = buffer.len();
+
+    if 1 != unsafe { EVP_PKEY_derive(*pkey_ctx, buffer.as_mut_ptr(), &mut out_key_len) } {
         return Err(());
     }
 
-    let peer_pub_key = ConstPointer::new(EC_KEY_get0_public_key(*peer_ec_key))?;
-
-    let field_size = EC_GROUP_get_degree(*priv_group) as usize;
-    let max_secret_len = (field_size + 7) / 8;
-
-    let outlen = ECDH_compute_key(
-        buffer.as_mut_ptr().cast(),
-        max_secret_len,
-        *peer_pub_key,
-        *priv_ec_key,
-        None,
-    );
-    if 0 >= outlen {
+    if 0 == out_key_len {
         return Err(());
     }
-    #[allow(clippy::cast_sign_loss)]
-    let outlen = outlen as usize;
 
-    Ok(&buffer[0..outlen])
+    Ok(&buffer[0..out_key_len])
 }
 
 #[inline]
-unsafe fn x25519_diffie_hellman(
-    out_shared_key: &mut [u8],
-    priv_key: &[u8; X25519_PRIVATE_KEY_LEN],
-    peer_pub_key: &[u8; X25519_PUBLIC_VALUE_LEN],
-) -> Result<(), ()> {
-    debug_assert!(out_shared_key.len() >= X25519_SHARED_KEY_LEN);
-    if 1 != aws_lc::X25519(
-        out_shared_key.as_mut_ptr(),
-        priv_key.as_ptr(),
-        peer_pub_key.as_ptr(),
-    ) {
+fn x25519_diffie_hellman<'a>(
+    buffer: &'a mut [u8; MAX_AGREEMENT_SECRET_LEN],
+    priv_key: &LcPtr<*mut EVP_PKEY>,
+    peer_pub_key: &[u8],
+) -> Result<&'a [u8], ()> {
+    let pkey_ctx = LcPtr::new(unsafe { EVP_PKEY_CTX_new(**priv_key, null_mut()) })?;
+
+    if 1 != unsafe { EVP_PKEY_derive_init(*pkey_ctx) } {
+        return Err(());
+    };
+
+    let pub_key = LcPtr::new(unsafe {
+        EVP_PKEY_new_raw_public_key(
+            EVP_PKEY_X25519,
+            null_mut(),
+            peer_pub_key.as_ptr(),
+            peer_pub_key.len(),
+        )
+    })?;
+
+    if 1 != unsafe { EVP_PKEY_derive_set_peer(*pkey_ctx, *pub_key) } {
         return Err(());
     }
-    Ok(())
+
+    let mut out_key_len = buffer.len();
+
+    if 1 != unsafe { EVP_PKEY_derive(*pkey_ctx, buffer.as_mut_ptr(), &mut out_key_len) } {
+        return Err(());
+    }
+
+    debug_assert!(out_key_len == X25519_SHARED_KEY_LEN);
+
+    Ok(&buffer[0..X25519_SHARED_KEY_LEN])
 }
 
 #[cfg(test)]

--- a/aws-lc-rs/src/ec.rs
+++ b/aws-lc-rs/src/ec.rs
@@ -11,19 +11,21 @@ use crate::ptr::{ConstPointer, DetachableLcPtr, LcPtr};
 
 use crate::signature::{Signature, VerificationAlgorithm};
 use crate::{digest, sealed, test};
+#[cfg(feature = "fips")]
+use aws_lc::EC_KEY_check_fips;
+#[cfg(not(feature = "fips"))]
+use aws_lc::EC_KEY_check_key;
 use aws_lc::{
     point_conversion_form_t, ECDSA_SIG_from_bytes, ECDSA_SIG_get0_r, ECDSA_SIG_get0_s,
     ECDSA_SIG_new, ECDSA_SIG_set0, ECDSA_SIG_to_bytes, EC_GROUP_get_curve_name,
     EC_GROUP_new_by_curve_name, EC_KEY_get0_group, EC_KEY_get0_public_key, EC_KEY_new,
-    EC_KEY_new_by_curve_name, EC_KEY_set_group, EC_KEY_set_private_key, EC_KEY_set_public_key,
-    EC_POINT_new, EC_POINT_oct2point, EC_POINT_point2oct, EVP_DigestVerify, EVP_DigestVerifyInit,
-    EVP_PKEY_assign_EC_KEY, EVP_PKEY_new, NID_X9_62_prime256v1, NID_secp384r1, NID_secp521r1,
-    BIGNUM, ECDSA_SIG, EC_GROUP, EC_KEY, EC_POINT, EVP_PKEY,
+    EC_KEY_set_group, EC_KEY_set_private_key, EC_KEY_set_public_key, EC_POINT_new,
+    EC_POINT_oct2point, EC_POINT_point2oct, EVP_DigestVerify, EVP_DigestVerifyInit,
+    EVP_PKEY_CTX_new_id, EVP_PKEY_CTX_set_ec_paramgen_curve_nid, EVP_PKEY_assign_EC_KEY,
+    EVP_PKEY_get0_EC_KEY, EVP_PKEY_keygen, EVP_PKEY_keygen_init, EVP_PKEY_new,
+    NID_X9_62_prime256v1, NID_secp384r1, NID_secp521r1, BIGNUM, ECDSA_SIG, EC_GROUP, EC_KEY,
+    EC_POINT, EVP_PKEY, EVP_PKEY_EC,
 };
-#[cfg(feature = "fips")]
-use aws_lc::{EC_KEY_check_fips, EC_KEY_generate_key_fips};
-#[cfg(not(feature = "fips"))]
-use aws_lc::{EC_KEY_check_key, EC_KEY_generate_key};
 
 #[cfg(test)]
 use aws_lc::EC_POINT_mul;
@@ -243,10 +245,12 @@ fn evp_pkey_from_public_key(
 
 #[inline]
 unsafe fn validate_ec_key(
-    ec_key: &ConstPointer<EC_KEY>,
+    evp_pkey: &ConstPointer<EVP_PKEY>,
     expected_curve_nid: i32,
 ) -> Result<(), KeyRejected> {
-    let ec_group = ConstPointer::new(EC_KEY_get0_group(**ec_key))?;
+    let ec_key = ConstPointer::new(EVP_PKEY_get0_EC_KEY(**evp_pkey))?;
+
+    let ec_group = ConstPointer::new(EC_KEY_get0_group(*ec_key))?;
     let key_nid = EC_GROUP_get_curve_name(*ec_group);
 
     if key_nid != expected_curve_nid {
@@ -254,12 +258,12 @@ unsafe fn validate_ec_key(
     }
 
     #[cfg(not(feature = "fips"))]
-    if 1 != EC_KEY_check_key(**ec_key) {
+    if 1 != EC_KEY_check_key(*ec_key) {
         return Err(KeyRejected::inconsistent_components());
     }
 
     #[cfg(feature = "fips")]
-    if 1 != EC_KEY_check_fips(**ec_key) {
+    if 1 != EC_KEY_check_fips(*ec_key) {
         return Err(KeyRejected::inconsistent_components());
     }
 
@@ -268,20 +272,27 @@ unsafe fn validate_ec_key(
 
 pub(crate) unsafe fn marshal_public_key_to_buffer(
     buffer: &mut [u8; PUBLIC_KEY_MAX_LEN],
-    ec_key: &ConstPointer<EC_KEY>,
+    evp_pkey: &ConstPointer<EVP_PKEY>,
 ) -> Result<usize, Unspecified> {
-    let ec_group = ConstPointer::new(EC_KEY_get0_group(**ec_key))?;
+    let ec_key = EVP_PKEY_get0_EC_KEY(**evp_pkey);
+    if ec_key.is_null() {
+        return Err(Unspecified);
+    }
 
-    let ec_point = ConstPointer::new(EC_KEY_get0_public_key(**ec_key))?;
+    let ec_group = ConstPointer::new(EC_KEY_get0_group(ec_key))?;
+
+    let ec_point = ConstPointer::new(EC_KEY_get0_public_key(ec_key))?;
 
     let out_len = ec_point_to_bytes(&ec_group, &ec_point, buffer)?;
     Ok(out_len)
 }
 
-pub(crate) fn marshal_public_key(ec_key: &ConstPointer<EC_KEY>) -> Result<PublicKey, Unspecified> {
+pub(crate) fn marshal_public_key(
+    evp_pkey: &ConstPointer<EVP_PKEY>,
+) -> Result<PublicKey, Unspecified> {
     unsafe {
         let mut pub_key_bytes = [0u8; PUBLIC_KEY_MAX_LEN];
-        let key_len = marshal_public_key_to_buffer(&mut pub_key_bytes, ec_key)?;
+        let key_len = marshal_public_key_to_buffer(&mut pub_key_bytes, evp_pkey)?;
         let pub_key = Vec::from(&pub_key_bytes[0..key_len]);
         Ok(PublicKey::new(pub_key.into_boxed_slice()))
     }
@@ -306,7 +317,7 @@ pub(crate) unsafe fn ec_key_from_public_point(
 pub(crate) unsafe fn ec_key_from_private(
     ec_group: &ConstPointer<EC_GROUP>,
     private_big_num: &ConstPointer<BIGNUM>,
-) -> Result<DetachableLcPtr<*mut EC_KEY>, Unspecified> {
+) -> Result<LcPtr<*mut EVP_PKEY>, Unspecified> {
     let ec_key = DetachableLcPtr::new(EC_KEY_new())?;
     if 1 != EC_KEY_set_group(*ec_key, **ec_group) {
         return Err(Unspecified);
@@ -329,26 +340,41 @@ pub(crate) unsafe fn ec_key_from_private(
         return Err(Unspecified);
     }
     let expected_curve_nid = EC_GROUP_get_curve_name(**ec_group);
-    // Validate the EC_KEY before returning it.
-    validate_ec_key(&ec_key.as_const(), expected_curve_nid)?;
 
-    Ok(ec_key)
+    let pkey = LcPtr::new(unsafe { EVP_PKEY_new() })?;
+
+    if 1 != unsafe { EVP_PKEY_assign_EC_KEY(*pkey, *ec_key) } {
+        return Err(Unspecified);
+    }
+    ec_key.detach();
+
+    // Validate the EC_KEY before returning it.
+    validate_ec_key(&pkey.as_const(), expected_curve_nid)?;
+
+    Ok(pkey)
 }
 
 #[inline]
-pub(crate) unsafe fn ec_key_generate(
-    nid: c_int,
-) -> Result<DetachableLcPtr<*mut EC_KEY>, Unspecified> {
-    let ec_key = DetachableLcPtr::new(EC_KEY_new_by_curve_name(nid))?;
-    #[cfg(not(feature = "fips"))]
-    if 1 != EC_KEY_generate_key(*ec_key) {
+pub(crate) fn ec_key_generate(nid: c_int) -> Result<DetachableLcPtr<*mut EVP_PKEY>, Unspecified> {
+    let pkey_ctx = LcPtr::new(unsafe { EVP_PKEY_CTX_new_id(EVP_PKEY_EC, null_mut()) })?;
+
+    if 1 != unsafe { EVP_PKEY_keygen_init(*pkey_ctx) } {
         return Err(Unspecified);
     }
-    #[cfg(feature = "fips")]
-    if 1 != EC_KEY_generate_key_fips(*ec_key) {
+
+    if 1 != unsafe { EVP_PKEY_CTX_set_ec_paramgen_curve_nid(*pkey_ctx, nid) } {
         return Err(Unspecified);
     }
-    Ok(ec_key)
+
+    let mut pkey = null_mut::<EVP_PKEY>();
+
+    if 1 != unsafe { EVP_PKEY_keygen(*pkey_ctx, &mut pkey) } {
+        return Err(Unspecified);
+    }
+
+    let pkey = DetachableLcPtr::new(pkey)?;
+
+    Ok(pkey)
 }
 
 #[inline]
@@ -356,8 +382,8 @@ unsafe fn ec_key_from_public_private(
     ec_group: &LcPtr<*mut EC_GROUP>,
     public_ec_point: &LcPtr<*mut EC_POINT>,
     private_bignum: &DetachableLcPtr<*mut BIGNUM>,
-) -> Result<LcPtr<*mut EC_KEY>, ()> {
-    let ec_key = LcPtr::new(EC_KEY_new())?;
+) -> Result<LcPtr<*mut EVP_PKEY>, ()> {
+    let ec_key = DetachableLcPtr::new(EC_KEY_new())?;
     if 1 != EC_KEY_set_group(*ec_key, **ec_group) {
         return Err(());
     }
@@ -367,7 +393,14 @@ unsafe fn ec_key_from_public_private(
     if 1 != EC_KEY_set_private_key(*ec_key, **private_bignum) {
         return Err(());
     }
-    Ok(ec_key)
+
+    let evp_pkey = LcPtr::new(EVP_PKEY_new())?;
+    if 1 != EVP_PKEY_assign_EC_KEY(*evp_pkey, *ec_key) {
+        return Err(());
+    }
+    ec_key.detach();
+
+    Ok(evp_pkey)
 }
 
 #[inline]

--- a/aws-lc-rs/src/ec.rs
+++ b/aws-lc-rs/src/ec.rs
@@ -355,7 +355,7 @@ pub(crate) unsafe fn ec_key_from_private(
 }
 
 #[inline]
-pub(crate) fn ec_key_generate(nid: c_int) -> Result<DetachableLcPtr<*mut EVP_PKEY>, Unspecified> {
+pub(crate) fn ec_key_generate(nid: c_int) -> Result<LcPtr<*mut EVP_PKEY>, Unspecified> {
     let pkey_ctx = LcPtr::new(unsafe { EVP_PKEY_CTX_new_id(EVP_PKEY_EC, null_mut()) })?;
 
     if 1 != unsafe { EVP_PKEY_keygen_init(*pkey_ctx) } {
@@ -372,7 +372,7 @@ pub(crate) fn ec_key_generate(nid: c_int) -> Result<DetachableLcPtr<*mut EVP_PKE
         return Err(Unspecified);
     }
 
-    let pkey = DetachableLcPtr::new(pkey)?;
+    let pkey = LcPtr::new(pkey)?;
 
     Ok(pkey)
 }

--- a/aws-lc-rs/src/evp_pkey.rs
+++ b/aws-lc-rs/src/evp_pkey.rs
@@ -70,6 +70,7 @@ impl LcPtr<*mut EVP_PKEY> {
         unsafe { EVP_PKEY_bits(**self) }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn get_ec_key(&self) -> Result<LcPtr<*mut EC_KEY>, KeyRejected> {
         unsafe {
             LcPtr::new(EVP_PKEY_get1_EC_KEY(**self)).map_err(|_| KeyRejected::wrong_algorithm())


### PR DESCRIPTION
### Before
 
```
Agreement-X25519/AWS-LC time:   [33.262 µs 33.266 µs 33.269 µs]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) low mild
  1 (1.00%) high severe
 
Agreement-P256/AWS-LC   time:   [59.261 µs 59.265 µs 59.268 µs]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
 
Agreement-P384/AWS-LC   time:   [242.20 µs 242.21 µs 242.22 µs]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
```
 
### After
 
```
Agreement-X25519/AWS-LC time:   [33.586 µs 33.590 µs 33.594 µs]
                        change: [+0.9610% +0.9827% +1.0041%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) low mild
  1 (1.00%) high mild
 
Agreement-P256/AWS-LC   time:   [59.677 µs 59.682 µs 59.686 µs]
                        change: [+0.6937% +0.7047% +0.7148%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high severe
 
Agreement-P384/AWS-LC   time:   [242.86 µs 242.88 µs 242.89 µs]
                        change: [+0.2657% +0.2754% +0.2848%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
