### PR TITLE
Refactor LcPtr, DetachablePtr for readability

### DIFF
--- a/aws-lc-rs/src/aead/aead_ctx.rs
+++ b/aws-lc-rs/src/aead/aead_ctx.rs
@@ -18,9 +18,9 @@ use aws_lc::{
     non_camel_case_types
 )]
 pub(crate) enum AeadCtx {
-    AES_128_GCM(LcPtr<*mut EVP_AEAD_CTX>),
-    AES_256_GCM(LcPtr<*mut EVP_AEAD_CTX>),
-    CHACHA20_POLY1305(LcPtr<*mut EVP_AEAD_CTX>),
+    AES_128_GCM(LcPtr<EVP_AEAD_CTX>),
+    AES_256_GCM(LcPtr<EVP_AEAD_CTX>),
+    CHACHA20_POLY1305(LcPtr<EVP_AEAD_CTX>),
 }
 
 unsafe impl Send for AeadCtx {}
@@ -60,7 +60,7 @@ impl AeadCtx {
     fn build_context(
         aead_fn: unsafe extern "C" fn() -> *const aws_lc::evp_aead_st,
         key_bytes: &[u8],
-    ) -> Result<LcPtr<*mut EVP_AEAD_CTX>, Unspecified> {
+    ) -> Result<LcPtr<EVP_AEAD_CTX>, Unspecified> {
         let aead = unsafe { aead_fn() };
 
         let aead_ctx = unsafe {

--- a/aws-lc-rs/src/agreement.rs
+++ b/aws-lc-rs/src/agreement.rs
@@ -160,9 +160,9 @@ const X25519_PUBLIC_VALUE_LEN: usize = aws_lc::X25519_PUBLIC_VALUE_LEN as usize;
 const X25519_SHARED_KEY_LEN: usize = aws_lc::X25519_SHARED_KEY_LEN as usize;
 #[allow(non_camel_case_types)]
 enum KeyInner {
-    ECDH_P256(LcPtr<*mut EC_KEY>),
-    ECDH_P384(LcPtr<*mut EC_KEY>),
-    ECDH_P521(LcPtr<*mut EC_KEY>),
+    ECDH_P256(LcPtr<EC_KEY>),
+    ECDH_P384(LcPtr<EC_KEY>),
+    ECDH_P521(LcPtr<EC_KEY>),
     X25519([u8; X25519_PRIVATE_KEY_LEN]),
 }
 

--- a/aws-lc-rs/src/bn.rs
+++ b/aws-lc-rs/src/bn.rs
@@ -7,7 +7,7 @@ use mirai_annotations::unrecoverable;
 use std::cmp::Ordering;
 use std::ptr::null_mut;
 
-impl TryFrom<&[u8]> for DetachableLcPtr<*mut BIGNUM> {
+impl TryFrom<&[u8]> for DetachableLcPtr<BIGNUM> {
     type Error = ();
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
@@ -15,7 +15,7 @@ impl TryFrom<&[u8]> for DetachableLcPtr<*mut BIGNUM> {
     }
 }
 
-impl TryFrom<u64> for DetachableLcPtr<*mut BIGNUM> {
+impl TryFrom<u64> for DetachableLcPtr<BIGNUM> {
     type Error = ();
 
     fn try_from(value: u64) -> Result<Self, Self::Error> {

--- a/aws-lc-rs/src/ec.rs
+++ b/aws-lc-rs/src/ec.rs
@@ -273,9 +273,7 @@ pub(crate) unsafe fn ec_key_from_private(
 }
 
 #[inline]
-pub(crate) unsafe fn ec_key_generate(
-    nid: c_int,
-) -> Result<DetachableLcPtr<EC_KEY>, Unspecified> {
+pub(crate) unsafe fn ec_key_generate(nid: c_int) -> Result<DetachableLcPtr<EC_KEY>, Unspecified> {
     let ec_key = DetachableLcPtr::new(EC_KEY_new_by_curve_name(nid))?;
     #[cfg(not(feature = "fips"))]
     if 1 != EC_KEY_generate_key(*ec_key) {

--- a/aws-lc-rs/src/ec.rs
+++ b/aws-lc-rs/src/ec.rs
@@ -226,9 +226,9 @@ pub(crate) fn marshal_public_key(ec_key: &ConstPointer<EC_KEY>) -> Result<Public
 
 #[inline]
 pub(crate) unsafe fn ec_key_from_public_point(
-    ec_group: &LcPtr<*mut EC_GROUP>,
-    public_ec_point: &LcPtr<*mut EC_POINT>,
-) -> Result<DetachableLcPtr<*mut EC_KEY>, Unspecified> {
+    ec_group: &LcPtr<EC_GROUP>,
+    public_ec_point: &LcPtr<EC_POINT>,
+) -> Result<DetachableLcPtr<EC_KEY>, Unspecified> {
     let ec_key = DetachableLcPtr::new(EC_KEY_new())?;
     if 1 != EC_KEY_set_group(*ec_key, **ec_group) {
         return Err(Unspecified);
@@ -243,7 +243,7 @@ pub(crate) unsafe fn ec_key_from_public_point(
 pub(crate) unsafe fn ec_key_from_private(
     ec_group: &ConstPointer<EC_GROUP>,
     private_big_num: &ConstPointer<BIGNUM>,
-) -> Result<DetachableLcPtr<*mut EC_KEY>, Unspecified> {
+) -> Result<DetachableLcPtr<EC_KEY>, Unspecified> {
     let ec_key = DetachableLcPtr::new(EC_KEY_new())?;
     if 1 != EC_KEY_set_group(*ec_key, **ec_group) {
         return Err(Unspecified);
@@ -275,7 +275,7 @@ pub(crate) unsafe fn ec_key_from_private(
 #[inline]
 pub(crate) unsafe fn ec_key_generate(
     nid: c_int,
-) -> Result<DetachableLcPtr<*mut EC_KEY>, Unspecified> {
+) -> Result<DetachableLcPtr<EC_KEY>, Unspecified> {
     let ec_key = DetachableLcPtr::new(EC_KEY_new_by_curve_name(nid))?;
     #[cfg(not(feature = "fips"))]
     if 1 != EC_KEY_generate_key(*ec_key) {
@@ -290,10 +290,10 @@ pub(crate) unsafe fn ec_key_generate(
 
 #[inline]
 unsafe fn ec_key_from_public_private(
-    ec_group: &LcPtr<*mut EC_GROUP>,
-    public_ec_point: &LcPtr<*mut EC_POINT>,
-    private_bignum: &DetachableLcPtr<*mut BIGNUM>,
-) -> Result<LcPtr<*mut EC_KEY>, ()> {
+    ec_group: &LcPtr<EC_GROUP>,
+    public_ec_point: &LcPtr<EC_POINT>,
+    private_bignum: &DetachableLcPtr<BIGNUM>,
+) -> Result<LcPtr<EC_KEY>, ()> {
     let ec_key = LcPtr::new(EC_KEY_new())?;
     if 1 != EC_KEY_set_group(*ec_key, **ec_group) {
         return Err(());
@@ -308,15 +308,15 @@ unsafe fn ec_key_from_public_private(
 }
 
 #[inline]
-pub(crate) unsafe fn ec_group_from_nid(nid: i32) -> Result<LcPtr<*mut EC_GROUP>, ()> {
+pub(crate) unsafe fn ec_group_from_nid(nid: i32) -> Result<LcPtr<EC_GROUP>, ()> {
     LcPtr::new(EC_GROUP_new_by_curve_name(nid))
 }
 
 #[inline]
 pub(crate) unsafe fn ec_point_from_bytes(
-    ec_group: &LcPtr<*mut EC_GROUP>,
+    ec_group: &LcPtr<EC_GROUP>,
     bytes: &[u8],
-) -> Result<LcPtr<*mut EC_POINT>, Unspecified> {
+) -> Result<LcPtr<EC_POINT>, Unspecified> {
     let ec_point = LcPtr::new(EC_POINT_new(**ec_group))?;
 
     if 1 != EC_POINT_oct2point(
@@ -356,7 +356,7 @@ unsafe fn ec_point_to_bytes(
 }
 
 #[inline]
-unsafe fn ecdsa_sig_to_asn1(ecdsa_sig: &LcPtr<*mut ECDSA_SIG>) -> Result<Signature, Unspecified> {
+unsafe fn ecdsa_sig_to_asn1(ecdsa_sig: &LcPtr<ECDSA_SIG>) -> Result<Signature, Unspecified> {
     let mut out_bytes = MaybeUninit::<*mut u8>::uninit();
     let mut out_len = MaybeUninit::<usize>::uninit();
 
@@ -376,7 +376,7 @@ unsafe fn ecdsa_sig_to_asn1(ecdsa_sig: &LcPtr<*mut ECDSA_SIG>) -> Result<Signatu
 #[inline]
 unsafe fn ecdsa_sig_to_fixed(
     alg_id: &'static AlgorithmID,
-    sig: &LcPtr<*mut ECDSA_SIG>,
+    sig: &LcPtr<ECDSA_SIG>,
 ) -> Result<Signature, Unspecified> {
     let expected_number_size = ecdsa_fixed_number_byte_size(alg_id);
 
@@ -403,7 +403,7 @@ unsafe fn ecdsa_sig_to_fixed(
 }
 
 #[inline]
-unsafe fn ecdsa_sig_from_asn1(signature: &[u8]) -> Result<LcPtr<*mut ECDSA_SIG>, ()> {
+unsafe fn ecdsa_sig_from_asn1(signature: &[u8]) -> Result<LcPtr<ECDSA_SIG>, ()> {
     LcPtr::new(ECDSA_SIG_from_bytes(signature.as_ptr(), signature.len()))
 }
 
@@ -420,7 +420,7 @@ const fn ecdsa_fixed_number_byte_size(alg_id: &'static AlgorithmID) -> usize {
 unsafe fn ecdsa_sig_from_fixed(
     alg_id: &'static AlgorithmID,
     signature: &[u8],
-) -> Result<LcPtr<*mut ECDSA_SIG>, ()> {
+) -> Result<LcPtr<ECDSA_SIG>, ()> {
     let num_size_bytes = ecdsa_fixed_number_byte_size(alg_id);
     if signature.len() != 2 * num_size_bytes {
         return Err(());

--- a/aws-lc-rs/src/ec/key_pair.rs
+++ b/aws-lc-rs/src/ec/key_pair.rs
@@ -25,7 +25,7 @@ use std::fmt::{Debug, Formatter};
 #[allow(clippy::module_name_repetitions)]
 pub struct EcdsaKeyPair {
     algorithm: &'static EcdsaSigningAlgorithm,
-    ec_key: LcPtr<*mut EC_KEY>,
+    ec_key: LcPtr<EC_KEY>,
     pubkey: PublicKey,
 }
 
@@ -48,7 +48,7 @@ impl KeyPair for EcdsaKeyPair {
     }
 }
 
-pub(crate) unsafe fn generate_key(nid: i32) -> Result<LcPtr<*mut EVP_PKEY>, Unspecified> {
+pub(crate) unsafe fn generate_key(nid: i32) -> Result<LcPtr<EVP_PKEY>, Unspecified> {
     let ec_key = DetachableLcPtr::new(EC_KEY_new_by_curve_name(nid))?;
 
     #[cfg(feature = "fips")]
@@ -73,7 +73,7 @@ pub(crate) unsafe fn generate_key(nid: i32) -> Result<LcPtr<*mut EVP_PKEY>, Unsp
 impl EcdsaKeyPair {
     unsafe fn new(
         algorithm: &'static EcdsaSigningAlgorithm,
-        ec_key: LcPtr<*mut EC_KEY>,
+        ec_key: LcPtr<EC_KEY>,
     ) -> Result<Self, ()> {
         let pubkey = ec::marshal_public_key(&ec_key.as_const())?;
 

--- a/aws-lc-rs/src/ed25519.rs
+++ b/aws-lc-rs/src/ed25519.rs
@@ -115,7 +115,7 @@ impl KeyPair for Ed25519KeyPair {
     }
 }
 
-pub(crate) unsafe fn generate_key(rng: &dyn SecureRandom) -> Result<LcPtr<*mut EVP_PKEY>, ()> {
+pub(crate) unsafe fn generate_key(rng: &dyn SecureRandom) -> Result<LcPtr<EVP_PKEY>, ()> {
     let mut seed = [0u8; ED25519_SEED_LEN];
     rng.fill(&mut seed)?;
 

--- a/aws-lc-rs/src/evp_pkey.rs
+++ b/aws-lc-rs/src/evp_pkey.rs
@@ -14,7 +14,7 @@ use aws_lc::{
 use std::mem::MaybeUninit;
 use std::os::raw::c_int;
 
-impl TryFrom<&[u8]> for LcPtr<*mut EVP_PKEY> {
+impl TryFrom<&[u8]> for LcPtr<EVP_PKEY> {
     type Error = KeyRejected;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
@@ -26,7 +26,7 @@ impl TryFrom<&[u8]> for LcPtr<*mut EVP_PKEY> {
     }
 }
 
-impl LcPtr<*mut EVP_PKEY> {
+impl LcPtr<EVP_PKEY> {
     pub(crate) fn validate_as_ed25519(&self) -> Result<(), KeyRejected> {
         const ED25519_KEY_TYPE: c_int = aws_lc::EVP_PKEY_ED25519;
         const ED25519_MIN_BITS: c_int = 253;
@@ -69,13 +69,13 @@ impl LcPtr<*mut EVP_PKEY> {
         unsafe { EVP_PKEY_bits(**self) }
     }
 
-    pub(crate) fn get_ec_key(&self) -> Result<LcPtr<*mut EC_KEY>, KeyRejected> {
+    pub(crate) fn get_ec_key(&self) -> Result<LcPtr<EC_KEY>, KeyRejected> {
         unsafe {
             LcPtr::new(EVP_PKEY_get1_EC_KEY(**self)).map_err(|_| KeyRejected::wrong_algorithm())
         }
     }
 
-    pub(crate) fn get_rsa(&self) -> Result<LcPtr<*mut RSA>, KeyRejected> {
+    pub(crate) fn get_rsa(&self) -> Result<LcPtr<RSA>, KeyRejected> {
         unsafe { LcPtr::new(EVP_PKEY_get1_RSA(**self)).map_err(|_| KeyRejected::wrong_algorithm()) }
     }
 

--- a/aws-lc-rs/src/ptr.rs
+++ b/aws-lc-rs/src/ptr.rs
@@ -7,12 +7,15 @@ use aws_lc::{EVP_AEAD_CTX_free, OPENSSL_free, EVP_AEAD_CTX};
 
 use mirai_annotations::verify_unreachable;
 
+pub(crate) type LcPtr<T> = ManagedPointer<*mut T>;
+pub(crate) type DetachableLcPtr<T> = DetachablePointer<*mut T>;
+
 #[derive(Debug)]
-pub(crate) struct LcPtr<P: Pointer> {
+pub(crate) struct ManagedPointer<P: Pointer> {
     pointer: P,
 }
 
-impl<P: Pointer> Deref for LcPtr<P> {
+impl<P: Pointer> Deref for ManagedPointer<P> {
     type Target = P;
     #[inline]
     fn deref(&self) -> &Self::Target {
@@ -20,7 +23,7 @@ impl<P: Pointer> Deref for LcPtr<P> {
     }
 }
 
-impl<P: Pointer> LcPtr<P> {
+impl<P: Pointer> ManagedPointer<P> {
     #[inline]
     pub fn new<T: IntoPointer<P>>(value: T) -> Result<Self, ()> {
         if let Some(pointer) = value.into_pointer() {
@@ -31,14 +34,14 @@ impl<P: Pointer> LcPtr<P> {
     }
 }
 
-impl<P: Pointer> Drop for LcPtr<P> {
+impl<P: Pointer> Drop for ManagedPointer<P> {
     #[inline]
     fn drop(&mut self) {
         self.pointer.free();
     }
 }
 
-impl<P: Pointer + Copy> LcPtr<P> {
+impl<P: Pointer + Copy> ManagedPointer<P> {
     #[inline]
     pub fn as_const<T>(&self) -> ConstPointer<T> {
         ConstPointer {
@@ -49,11 +52,11 @@ impl<P: Pointer + Copy> LcPtr<P> {
 
 #[derive(Debug)]
 #[allow(clippy::module_name_repetitions)]
-pub(crate) struct DetachableLcPtr<P: Pointer> {
+pub(crate) struct DetachablePointer<P: Pointer> {
     pointer: Option<P>,
 }
 
-impl<P: Pointer> Deref for DetachableLcPtr<P> {
+impl<P: Pointer> Deref for DetachablePointer<P> {
     type Target = P;
     #[inline]
     fn deref(&self) -> &Self::Target {
@@ -67,7 +70,7 @@ impl<P: Pointer> Deref for DetachableLcPtr<P> {
     }
 }
 
-impl<P: Pointer> DetachableLcPtr<P> {
+impl<P: Pointer> DetachablePointer<P> {
     #[inline]
     pub fn new<T: IntoPointer<P>>(value: T) -> Result<Self, ()> {
         if let Some(pointer) = value.into_pointer() {
@@ -85,7 +88,7 @@ impl<P: Pointer> DetachableLcPtr<P> {
     }
 }
 
-impl<P: Pointer + Copy> DetachableLcPtr<P> {
+impl<P: Pointer + Copy> DetachablePointer<P> {
     #[inline]
     pub fn as_const<T>(&self) -> ConstPointer<T> {
         match self.pointer {
@@ -100,11 +103,11 @@ impl<P: Pointer + Copy> DetachableLcPtr<P> {
     }
 }
 
-impl<P: Pointer> From<DetachableLcPtr<P>> for LcPtr<P> {
+impl<P: Pointer> From<DetachablePointer<P>> for ManagedPointer<P> {
     #[inline]
-    fn from(mut dptr: DetachableLcPtr<P>) -> Self {
+    fn from(mut dptr: DetachablePointer<P>) -> Self {
         match dptr.pointer.take() {
-            Some(pointer) => LcPtr { pointer },
+            Some(pointer) => ManagedPointer { pointer },
             None => {
                 // Safety: pointer is only None when DetachableLcPtr is detached or dropped
                 verify_unreachable!()
@@ -113,7 +116,7 @@ impl<P: Pointer> From<DetachableLcPtr<P>> for LcPtr<P> {
     }
 }
 
-impl<P: Pointer> Drop for DetachableLcPtr<P> {
+impl<P: Pointer> Drop for DetachablePointer<P> {
     #[inline]
     fn drop(&mut self) {
         if let Some(mut pointer) = self.pointer.take() {
@@ -201,22 +204,22 @@ create_pointer!(EVP_AEAD_CTX, EVP_AEAD_CTX_free);
 
 #[cfg(test)]
 mod tests {
-    use crate::ptr::{ConstPointer, DetachableLcPtr, LcPtr};
+    use crate::ptr::{ConstPointer, DetachablePointer, ManagedPointer};
     use aws_lc::BIGNUM;
 
     #[test]
     fn test_debug() {
         let num = 100u64;
-        let detachable_ptr: DetachableLcPtr<*mut BIGNUM> = DetachableLcPtr::try_from(num).unwrap();
+        let detachable_ptr: DetachablePointer<*mut BIGNUM> = DetachablePointer::try_from(num).unwrap();
         let debug = format!("{detachable_ptr:?}");
-        assert!(debug.contains("DetachableLcPtr { pointer: Some("));
+        assert!(debug.contains("DetachablePointer { pointer: Some("));
 
         let const_ptr: ConstPointer<BIGNUM> = detachable_ptr.as_const();
         let debug = format!("{const_ptr:?}");
         assert!(debug.contains("ConstPointer { ptr:"));
 
-        let lc_ptr = LcPtr::new(detachable_ptr.detach()).unwrap();
+        let lc_ptr = ManagedPointer::new(detachable_ptr.detach()).unwrap();
         let debug = format!("{lc_ptr:?}");
-        assert!(debug.contains("LcPtr { pointer:"));
+        assert!(debug.contains("ManagedPointer { pointer:"));
     }
 }

--- a/aws-lc-rs/src/rsa.rs
+++ b/aws-lc-rs/src/rsa.rs
@@ -48,7 +48,7 @@ pub struct RsaKeyPair {
     // other thread is concurrently calling a mutating function. Unless otherwise
     // documented, functions which take a |const| pointer are non-mutating and
     // functions which take a non-|const| pointer are mutating.
-    rsa_key: LcPtr<*mut RSA>,
+    rsa_key: LcPtr<RSA>,
     serialized_public_key: RsaSubjectPublicKey,
 }
 
@@ -57,7 +57,7 @@ unsafe impl Send for RsaKeyPair {}
 unsafe impl Sync for RsaKeyPair {}
 
 impl RsaKeyPair {
-    fn new(rsa_key: LcPtr<*mut RSA>) -> Result<Self, KeyRejected> {
+    fn new(rsa_key: LcPtr<RSA>) -> Result<Self, KeyRejected> {
         unsafe {
             let serialized_public_key = RsaSubjectPublicKey::new(&rsa_key.as_const())?;
             Ok(RsaKeyPair {
@@ -507,7 +507,7 @@ impl RsaParameters {
 
 #[inline]
 #[allow(non_snake_case)]
-unsafe fn build_public_RSA(public_key: &[u8]) -> Result<LcPtr<*mut RSA>, Unspecified> {
+unsafe fn build_public_RSA(public_key: &[u8]) -> Result<LcPtr<RSA>, Unspecified> {
     let mut cbs = cbs::build_CBS(public_key);
 
     let rsa = LcPtr::new(RSA_parse_public_key(&mut cbs))?;
@@ -516,7 +516,7 @@ unsafe fn build_public_RSA(public_key: &[u8]) -> Result<LcPtr<*mut RSA>, Unspeci
 
 #[inline]
 #[allow(non_snake_case)]
-unsafe fn build_private_RSA(public_key: &[u8]) -> Result<LcPtr<*mut RSA>, KeyRejected> {
+unsafe fn build_private_RSA(public_key: &[u8]) -> Result<LcPtr<RSA>, KeyRejected> {
     let mut cbs = cbs::build_CBS(public_key);
 
     let rsa =
@@ -529,7 +529,7 @@ unsafe fn build_private_RSA(public_key: &[u8]) -> Result<LcPtr<*mut RSA>, KeyRej
 fn verify_RSA(
     algorithm: &'static digest::Algorithm,
     padding: &'static RsaPadding,
-    public_key: &LcPtr<*mut RSA>,
+    public_key: &LcPtr<RSA>,
     msg: &[u8],
     signature: &[u8],
     allowed_bit_size: &RangeInclusive<u32>,
@@ -600,7 +600,7 @@ where
 {
     #[allow(non_snake_case)]
     #[inline]
-    unsafe fn build_RSA(&self) -> Result<LcPtr<*mut RSA>, ()> {
+    unsafe fn build_RSA(&self) -> Result<LcPtr<RSA>, ()> {
         let n_bytes = self.n.as_ref();
         if n_bytes.is_empty() || n_bytes[0] == 0u8 {
             return Err(());


### PR DESCRIPTION
### Description of changes: 
Just cleans up the usage so they you don't need to specify `LcPtr<*mut T>` or `DetachableLcPtr<*mut T>` but can just say `LcPtr<T>` or `DetacableLcPtr<T>` similar to how `ConstPtr<T>` is already how that type functions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
