### PR TITLE
Include Windows '*.asm' assembly files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,38 @@ jobs:
         working-directory: ./aws-lc-rs
         run: cargo test ${{ matrix.args }}
 
+  publish-dry-run:
+    name: publish dry-run
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [ stable ]
+        os: [ windows-2019, ubuntu-latest, macOS-latest ]
+        args:
+          - publish --dry-run
+    steps:
+      - if: ${{ matrix.os == 'windows-2019' }}
+        uses: ilammy/setup-nasm@v1
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - uses: actions-rs/toolchain@v1.0.7
+        id: toolchain
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: aws-lc-sys
+        working-directory: ./aws-lc-sys
+        run: cargo ${{ matrix.args }}
+      - name: aws-lc-fips-sys
+        if: ${{ matrix.os != 'windows-2019' }}
+        working-directory: ./aws-lc-fips-sys
+        run: cargo ${{ matrix.args }}
+      - name: aws-lc-rs
+        working-directory: ./aws-lc-rs
+        run: cargo ${{ matrix.args }}
+
   aws-lc-rs-coverage:
     name: aws-ls-rs coverage
     runs-on: ubuntu-latest

--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-lc-fips-sys"
 description = "AWS-LC is a general-purpose cryptographic library maintained by the AWS Cryptography team for AWS and their customers. This is the FIPS validated version of AWS-LC."
-version = "0.10.0"
+version = "0.10.1"
 authors = ["AWS-LC"]
 edition = "2021"
 repository = "https://github.com/aws/aws-lc-rs"

--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -14,6 +14,7 @@ include = [
     "/aws-lc/**/*.pl",
     "/aws-lc/**/*.h",
     "/aws-lc/**/*.S",
+    "/aws-lc/**/*.asm",
     "/aws-lc/**/CMakeLists.txt",
     "/aws-lc/**/*.cmake",
     "/aws-lc/**/*.errordata",

--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-lc-fips-sys"
 description = "AWS-LC is a general-purpose cryptographic library maintained by the AWS Cryptography team for AWS and their customers. This is the FIPS validated version of AWS-LC."
-version = "0.10.1"
+version = "0.10.0"
 authors = ["AWS-LC"]
 edition = "2021"
 repository = "https://github.com/aws/aws-lc-rs"

--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-lc-sys"
 description = "AWS-LC is a general-purpose cryptographic library maintained by the AWS Cryptography team for AWS and their customers. It іs based on code from the Google BoringSSL project and the OpenSSL project."
-version = "0.10.1"
+version = "0.10.0"
 authors = ["AWS-LC"]
 edition = "2021"
 repository = "https://github.com/aws/aws-lc-rs"

--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-lc-sys"
 description = "AWS-LC is a general-purpose cryptographic library maintained by the AWS Cryptography team for AWS and their customers. It іs based on code from the Google BoringSSL project and the OpenSSL project."
-version = "0.10.0"
+version = "0.10.1"
 authors = ["AWS-LC"]
 edition = "2021"
 repository = "https://github.com/aws/aws-lc-rs"

--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -14,6 +14,7 @@ include = [
     "/aws-lc/**/*.pl",
     "/aws-lc/**/*.h",
     "/aws-lc/**/*.S",
+    "/aws-lc/**/*.asm",
     "/aws-lc/**/CMakeLists.txt",
     "/aws-lc/**/*.cmake",
     "/aws-lc/**/*.errordata",


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Our package configurations were not including the "*.asm" files for Windows x86 and x86-64.
* Added a CI for a `cargo publish --dry-run` step on Linux, Macos and Windows.

### Call-outs:
* Found while investigating: https://github.com/aws/aws-lc-rs/issues/225

### Testing:
I verified that the files are now included in our package:
```
❯ find ./target/package -name "chacha-*.asm" 
./target/package/aws-lc-fips-sys-0.10.0/aws-lc/generated-src/win-x86_64/crypto/chacha/chacha-x86_64.asm
./target/package/aws-lc-fips-sys-0.10.0/aws-lc/generated-src/win-x86/crypto/chacha/chacha-x86.asm
./target/package/aws-lc-sys-0.10.0/aws-lc/generated-src/win-x86_64/crypto/chacha/chacha-x86_64.asm
./target/package/aws-lc-sys-0.10.0/aws-lc/generated-src/win-x86/crypto/chacha/chacha-x86.asm
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
