### PR TITLE
Clippy: fix 'should_panic' lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions-rs/toolchain@v1.0.7
         id: toolchain
         with:
-          toolchain: nightly-2023-05-24
+          toolchain: nightly-2023-08-25
           profile: minimal
           override: true
       - name: Install cargo-public-api

--- a/aws-lc-rs/src/digest.rs
+++ b/aws-lc-rs/src/digest.rs
@@ -324,13 +324,13 @@ mod tests {
                         super::max_input_test(&digest::$algorithm_name);
                     }
                     #[test]
-                    #[should_panic]
+                    #[should_panic(expected = "digest update failed")]
                     fn too_long_input_test_block() {
                         super::too_long_input_test_block(&digest::$algorithm_name);
                     }
 
                     #[test]
-                    #[should_panic]
+                    #[should_panic(expected = "digest update failed")]
                     fn too_long_input_test_byte() {
                         super::too_long_input_test_byte(&digest::$algorithm_name);
                     }

--- a/aws-lc-rs/src/test.rs
+++ b/aws-lc-rs/src/test.rs
@@ -558,7 +558,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(
+        expected = "source slice length (42) does not match destination slice length (0)"
+    )]
     fn fixed_slice_random_length_mismatch() {
         let fbr = FixedSliceRandom { bytes: &[42u8; 42] };
         let _: Result<(), error::Unspecified> = fbr.fill_impl(&mut []);
@@ -579,7 +581,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "index out of bounds: the len is 0 but the index is 0")]
     fn fixed_slice_sequence_random_no_remaining() {
         let fbr = FixedSliceSequenceRandom {
             bytes: &[],


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Fix clippy complaints regarding `[should_panic]`.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
