### PR TITLE
feat: add AEAD seal_in_place_scatter method

### DIFF
--- a/aws-lc-rs/src/aead.rs
+++ b/aws-lc-rs/src/aead.rs
@@ -811,13 +811,7 @@ where
     InOut: AsMut<[u8]> + for<'in_out> Extend<&'in_out u8>,
 {
     unsafe {
-        let aead_ctx = match key {
-            AeadCtx::AES_128_GCM(aead_ctx)
-            | AeadCtx::AES_256_GCM(aead_ctx)
-            | AeadCtx::AES_128_GCM_SIV(aead_ctx)
-            | AeadCtx::AES_256_GCM_SIV(aead_ctx)
-            | AeadCtx::CHACHA20_POLY1305(aead_ctx) => aead_ctx,
-        };
+        let aead_ctx = key.as_ref();
         let nonce = nonce.as_ref();
 
         let plaintext_len = in_out.as_mut().len();
@@ -856,13 +850,7 @@ pub(crate) fn aead_open_combined(
     in_out: &mut [u8],
 ) -> Result<(), Unspecified> {
     unsafe {
-        let aead_ctx = match key {
-            AeadCtx::AES_128_GCM(aead_ctx)
-            | AeadCtx::AES_256_GCM(aead_ctx)
-            | AeadCtx::AES_128_GCM_SIV(aead_ctx)
-            | AeadCtx::AES_256_GCM_SIV(aead_ctx)
-            | AeadCtx::CHACHA20_POLY1305(aead_ctx) => aead_ctx,
-        };
+        let aead_ctx = key.as_ref();
         let nonce = nonce.as_ref();
 
         let plaintext_len = in_out.len() - TAG_LEN;

--- a/aws-lc-rs/src/aead.rs
+++ b/aws-lc-rs/src/aead.rs
@@ -396,43 +396,6 @@ impl<N: NonceSequence> SealingKey<N> {
             in_out,
         )
     }
-
-    /// Encrypts and signs (“seals”) data in place with extra plaintext.
-    ///
-    /// `aad` is the additional authenticated data (AAD), if any. This is
-    /// authenticated but not encrypted. The type `A` could be a byte slice
-    /// `&[u8]`, a byte array `[u8; N]` for some constant `N`, `Vec<u8>`, etc.
-    /// If there is no AAD then use `Aad::empty()`.
-    ///
-    /// The plaintext is given as the input value of `in_out` and `extra_in`. `seal_in_place()`
-    /// will overwrite the plaintext contained in `in_out` with the ciphertext. The `extra_in` will
-    /// be encrypted into the `extra_out_and_tag`, along with the tag.
-    /// The `extra_out_and_tag` length must be equal to the `extra_len` and `self.algorithm.tag_len()`.
-    ///
-    /// # Errors
-    /// `error::Unspecified` when `nonce_sequence` cannot be advanced.
-    ///
-    #[inline]
-    #[allow(clippy::needless_pass_by_value)]
-    pub fn seal_in_place_scatter<A>(
-        &mut self,
-        aad: Aad<A>,
-        in_out: &mut [u8],
-        extra_in: &[u8],
-        extra_out_and_tag: &mut [u8],
-    ) -> Result<(), Unspecified>
-    where
-        A: AsRef<[u8]>,
-    {
-        seal_in_place_separate_scatter_(
-            &self.key,
-            self.nonce_sequence.advance()?,
-            Aad::from(aad.as_ref()),
-            in_out,
-            extra_in,
-            extra_out_and_tag,
-        )
-    }
 }
 
 #[inline]
@@ -689,8 +652,17 @@ impl LessSafeKey {
         seal_in_place_separate_tag_(&self.key, nonce, Aad::from(aad.as_ref()), in_out)
     }
 
-    /// Like `SealingKey::seal_in_place_scatter()`, except it accepts an
-    /// arbitrary nonce.
+    /// Encrypts and signs (“seals”) data in place with extra plaintext.
+    ///
+    /// `aad` is the additional authenticated data (AAD), if any. This is
+    /// authenticated but not encrypted. The type `A` could be a byte slice
+    /// `&[u8]`, a byte array `[u8; N]` for some constant `N`, `Vec<u8>`, etc.
+    /// If there is no AAD then use `Aad::empty()`.
+    ///
+    /// The plaintext is given as the input value of `in_out` and `extra_in`. `seal_in_place()`
+    /// will overwrite the plaintext contained in `in_out` with the ciphertext. The `extra_in` will
+    /// be encrypted into the `extra_out_and_tag`, along with the tag.
+    /// The `extra_out_and_tag` length must be equal to the `extra_len` and `self.algorithm.tag_len()`.
     ///
     /// `nonce` must be unique for every use of the key to seal data.
     ///

--- a/aws-lc-rs/src/aead/aead_ctx.rs
+++ b/aws-lc-rs/src/aead/aead_ctx.rs
@@ -102,11 +102,11 @@ impl AsRef<LcPtr<EVP_AEAD_CTX>> for AeadCtx {
     #[inline]
     fn as_ref(&self) -> &LcPtr<EVP_AEAD_CTX> {
         match self {
-            AeadCtx::AES_128_GCM(ctx) => ctx,
-            AeadCtx::AES_256_GCM(ctx) => ctx,
-            AeadCtx::AES_128_GCM_SIV(ctx) => ctx,
-            AeadCtx::AES_256_GCM_SIV(ctx) => ctx,
-            AeadCtx::CHACHA20_POLY1305(ctx) => ctx,
+            AeadCtx::AES_128_GCM(ctx)
+            | AeadCtx::AES_256_GCM(ctx)
+            | AeadCtx::AES_128_GCM_SIV(ctx)
+            | AeadCtx::AES_256_GCM_SIV(ctx)
+            | AeadCtx::CHACHA20_POLY1305(ctx) => ctx,
         }
     }
 }

--- a/aws-lc-rs/src/aead/aead_ctx.rs
+++ b/aws-lc-rs/src/aead/aead_ctx.rs
@@ -97,3 +97,16 @@ impl AeadCtx {
         Ok(aead_ctx)
     }
 }
+
+impl AsRef<LcPtr<EVP_AEAD_CTX>> for AeadCtx {
+    #[inline]
+    fn as_ref(&self) -> &LcPtr<EVP_AEAD_CTX> {
+        match self {
+            AeadCtx::AES_128_GCM(ctx) => ctx,
+            AeadCtx::AES_256_GCM(ctx) => ctx,
+            AeadCtx::AES_128_GCM_SIV(ctx) => ctx,
+            AeadCtx::AES_256_GCM_SIV(ctx) => ctx,
+            AeadCtx::CHACHA20_POLY1305(ctx) => ctx,
+        }
+    }
+}

--- a/aws-lc-rs/src/aead/aes_gcm.rs
+++ b/aws-lc-rs/src/aead/aes_gcm.rs
@@ -85,7 +85,7 @@ pub(crate) fn aead_seal_separate_scatter(
         let mut out_tag_len = extra_out_and_tag.len();
 
         if 1 != EVP_AEAD_CTX_seal_scatter(
-            aead_ctx,
+            *aead_ctx.as_const(),
             in_out.as_mut_ptr(),
             extra_out_and_tag.as_mut_ptr(),
             &mut out_tag_len,

--- a/aws-lc-rs/src/aead/aes_gcm.rs
+++ b/aws-lc-rs/src/aead/aes_gcm.rs
@@ -63,6 +63,16 @@ pub(crate) fn aead_seal_separate_scatter(
     extra_in: &[u8],
     extra_out_and_tag: &mut [u8],
 ) -> Result<(), Unspecified> {
+    // ensure that the extra lengths match
+    {
+        let actual = extra_in.len() + MAX_TAG_LEN;
+        let expected = extra_out_and_tag.len();
+
+        if actual != expected {
+            return Err(Unspecified);
+        }
+    }
+
     unsafe {
         let aead_ctx = match key {
             AeadCtx::CHACHA20_POLY1305(aead_ctx)
@@ -77,7 +87,7 @@ pub(crate) fn aead_seal_separate_scatter(
         if 1 != EVP_AEAD_CTX_seal_scatter(
             aead_ctx,
             in_out.as_mut_ptr(),
-            extra_out_and_tag.as_mut_ptr().cast(),
+            extra_out_and_tag.as_mut_ptr(),
             &mut out_tag_len,
             extra_out_and_tag.len(),
             nonce.as_ptr(),

--- a/aws-lc-rs/src/aead/aes_gcm.rs
+++ b/aws-lc-rs/src/aead/aes_gcm.rs
@@ -19,14 +19,7 @@ pub(crate) fn aead_seal_separate(
     in_out: &mut [u8],
 ) -> Result<Tag, Unspecified> {
     unsafe {
-        let aead_ctx = match key {
-            AeadCtx::CHACHA20_POLY1305(aead_ctx)
-            | AeadCtx::AES_128_GCM(aead_ctx)
-            | AeadCtx::AES_256_GCM(aead_ctx)
-            | AeadCtx::AES_128_GCM_SIV(aead_ctx)
-            | AeadCtx::AES_256_GCM_SIV(aead_ctx) => aead_ctx,
-        };
-
+        let aead_ctx = key.as_ref();
         let aad_slice = aad.as_ref();
         let nonce = nonce.as_ref();
         let mut tag = MaybeUninit::<[u8; MAX_TAG_LEN]>::uninit();
@@ -74,12 +67,7 @@ pub(crate) fn aead_seal_separate_scatter(
     }
 
     unsafe {
-        let aead_ctx = match key {
-            AeadCtx::CHACHA20_POLY1305(aead_ctx)
-            | AeadCtx::AES_128_GCM(aead_ctx)
-            | AeadCtx::AES_256_GCM(aead_ctx) => aead_ctx,
-        };
-
+        let aead_ctx = key.as_ref();
         let aad_slice = aad.as_ref();
         let nonce = nonce.as_ref();
         let mut out_tag_len = extra_out_and_tag.len();

--- a/aws-lc-rs/tests/aead_test.rs
+++ b/aws-lc-rs/tests/aead_test.rs
@@ -19,7 +19,19 @@ fn aead_aes_gcm_128() {
     );
     test_aead(
         &aead::AES_128_GCM,
+        seal_with_key_scatter,
+        open_with_key,
+        test_file!("data/aead_aes_128_gcm_tests.txt"),
+    );
+    test_aead(
+        &aead::AES_128_GCM,
         seal_with_less_safe_key,
+        open_with_less_safe_key,
+        test_file!("data/aead_aes_128_gcm_tests.txt"),
+    );
+    test_aead(
+        &aead::AES_128_GCM,
+        seal_with_less_safe_key_scatter,
         open_with_less_safe_key,
         test_file!("data/aead_aes_128_gcm_tests.txt"),
     );
@@ -35,7 +47,19 @@ fn aead_aes_gcm_256() {
     );
     test_aead(
         &aead::AES_256_GCM,
+        seal_with_key_scatter,
+        open_with_key,
+        test_file!("data/aead_aes_256_gcm_tests.txt"),
+    );
+    test_aead(
+        &aead::AES_256_GCM,
         seal_with_less_safe_key,
+        open_with_less_safe_key,
+        test_file!("data/aead_aes_256_gcm_tests.txt"),
+    );
+    test_aead(
+        &aead::AES_256_GCM,
+        seal_with_less_safe_key_scatter,
         open_with_less_safe_key,
         test_file!("data/aead_aes_256_gcm_tests.txt"),
     );
@@ -83,7 +107,19 @@ fn aead_chacha20_poly1305() {
     );
     test_aead(
         &aead::CHACHA20_POLY1305,
+        seal_with_key_scatter,
+        open_with_key,
+        test_file!("data/aead_chacha20_poly1305_tests.txt"),
+    );
+    test_aead(
+        &aead::CHACHA20_POLY1305,
         seal_with_less_safe_key,
+        open_with_less_safe_key,
+        test_file!("data/aead_chacha20_poly1305_tests.txt"),
+    );
+    test_aead(
+        &aead::CHACHA20_POLY1305,
+        seal_with_less_safe_key_scatter,
         open_with_less_safe_key,
         test_file!("data/aead_chacha20_poly1305_tests.txt"),
     );
@@ -383,6 +419,33 @@ fn seal_with_key(
     s_key.seal_in_place_append_tag(aad, in_out)
 }
 
+fn seal_with_key_scatter(
+    algorithm: &'static aead::Algorithm,
+    key: &[u8],
+    nonce: Nonce,
+    aad: aead::Aad<&[u8]>,
+    in_out: &mut Vec<u8>,
+) -> Result<(), error::Unspecified> {
+    // choose a split point for the `extra` data
+    let split_point = if in_out.is_empty() {
+        0
+    } else {
+        let split_point = u32::from_ne_bytes(key[..4].try_into().unwrap());
+        split_point as usize % in_out.len()
+    };
+
+    // create an extra bit of data to be encrypted
+    let extra_in = in_out[split_point..].to_vec();
+    let mut key: aead::SealingKey<OneNonceSequence> = make_key(algorithm, key, nonce);
+
+    // reserve space at the end for the tag
+    in_out.extend_from_slice(&[0u8; crate::aead::MAX_TAG_LEN][..algorithm.tag_len()]);
+
+    let (in_out, extra_out_and_tag) = in_out.split_at_mut(split_point);
+
+    key.seal_in_place_scatter(aad, in_out, &extra_in, extra_out_and_tag)
+}
+
 fn open_with_key<'a>(
     algorithm: &'static aead::Algorithm,
     key: &[u8],
@@ -404,6 +467,33 @@ fn seal_with_less_safe_key(
 ) -> Result<(), error::Unspecified> {
     let key = make_less_safe_key(algorithm, key);
     key.seal_in_place_append_tag(nonce, aad, in_out)
+}
+
+fn seal_with_less_safe_key_scatter(
+    algorithm: &'static aead::Algorithm,
+    key: &[u8],
+    nonce: Nonce,
+    aad: aead::Aad<&[u8]>,
+    in_out: &mut Vec<u8>,
+) -> Result<(), error::Unspecified> {
+    // choose a split point for the `extra` data
+    let split_point = if in_out.is_empty() {
+        0
+    } else {
+        let split_point = u32::from_ne_bytes(key[..4].try_into().unwrap());
+        split_point as usize % in_out.len()
+    };
+
+    // create an extra bit of data to be encrypted
+    let extra_in = in_out[split_point..].to_vec();
+    let key = make_less_safe_key(algorithm, key);
+
+    // reserve space at the end for the tag
+    in_out.extend_from_slice(&[0u8; crate::aead::MAX_TAG_LEN][..algorithm.tag_len()]);
+
+    let (in_out, extra_out_and_tag) = in_out.split_at_mut(split_point);
+
+    key.seal_in_place_scatter(nonce, aad, in_out, &extra_in, extra_out_and_tag)
 }
 
 fn open_with_less_safe_key<'a>(

--- a/aws-lc-rs/tests/aead_test.rs
+++ b/aws-lc-rs/tests/aead_test.rs
@@ -19,12 +19,6 @@ fn aead_aes_gcm_128() {
     );
     test_aead(
         &aead::AES_128_GCM,
-        seal_with_key_scatter,
-        open_with_key,
-        test_file!("data/aead_aes_128_gcm_tests.txt"),
-    );
-    test_aead(
-        &aead::AES_128_GCM,
         seal_with_less_safe_key,
         open_with_less_safe_key,
         test_file!("data/aead_aes_128_gcm_tests.txt"),
@@ -42,12 +36,6 @@ fn aead_aes_gcm_256() {
     test_aead(
         &aead::AES_256_GCM,
         seal_with_key,
-        open_with_key,
-        test_file!("data/aead_aes_256_gcm_tests.txt"),
-    );
-    test_aead(
-        &aead::AES_256_GCM,
-        seal_with_key_scatter,
         open_with_key,
         test_file!("data/aead_aes_256_gcm_tests.txt"),
     );
@@ -102,12 +90,6 @@ fn aead_chacha20_poly1305() {
     test_aead(
         &aead::CHACHA20_POLY1305,
         seal_with_key,
-        open_with_key,
-        test_file!("data/aead_chacha20_poly1305_tests.txt"),
-    );
-    test_aead(
-        &aead::CHACHA20_POLY1305,
-        seal_with_key_scatter,
         open_with_key,
         test_file!("data/aead_chacha20_poly1305_tests.txt"),
     );
@@ -417,33 +399,6 @@ fn seal_with_key(
 ) -> Result<(), error::Unspecified> {
     let mut s_key: aead::SealingKey<OneNonceSequence> = make_key(algorithm, key, nonce);
     s_key.seal_in_place_append_tag(aad, in_out)
-}
-
-fn seal_with_key_scatter(
-    algorithm: &'static aead::Algorithm,
-    key: &[u8],
-    nonce: Nonce,
-    aad: aead::Aad<&[u8]>,
-    in_out: &mut Vec<u8>,
-) -> Result<(), error::Unspecified> {
-    // choose a split point for the `extra` data
-    let split_point = if in_out.is_empty() {
-        0
-    } else {
-        let split_point = u32::from_ne_bytes(key[..4].try_into().unwrap());
-        split_point as usize % in_out.len()
-    };
-
-    // create an extra bit of data to be encrypted
-    let extra_in = in_out[split_point..].to_vec();
-    let mut key: aead::SealingKey<OneNonceSequence> = make_key(algorithm, key, nonce);
-
-    // reserve space at the end for the tag
-    in_out.extend_from_slice(&[0u8; crate::aead::MAX_TAG_LEN][..algorithm.tag_len()]);
-
-    let (in_out, extra_out_and_tag) = in_out.split_at_mut(split_point);
-
-    key.seal_in_place_scatter(aad, in_out, &extra_in, extra_out_and_tag)
 }
 
 fn open_with_key<'a>(


### PR DESCRIPTION
### Description of changes: 

The current AEAD encrypt API takes a `in_out: &mut [u8]`, which forces callers to copy all of the cleartext into a single slice. This shouldn't be needed since encrypting a payload _is_ copying the data since it has to XOR it with the cipher stream. 

Luckily, AWS-LC already provides a EVP API to account for this: [EVP_AEAD_CTX_seal_scatter](https://docs.rs/aws-lc-sys/latest/aws_lc_sys/fn.EVP_AEAD_CTX_seal_scatter.html). This allows the caller to pass a `extra_in`, which is encrypted into the `tag_out` buffer.

In transport protocols like TLS and QUIC, where the bulk of the data being encrypted is separate from the framing header, using this API can yield large wins. In the case of s2n-quic, we see a reduction in 8% of CPU by avoiding the copy.

### Call-outs:

#### API ergonomics

This new API isn't the most straightforward interface to use. You have to make sure to split the slices up in the correct order and account for the tag size. If we want to limit its use, we can add a feature flag stating that it's somewhat advanced.

#### API naming

I'm not sure if this is the best name, but it's what I came up with. Let me know if there's something better.

### Testing:

I've updated the AEAD tests to check the new API matches the existing ones. I'm using part of the key bytes to pick an arbitrary split point in the input for the `extra_in` parameter. This will make the tests deterministic for a given key but still be somewhat "random" in how the `in_out` is split from the `extra_in`.

#### s2n-quic without this change

Throughput is ~20Gbps. You can see the `memcpy` taking about 8% of CPU cycles in the flamegraph:

![flamegraph](https://github.com/aws/aws-lc-rs/assets/799311/c6d9c69e-810a-47c9-a0d2-7b7d56a9e960)

#### s2n-quic with this change

Throughput is ~21Gbps. You can see in the flamegraph that the `memcpy` is gone:

![flamegraph](https://github.com/aws/aws-lc-rs/assets/799311/be142d55-8a44-4e55-8fce-32debf1b248a)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
