### PR TITLE
Make docker configs consistent

### DIFF
--- a/docker/linux-386/Dockerfile
+++ b/docker/linux-386/Dockerfile
@@ -10,6 +10,7 @@ ARG GO_VERSION=go1.20.1
 RUN apt-get update && \
     apt-get -y install clang cmake golang && \
     rustup update && \
+    rustup toolchain install nightly && \
     rustup component add rustfmt clippy && \
     cargo install rust-script && \
     git config --global --add safe.directory '*' && \
@@ -22,3 +23,7 @@ RUN apt-get update && \
     rm -rf /tmp/*
 
 ENV PATH="/root/sdk/${GO_VERSION}/bin:${PATH}"
+
+# Static FIPS build only supports clang.
+ENV CC=clang
+ENV CXX=clang++

--- a/docker/linux-386/Dockerfile
+++ b/docker/linux-386/Dockerfile
@@ -8,7 +8,7 @@ SHELL ["/bin/bash", "-c"]
 ARG GO_VERSION=go1.20.1
 
 RUN apt-get update && \
-    apt-get -y install clang cmake golang && \
+    apt-get -y install clang libclang1 cmake golang && \
     rustup update && \
     rustup toolchain install nightly && \
     rustup component add rustfmt clippy && \

--- a/docker/linux-386/Dockerfile
+++ b/docker/linux-386/Dockerfile
@@ -24,6 +24,5 @@ RUN apt-get update && \
 
 ENV PATH="/root/sdk/${GO_VERSION}/bin:${PATH}"
 
-# Static FIPS build only supports clang.
 ENV CC=clang
 ENV CXX=clang++

--- a/docker/linux-arm64/Dockerfile
+++ b/docker/linux-arm64/Dockerfile
@@ -8,7 +8,7 @@ SHELL ["/bin/bash", "-c"]
 ARG GO_VERSION=go1.20.1
 
 RUN apt-get update && \
-    apt-get -y install clang cmake golang && \
+    apt-get -y install clang libclang1 cmake golang && \
     rustup update && \
     rustup toolchain install nightly && \
     rustup component add rustfmt clippy && \

--- a/docker/linux-arm64/Dockerfile
+++ b/docker/linux-arm64/Dockerfile
@@ -24,6 +24,5 @@ RUN apt-get update && \
 
 ENV PATH="/root/sdk/${GO_VERSION}/bin:${PATH}"
 
-# Static FIPS build only supports clang.
 ENV CC=clang
 ENV CXX=clang++

--- a/docker/linux-arm64/Dockerfile
+++ b/docker/linux-arm64/Dockerfile
@@ -1,10 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR ISC
 
-# Download exactly what is needed using the sparse registry.
-# https://github.com/rust-lang/cargo/issues/10781
-# https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html
-
 FROM --platform=linux/arm64 rust:latest
 
 SHELL ["/bin/bash", "-c"]
@@ -15,9 +11,7 @@ RUN apt-get update && \
     apt-get -y install clang cmake golang && \
     rustup update && \
     rustup toolchain install nightly && \
-    rustup default nightly && \
     rustup component add rustfmt clippy && \
-    cargo +nightly install -Z sparse-registry --debug cargo-ament-build && \
     cargo install rust-script && \
     git config --global --add safe.directory '*' && \
     go get golang.org/dl/${GO_VERSION} && \
@@ -29,7 +23,6 @@ RUN apt-get update && \
     rm -rf /tmp/*
 
 ENV PATH="/root/sdk/${GO_VERSION}/bin:${PATH}"
-ENV CARGO_UNSTABLE_SPARSE_REGISTRY=true
 
 # Static FIPS build only supports clang.
 ENV CC=clang

--- a/docker/linux-x86_64/Dockerfile
+++ b/docker/linux-x86_64/Dockerfile
@@ -10,6 +10,7 @@ ARG GO_VERSION=go1.20.1
 RUN apt-get update && \
     apt-get -y install clang cmake golang && \
     rustup update && \
+    rustup toolchain install nightly && \
     rustup component add rustfmt clippy && \
     cargo install rust-script && \
     git config --global --add safe.directory '*' && \
@@ -22,3 +23,7 @@ RUN apt-get update && \
     rm -rf /tmp/*
 
 ENV PATH="/root/sdk/${GO_VERSION}/bin:${PATH}"
+
+# Static FIPS build only supports clang.
+ENV CC=clang
+ENV CXX=clang++

--- a/docker/linux-x86_64/Dockerfile
+++ b/docker/linux-x86_64/Dockerfile
@@ -8,7 +8,7 @@ SHELL ["/bin/bash", "-c"]
 ARG GO_VERSION=go1.20.1
 
 RUN apt-get update && \
-    apt-get -y install clang cmake golang && \
+    apt-get -y install clang libclang1 cmake golang && \
     rustup update && \
     rustup toolchain install nightly && \
     rustup component add rustfmt clippy && \

--- a/docker/linux-x86_64/Dockerfile
+++ b/docker/linux-x86_64/Dockerfile
@@ -24,6 +24,5 @@ RUN apt-get update && \
 
 ENV PATH="/root/sdk/${GO_VERSION}/bin:${PATH}"
 
-# Static FIPS build only supports clang.
 ENV CC=clang
 ENV CXX=clang++


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* The "sparse-registry" config in arm64 image is [no longer needed](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html#sparse-by-default-for-cratesio).
* Docker images were inconsistent at to whether:
    * to install nightly
    * to set CC/CXX

### Call-outs:
N/A

### Testing:
Using for sys crate updates.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
