### PR TITLE
Refactor HKDF for FIPS

### DIFF
--- a/aws-lc-rs-testing/benches/hkdf_benchmark.rs
+++ b/aws-lc-rs-testing/benches/hkdf_benchmark.rs
@@ -113,17 +113,17 @@ fn bench_hkdf(c: &mut Criterion, config: &HKDFConfig) {
         let bench_group_name = format!("HKDF-{:?}-{}-bytes", config.algorithm, chunk_len);
         let mut group = c.benchmark_group(bench_group_name);
 
-        let aws_prk = aws_lc_rs_benchmarks::run_hkdf_extract(config);
         group.bench_function("AWS-LC", |b| {
             b.iter(|| {
+                let aws_prk = aws_lc_rs_benchmarks::run_hkdf_extract(config);
                 aws_lc_rs_benchmarks::run_hkdf_expand(&aws_prk, info_chunk);
             });
         });
         #[cfg(feature = "ring-benchmarks")]
         {
-            let ring_prk = ring_benchmarks::run_hkdf_extract(config);
             group.bench_function("Ring", |b| {
                 b.iter(|| {
+                    let ring_prk = ring_benchmarks::run_hkdf_extract(config);
                     ring_benchmarks::run_hkdf_expand(&ring_prk, info_chunk);
                 });
             });

--- a/aws-lc-rs/src/hkdf.rs
+++ b/aws-lc-rs/src/hkdf.rs
@@ -212,7 +212,7 @@ struct ZeroizeBoxSlice<T: Zeroize>(Box<[T]>);
 
 impl<T: Clone + Zeroize> From<&[T]> for ZeroizeBoxSlice<T> {
     fn from(value: &[T]) -> Self {
-        Self(Box::from(value))
+        Self(Vec::from(value).into_boxed_slice())
     }
 }
 

--- a/aws-lc-rs/src/hkdf.rs
+++ b/aws-lc-rs/src/hkdf.rs
@@ -88,8 +88,8 @@ impl KeyType for Algorithm {
 /// A salt for HKDF operations.
 pub struct Salt {
     algorithm: Algorithm,
-    key_bytes: [u8; MAX_HKDF_SALT_LEN],
-    key_len: usize,
+    salt_bytes: [u8; MAX_HKDF_SALT_LEN],
+    salt_len: usize,
 }
 
 #[allow(clippy::missing_fields_in_debug)]
@@ -103,7 +103,7 @@ impl fmt::Debug for Salt {
 
 impl Drop for Salt {
     fn drop(&mut self) {
-        self.key_bytes.zeroize();
+        self.salt_bytes.zeroize();
     }
 }
 
@@ -122,16 +122,16 @@ impl Salt {
     }
 
     fn try_new(algorithm: Algorithm, value: &[u8]) -> Result<Salt, Unspecified> {
-        let key_len = value.len();
-        if key_len > MAX_HKDF_SALT_LEN {
+        let salt_len = value.len();
+        if salt_len > MAX_HKDF_SALT_LEN {
             return Err(Unspecified);
         }
-        let mut key_bytes = [0u8; MAX_HKDF_SALT_LEN];
-        key_bytes[0..key_len].copy_from_slice(value);
+        let mut salt_bytes = [0u8; MAX_HKDF_SALT_LEN];
+        salt_bytes[0..salt_len].copy_from_slice(value);
         Ok(Self {
             algorithm,
-            key_bytes,
-            key_len,
+            salt_bytes,
+            salt_len,
         })
     }
 
@@ -148,8 +148,8 @@ impl Salt {
             algorithm: self.algorithm,
             mode: PrkMode::ExtractExpand {
                 secret: Arc::from(ZeroizeBoxSlice::from(secret)),
-                salt: self.key_bytes,
-                salt_len: self.key_len,
+                salt: self.salt_bytes,
+                salt_len: self.salt_len,
             },
         }
     }
@@ -173,8 +173,8 @@ impl From<Okm<'_, Algorithm>> for Salt {
         okm.fill(&mut key_bytes[..key_len]).unwrap();
         Self {
             algorithm,
-            key_bytes,
-            key_len,
+            salt_bytes: key_bytes,
+            salt_len: key_len,
         }
     }
 }

--- a/aws-lc-rs/src/hkdf.rs
+++ b/aws-lc-rs/src/hkdf.rs
@@ -168,13 +168,13 @@ const _: () = assert!(MAX_HKDF_PRK_LEN <= MAX_HKDF_SALT_LEN);
 impl From<Okm<'_, Algorithm>> for Salt {
     fn from(okm: Okm<'_, Algorithm>) -> Self {
         let algorithm = okm.prk.algorithm;
-        let mut key_bytes = [0u8; MAX_HKDF_SALT_LEN];
-        let key_len = okm.len().len();
-        okm.fill(&mut key_bytes[..key_len]).unwrap();
+        let mut salt_bytes = [0u8; MAX_HKDF_SALT_LEN];
+        let salt_len = okm.len().len();
+        okm.fill(&mut salt_bytes[..salt_len]).unwrap();
         Self {
             algorithm,
-            salt_bytes: key_bytes,
-            salt_len: key_len,
+            salt_bytes,
+            salt_len,
         }
     }
 }

--- a/aws-lc-rs/src/hkdf.rs
+++ b/aws-lc-rs/src/hkdf.rs
@@ -227,8 +227,8 @@ impl PrkMode {
                         out.as_mut_ptr(),
                         out.len(),
                         digest,
-                        secret.0.as_ptr(),
-                        secret.0.len(),
+                        secret.as_ptr(),
+                        secret.len(),
                         salt.as_ptr(),
                         *salt_len,
                         info.as_ptr(),
@@ -255,15 +255,17 @@ impl core::fmt::Debug for PrkMode {
 
 struct ZeroizeBoxSlice<T: Zeroize>(Box<[T]>);
 
-impl<T: Clone + Zeroize> From<&[T]> for ZeroizeBoxSlice<T> {
-    fn from(value: &[T]) -> Self {
-        Self(Vec::from(value).into_boxed_slice())
+impl<T: Zeroize> std::ops::Deref for ZeroizeBoxSlice<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
-impl<T: Zeroize> AsRef<[T]> for ZeroizeBoxSlice<T> {
-    fn as_ref(&self) -> &[T] {
-        &self.0
+impl<T: Clone + Zeroize> From<&[T]> for ZeroizeBoxSlice<T> {
+    fn from(value: &[T]) -> Self {
+        Self(Vec::from(value).into_boxed_slice())
     }
 }
 


### PR DESCRIPTION
### Description of changes: 
Current HKDF API is a slightly difficult to map onto the AWS-LC FIPS API. The standalone `HDKF_expand` API is meant to be used with a KDF Feedback design mode as specified in [SP 800-108 section 4.2](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-108r1.pdf). In AWS-LC this function will set the FIPS indicator based on the digest algorithm and nothing else.

The other usage for KDF is defined in [SP 800-56C section 5](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Cr2.pdf) for key derivation (like a key agreement scheme) where the extraction and expansion are performed together as a single procedure.

The aws-lc-rs provides a mixed usage of both, even if the net outcome is the same. This is due to the `hkdf::Prk::new_less_safe` providing a construction that allows the specification of the raw Prk key bytes (which would allow for KDF feedback designs). The other mode users are directed towards is the flow of using: 
```
  Salt::new(salt_bytes) -> Salt::extract(key_bytes) 
                        -> Prk::expand(info_bytes) 
                        -> Okm::fill(output_buffer)
```
This is 1-1 the expand/extract workflow (note `Okm::fill` is where `HKDF_expand` is already called today, the Prk function is technically a misnomer in how we map to the AWS-LC) API.

This PR adds the concept of the "Prk operating mode" for determining whether we were constructed from raw key bytes, or from a given salt and secret. We then move the computation step to `Okm:fill` where we perform `HKDF_expand` or `HKDF(...)` (one-shot expand+extract function) so we can have the proper indicator checks (FIPS indicator validates salt length & info length in addition to the digest used).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
