### PR TITLE
Remove unneeded calls to .cast()

### DIFF
--- a/aws-lc-rs/src/aead/aead_ctx.rs
+++ b/aws-lc-rs/src/aead/aead_ctx.rs
@@ -69,7 +69,7 @@ impl AeadCtx {
             if 1 != EVP_AEAD_CTX_init(
                 aead_ctx.as_mut_ptr(),
                 aead,
-                key_bytes.as_ptr().cast(),
+                key_bytes.as_ptr(),
                 key_bytes.len(),
                 TAG_LEN,
                 null_mut(),

--- a/aws-lc-rs/src/aead/poly1305.rs
+++ b/aws-lc-rs/src/aead/poly1305.rs
@@ -35,8 +35,7 @@ pub struct Context {
 // are used, is only correct when the state buffer is 64-byte aligned.
 #[repr(C, align(64))]
 #[allow(non_camel_case_types)]
-struct poly1305_state([u8; OPAQUE_LEN]);
-const OPAQUE_LEN: usize = 512;
+struct poly1305_state(aws_lc::poly1305_state);
 
 impl Context {
     #[inline]

--- a/aws-lc-rs/src/agreement.rs
+++ b/aws-lc-rs/src/agreement.rs
@@ -358,7 +358,7 @@ impl EphemeralPrivateKey {
             KeyInner::X25519(priv_key) => {
                 let mut buffer = [0u8; MAX_PUBLIC_KEY_LEN];
                 unsafe {
-                    X25519_public_from_private(buffer.as_mut_ptr().cast(), priv_key.as_ptr());
+                    X25519_public_from_private(buffer.as_mut_ptr(), priv_key.as_ptr());
                 }
 
                 Ok(PublicKey {

--- a/aws-lc-rs/src/ec.rs
+++ b/aws-lc-rs/src/ec.rs
@@ -344,7 +344,7 @@ unsafe fn ec_point_to_bytes(
         **ec_group,
         **ec_point,
         pt_conv_form,
-        buf.as_mut_ptr().cast(),
+        buf.as_mut_ptr(),
         PUBLIC_KEY_MAX_LEN,
         null_mut(),
     );

--- a/aws-lc-rs/src/error.rs
+++ b/aws-lc-rs/src/error.rs
@@ -256,6 +256,7 @@ mod tests {
         let unspecified = super::Unspecified::from(key_rejected);
         assert_eq!("Unspecified", unspecified.description());
 
+        #[allow(clippy::redundant_locals)]
         let unspecified = unspecified;
         assert_eq!("Unspecified", unspecified.description());
     }

--- a/aws-lc-rs/src/hmac.rs
+++ b/aws-lc-rs/src/hmac.rs
@@ -370,11 +370,7 @@ impl Context {
     #[inline]
     fn try_update(&mut self, data: &[u8]) -> Result<(), Unspecified> {
         unsafe {
-            if 1 != HMAC_Update(
-                self.key.get_hmac_ctx_ptr(),
-                data.as_ptr().cast(),
-                data.len(),
-            ) {
+            if 1 != HMAC_Update(self.key.get_hmac_ctx_ptr(), data.as_ptr(), data.len()) {
                 return Err(Unspecified);
             }
         }


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Remove unnecessary/redundant pointer casts.
* Change `poly1305_state` wrapper to directly wrap the underlying type.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
