### PR TITLE
FIPS Usage Documentation

### DIFF
--- a/.github/workflows/deploy-user-guide.yml
+++ b/.github/workflows/deploy-user-guide.yml
@@ -18,7 +18,7 @@ jobs:
           override: true
       - name: Build and Test User Guide
         run: |
-          curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.28/mdbook-v0.4.28-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.34/mdbook-v0.4.34-x86_64-unknown-linux-gnu.tar.gz | tar xz
           ./mdbook build book
           ./mdbook test book
       - name: Deploy User Guide

--- a/aws-lc-rs/src/aead/chacha20_poly1305_openssh.rs
+++ b/aws-lc-rs/src/aead/chacha20_poly1305_openssh.rs
@@ -19,6 +19,9 @@
 //! [chacha20-poly1305@openssh.com]:
 //!    http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/PROTOCOL.chacha20poly1305?annotate=HEAD
 //! [RFC 4253]: https://tools.ietf.org/html/rfc4253
+//!
+//! # FIPS
+//! FIPS users should not use the APIs offered in this module.
 
 use super::{poly1305, Nonce, Tag};
 use crate::cipher::block::BLOCK_LEN;
@@ -48,6 +51,9 @@ impl SealingKey {
     /// `padding_length||payload||random padding`. It will be overwritten by
     /// `encrypted_packet_length||ciphertext`, where `encrypted_packet_length`
     /// is encrypted with `K_1` and `ciphertext` is encrypted by `K_2`.
+    ///
+    /// # FIPS
+    /// FIPS users should not use this method.
     #[inline]
     pub fn seal_in_place(
         &self,
@@ -92,6 +98,9 @@ impl OpeningKey {
     ///
     /// Importantly, the result won't be authenticated until `open_in_place` is
     /// called.
+    ///
+    /// # FIPS
+    /// FIPS users should not use this method.
     #[inline]
     #[must_use]
     pub fn decrypt_packet_length(
@@ -120,6 +129,8 @@ impl OpeningKey {
     /// # Errors
     /// `error::Unspecified` when ciphertext is invalid
     ///
+    /// # FIPS
+    /// FIPS users should not use this method.
     #[inline]
     pub fn open_in_place<'a>(
         &self,

--- a/aws-lc-rs/src/aead/nonce_sequence.rs
+++ b/aws-lc-rs/src/aead/nonce_sequence.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 //! Implementations of `NonceSequence` for use with `BoundKey`s.
-//!
-//!
 
 mod counter32;
 mod counter64;

--- a/aws-lc-rs/src/aead/nonce_sequence/counter32.rs
+++ b/aws-lc-rs/src/aead/nonce_sequence/counter32.rs
@@ -13,7 +13,6 @@ use crate::iv::FixedLength;
 /// `u32::MAX`.
 ///
 /// See [Section 3.2 of RFC 5116](https://www.rfc-editor.org/rfc/rfc5116#section-3.2).
-///
 #[allow(clippy::module_name_repetitions)]
 pub struct Counter32 {
     limit: u32,

--- a/aws-lc-rs/src/aead/quic.rs
+++ b/aws-lc-rs/src/aead/quic.rs
@@ -36,7 +36,6 @@ impl HeaderProtectionKey {
     ///
     /// # Errors
     /// `error::Unspecified` when `key_bytes` length is not `algorithm.key_len`
-    ///
     pub fn new(
         algorithm: &'static Algorithm,
         key_bytes: &[u8],
@@ -51,7 +50,6 @@ impl HeaderProtectionKey {
     ///
     /// # Errors
     /// `error::Unspecified` when `sample` length is not `self.algorithm().sample_len()`.
-    ///
     #[inline]
     pub fn new_mask(&self, sample: &[u8]) -> Result<[u8; 5], error::Unspecified> {
         let sample = <&[u8; SAMPLE_LEN]>::try_from(sample)?;

--- a/aws-lc-rs/src/aead/tests/fips.rs
+++ b/aws-lc-rs/src/aead/tests/fips.rs
@@ -9,7 +9,7 @@ mod quic;
 use crate::{
     aead::{
         nonce_sequence::Counter64Builder, Aad, BoundKey, Nonce, OpeningKey, RandomizedNonceKey,
-        SealingKey, TLSProtocolId, TLSRecordOpeningKey, TLSRecordSealingKey, UnboundKey,
+        SealingKey, TlsProtocolId, TlsRecordOpeningKey, TlsRecordSealingKey, UnboundKey,
         AES_128_GCM, AES_256_GCM, CHACHA20_POLY1305,
     },
     fips::{assert_fips_status_indicator, FipsServiceStatus},
@@ -191,7 +191,7 @@ macro_rules! tls_nonce_api {
     ($name:ident, $alg:expr, $proto:expr, $key:expr) => {
         #[test]
         fn $name() {
-            let key = TLSRecordSealingKey::new($alg, $proto, $key).unwrap();
+            let key = TlsRecordSealingKey::new($alg, $proto, $key).unwrap();
 
             let mut in_out = Vec::from(TEST_MESSAGE);
 
@@ -205,7 +205,7 @@ macro_rules! tls_nonce_api {
             )
             .unwrap();
 
-            let key = TLSRecordOpeningKey::new($alg, $proto, $key).unwrap();
+            let key = TlsRecordOpeningKey::new($alg, $proto, $key).unwrap();
 
             let in_out = assert_fips_status_indicator!(
                 key.open_in_place(Nonce::from(&TEST_NONCE_96_BIT), Aad::empty(), &mut in_out),
@@ -220,8 +220,8 @@ macro_rules! tls_nonce_api {
     ($name:ident, $alg:expr, $proto:expr, $key:expr, false) => {
         #[test]
         fn $name() {
-            assert!(TLSRecordSealingKey::new($alg, $proto, $key).is_err());
-            assert!(TLSRecordOpeningKey::new($alg, $proto, $key).is_err());
+            assert!(TlsRecordSealingKey::new($alg, $proto, $key).is_err());
+            assert!(TlsRecordOpeningKey::new($alg, $proto, $key).is_err());
         }
     };
 }
@@ -229,38 +229,38 @@ macro_rules! tls_nonce_api {
 tls_nonce_api!(
     aes_128_tls12_nonce_api,
     &AES_128_GCM,
-    TLSProtocolId::TLS12,
+    TlsProtocolId::TLS12,
     &TEST_KEY_128_BIT
 );
 tls_nonce_api!(
     aes_256_tls12_nonce_api,
     &AES_256_GCM,
-    TLSProtocolId::TLS12,
+    TlsProtocolId::TLS12,
     &TEST_KEY_256_BIT
 );
 tls_nonce_api!(
     aes_128_tls13_nonce_api,
     &AES_128_GCM,
-    TLSProtocolId::TLS13,
+    TlsProtocolId::TLS13,
     &TEST_KEY_128_BIT
 );
 tls_nonce_api!(
     aes_256_tls13_nonce_api,
     &AES_256_GCM,
-    TLSProtocolId::TLS13,
+    TlsProtocolId::TLS13,
     &TEST_KEY_256_BIT
 );
 tls_nonce_api!(
     chaca20_poly1305_tls12_nonce_api,
     &CHACHA20_POLY1305,
-    TLSProtocolId::TLS12,
+    TlsProtocolId::TLS12,
     &TEST_KEY_256_BIT,
     false
 );
 tls_nonce_api!(
     chaca20_poly1305_tls13_nonce_api,
     &CHACHA20_POLY1305,
-    TLSProtocolId::TLS13,
+    TlsProtocolId::TLS13,
     &TEST_KEY_256_BIT,
     false
 );

--- a/aws-lc-rs/src/agreement.rs
+++ b/aws-lc-rs/src/agreement.rs
@@ -213,6 +213,8 @@ impl EphemeralPrivateKey {
     /// # Errors
     /// `error::Unspecified` when operation fails due to internal error.
     ///
+    /// # FIPS
+    /// FIPS users should only utilize this method with `ECDH_P256`, `ECDH_P384`, or `ECDH_P521` algorithms.
     pub fn generate(alg: &'static Algorithm, _rng: &dyn SecureRandom) -> Result<Self, Unspecified> {
         match alg.id {
             AlgorithmID::X25519 => {
@@ -320,7 +322,6 @@ impl EphemeralPrivateKey {
     ///
     /// # Errors
     /// `error::Unspecified` when operation fails due to internal error.
-    ///
     pub fn compute_public_key(&self) -> Result<PublicKey, Unspecified> {
         match &self.inner_key {
             KeyInner::ECDH_P256(evp_pkey)
@@ -501,6 +502,8 @@ impl<B: AsRef<[u8]>> UnparsedPublicKey<B> {
 /// # Errors
 /// `error_value` on internal failure.
 ///
+/// # FIPS
+/// FIPS users should only utilize this method with `ECDH_P256`, `ECDH_P384`, or `ECDH_P521` keys.
 #[inline]
 #[allow(clippy::needless_pass_by_value)]
 #[allow(clippy::missing_panics_doc)]

--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -421,6 +421,9 @@ impl PaddedBlockEncryptingKey {
     ///
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error cosntructing a `PaddedBlockEncryptingKey`.
+    ///
+    /// # FIPS
+    /// This mode utilizes cryptographic implementations that follow FIPS implementation guidance.
     pub fn cbc_pkcs7(key: UnboundCipherKey) -> Result<PaddedBlockEncryptingKey, Unspecified> {
         PaddedBlockEncryptingKey::new(key, OperatingMode::CBC, PaddingStrategy::PKCS7)
     }
@@ -655,6 +658,9 @@ impl DecryptingKey {
     ///
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error during decryption.
+    ///
+    /// # FIPS
+    /// This mode utilizes cryptographic functions that follow FIPS implementation guidance.
     pub fn ctr(key: UnboundCipherKey) -> Result<DecryptingKey, Unspecified> {
         DecryptingKey::new(key, OperatingMode::CTR)
     }

--- a/aws-lc-rs/src/constant_time.rs
+++ b/aws-lc-rs/src/constant_time.rs
@@ -15,7 +15,6 @@ use aws_lc::CRYPTO_memcmp;
 ///
 /// # Errors
 /// `error::Unspecified` when `a` and `b` differ.
-///
 #[inline]
 pub fn verify_slices_are_equal(a: &[u8], b: &[u8]) -> Result<(), error::Unspecified> {
     if a.len() != b.len() {

--- a/aws-lc-rs/src/digest.rs
+++ b/aws-lc-rs/src/digest.rs
@@ -49,7 +49,6 @@ use std::mem::MaybeUninit;
 use std::os::raw::c_uint;
 
 /// A context for multi-step (Init-Update-Finish) digest calculations.
-///
 #[derive(Clone)]
 pub struct Context {
     /// The context's algorithm.
@@ -123,6 +122,15 @@ impl Context {
     ///
     /// # Panics
     /// Panics if the digest is unable to be finalized
+    ///
+    /// # FIPS
+    /// FIPS users should only utilize this method with the following algorithms:
+    /// * `SHA1_FOR_LEGACY_USE_ONLY`
+    /// * `SHA224`
+    /// * `SHA256`
+    /// * `SHA384`
+    /// * `SHA512`
+    /// * `SHA512_256`
     #[inline]
     #[must_use]
     pub fn finish(self) -> Digest {
@@ -159,6 +167,15 @@ impl Context {
 }
 
 /// Returns the digest of `data` using the given digest algorithm.
+///
+/// # FIPS
+/// FIPS users should only utilize this method with the following algorithms:
+/// * `SHA1_FOR_LEGACY_USE_ONLY`
+/// * `SHA224`
+/// * `SHA256`
+/// * `SHA384`
+/// * `SHA512`
+/// * `SHA512_256`
 ///
 /// # Examples:
 ///

--- a/aws-lc-rs/src/ec/key_pair.rs
+++ b/aws-lc-rs/src/ec/key_pair.rs
@@ -92,7 +92,6 @@ impl EcdsaKeyPair {
     ///
     /// # Errors
     /// `error::Unspecified` on internal error.
-    ///
     pub fn generate_pkcs8(
         alg: &'static EcdsaSigningAlgorithm,
         _rng: &dyn SecureRandom,
@@ -148,6 +147,10 @@ impl EcdsaKeyPair {
     /// # Errors
     /// `error::Unspecified` on internal error.
     ///
+    /// # FIPS
+    /// FIPS users should utilize this method when meeting the following conditions:
+    /// * NIST Elliptic Curves: P256, P384, P521
+    /// * Digest Algorithms: SHA256, SHA384, SHA512
     #[inline]
     pub fn sign(&self, _rng: &dyn SecureRandom, message: &[u8]) -> Result<Signature, Unspecified> {
         let mut md_ctx = DigestContext::new_uninit();

--- a/aws-lc-rs/src/ed25519.rs
+++ b/aws-lc-rs/src/ed25519.rs
@@ -155,6 +155,9 @@ impl Ed25519KeyPair {
     ///
     /// # Errors
     /// `error::Unspecified` if `rng` cannot provide enough bits or if there's an internal error.
+    ///
+    /// # FIPS
+    /// FIPS users should not use this method.
     pub fn generate_pkcs8(_rng: &dyn SecureRandom) -> Result<Document, Unspecified> {
         let evp_pkey = unsafe { generate_key()? };
         evp_pkey.marshall_private_key(Version::V2)
@@ -171,6 +174,9 @@ impl Ed25519KeyPair {
     ///
     /// # Errors
     /// `error::Unspecified` if `rng` cannot provide enough bits or if there's an internal error.
+    ///
+    /// # FIPS
+    /// FIPS users should not use this method.
     pub fn generate_pkcs8v1(_rng: &dyn SecureRandom) -> Result<Document, Unspecified> {
         let evp_pkey = unsafe { generate_key()? };
         evp_pkey.marshall_private_key(Version::V1)
@@ -189,7 +195,6 @@ impl Ed25519KeyPair {
     ///
     /// # Errors
     /// `error::KeyRejected` if parse error, or if key is otherwise unacceptable.
-    ///
     pub fn from_seed_and_public_key(seed: &[u8], public_key: &[u8]) -> Result<Self, KeyRejected> {
         if seed.len() < ED25519_SEED_LEN {
             return Err(KeyRejected::inconsistent_components());
@@ -233,7 +238,6 @@ impl Ed25519KeyPair {
     ///
     /// # Errors
     /// `error::KeyRejected` on parse error, or if key is otherwise unacceptable.
-    ///
     pub fn from_pkcs8(pkcs8: &[u8]) -> Result<Self, KeyRejected> {
         Self::parse_pkcs8(pkcs8)
     }
@@ -253,7 +257,6 @@ impl Ed25519KeyPair {
     ///
     /// # Errors
     /// `error::KeyRejected` on parse error, or if key is otherwise unacceptable.
-    ///
     pub fn from_pkcs8_maybe_unchecked(pkcs8: &[u8]) -> Result<Self, KeyRejected> {
         Self::parse_pkcs8(pkcs8)
     }
@@ -291,6 +294,9 @@ impl Ed25519KeyPair {
     ///
     /// # Panics
     /// Panics if the message is unable to be signed
+    ///
+    /// # FIPS
+    /// FIPS users should not use this method.
     #[inline]
     #[must_use]
     pub fn sign(&self, msg: &[u8]) -> Signature {

--- a/aws-lc-rs/src/error.rs
+++ b/aws-lc-rs/src/error.rs
@@ -34,7 +34,9 @@ use std::num::TryFromIntError;
 /// }
 ///
 /// impl From<aws_lc_rs::error::Unspecified> for Error {
-///     fn from(_: aws_lc_rs::error::Unspecified) -> Self { Error::CryptoError }
+///     fn from(_: aws_lc_rs::error::Unspecified) -> Self {
+///         Error::CryptoError
+///     }
 /// }
 ///
 /// fn eight_random_bytes() -> Result<[u8; 8], Error> {
@@ -232,23 +234,6 @@ impl From<TryFromIntError> for Unspecified {
 impl From<TryFromIntError> for KeyRejected {
     fn from(_: TryFromIntError) -> Self {
         KeyRejected::unexpected_error()
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct ServiceNotApproved;
-
-impl std::error::Error for ServiceNotApproved {}
-
-impl core::fmt::Display for ServiceNotApproved {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("ServiceNotApproved")
-    }
-}
-
-impl From<ServiceNotApproved> for Unspecified {
-    fn from(_: ServiceNotApproved) -> Self {
-        Self {}
     }
 }
 

--- a/aws-lc-rs/src/hkdf.rs
+++ b/aws-lc-rs/src/hkdf.rs
@@ -22,15 +22,19 @@
 //! let pseudo_random_key = salt.extract(b"secret input keying material");
 //!
 //! // Derive HMAC key
-//! let hmac_key_material = pseudo_random_key.expand(&[b"hmac contextual info"],
-//!         hkdf::HKDF_SHA256.hmac_algorithm()).unwrap();
+//! let hmac_key_material = pseudo_random_key
+//!     .expand(
+//!         &[b"hmac contextual info"],
+//!         hkdf::HKDF_SHA256.hmac_algorithm(),
+//!     )
+//!     .unwrap();
 //! let hmac_key = hmac::Key::from(hmac_key_material);
 //!
 //! // Derive UnboundKey for AES-128-GCM
-//! let aes_keying_material = pseudo_random_key.expand(&[b"aes contextual info"],
-//!         &aead::AES_128_GCM).unwrap();
+//! let aes_keying_material = pseudo_random_key
+//!     .expand(&[b"aes contextual info"], &aead::AES_128_GCM)
+//!     .unwrap();
 //! let aead_unbound_key = aead::UnboundKey::from(aes_keying_material);
-//!
 //! ```
 
 use crate::error::Unspecified;
@@ -406,6 +410,16 @@ impl<L: KeyType> Okm<'_, L> {
     /// `error::Unspecified` if the requested output length differs from the length specified by
     /// `L: KeyType`.
     ///
+    ///# FIPS
+    /// FIPS users should utilize this method when meeting the following conditions:
+    /// * The HKDF algorithm is one of:
+    ///    * `HKDF_SHA1_FOR_LEGACY_USE_ONLY`
+    ///    * `HKDF_SHA256`
+    ///    * `HKDF_SHA384`
+    ///    * `HKDF_SHA512`
+    /// * If the [`Okm`] was constructed from a [`Prk`] created with [`Salt::extract`]:
+    ///    * The `value.len()` passed to [`Salt::new`] was non-zero.
+    ///    * The `info_len` from [`Prk::expand`] was non-zero.
     #[inline]
     pub fn fill(self, out: &mut [u8]) -> Result<(), Unspecified> {
         if out.len() != self.len.len() {

--- a/aws-lc-rs/src/hmac.rs
+++ b/aws-lc-rs/src/hmac.rs
@@ -40,8 +40,8 @@
 //! ## Using the one-shot API:
 //!
 //! ```
-//! use aws_lc_rs::{digest, hmac, rand};
 //! use aws_lc_rs::rand::SecureRandom;
+//! use aws_lc_rs::{digest, hmac, rand};
 //!
 //! let msg = "hello, world";
 //!
@@ -64,8 +64,8 @@
 //!
 //! ## Using the multi-part API:
 //! ```
-//! use aws_lc_rs::{digest, hmac, rand};
 //! use aws_lc_rs::rand::SecureRandom;
+//! use aws_lc_rs::{digest, hmac, rand};
 //!
 //! let parts = ["hello", ", ", "world"];
 //!
@@ -230,7 +230,6 @@ impl Key {
     ///
     /// # Errors
     /// `error::Unspecified` is the `rng` fails.
-    ///
     pub fn generate(
         algorithm: Algorithm,
         rng: &dyn crate::rand::SecureRandom,
@@ -419,6 +418,10 @@ impl Context {
 ///
 /// It is generally not safe to implement HMAC verification by comparing the
 /// return value of `sign` to a tag. Use `verify` for verification instead.
+///
+/// # FIPS
+/// FIPS users should only utilize this method with `HMAC_SHA1_FOR_LEGACY_USE_ONLY`, `HMAC_SHA224`, `HMAC_SHA256`,
+/// `HMAC_SHA384`, or `HMAC_SHA512` algorithms.
 #[inline]
 #[must_use]
 pub fn sign(key: &Key, data: &[u8]) -> Tag {
@@ -438,6 +441,9 @@ pub fn sign(key: &Key, data: &[u8]) -> Tag {
 /// # Errors
 /// `error::Unspecified` if the inputs are not verified.
 ///
+/// # FIPS
+/// FIPS users should only utilize this method with `HMAC_SHA1_FOR_LEGACY_USE_ONLY`, `HMAC_SHA224`, `HMAC_SHA256`,
+/// `HMAC_SHA384`, or `HMAC_SHA512` algorithms.
 #[inline]
 pub fn verify(key: &Key, data: &[u8], tag: &[u8]) -> Result<(), Unspecified> {
     constant_time::verify_slices_are_equal(sign(key, data).as_ref(), tag)

--- a/aws-lc-rs/src/iv.rs
+++ b/aws-lc-rs/src/iv.rs
@@ -29,7 +29,6 @@ impl<const L: usize> FixedLength<L> {
     /// # Errors
     ///
     /// * [`Unspecified`]: Returned if there is a failure generating `L` bytes.
-    ///
     pub fn new() -> Result<Self, Unspecified> {
         let mut iv_bytes = [0u8; L];
         rand::fill(&mut iv_bytes)?;

--- a/aws-lc-rs/src/lib.rs
+++ b/aws-lc-rs/src/lib.rs
@@ -89,7 +89,6 @@
 //! for ring that provides FIPS support and is compatible with the ring API. Rust developers with
 //! prescribed cryptographic requirements can seamlessly integrate aws-lc-rs into their applications
 //! and deploy them into AWS Regions.
-//!
 
 #![warn(missing_docs)]
 

--- a/aws-lc-rs/src/pbkdf2.rs
+++ b/aws-lc-rs/src/pbkdf2.rs
@@ -166,6 +166,13 @@ const MAX_USIZE32: u64 = u32::MAX as u64;
 ///
 /// `derive` panics if `out.len()` is larger than (2**32 - 1) * the digest
 /// algorithm's output length, per the PBKDF2 specification.
+///
+/// # FIPS
+/// FIPS users should utilize this method when meeting the following conditions:
+/// * Algorithms: `HMAC_SHA1_FOR_LEGACY_USE_ONLY`, `HMAC_SHA224`, `HMAC_SHA256`, `HMAC_SHA384`, or `HMAC_SHA512`.
+/// * `salt.len()` >= 16
+/// * `sercet.len()` >= 14
+/// * `iterations` >= 1000
 #[inline]
 pub fn derive(
     algorithm: Algorithm,
@@ -231,6 +238,12 @@ fn try_derive(
 /// `verify` panics if `previously_derived.len()` is larger than (2**32 - 1) * the digest
 /// algorithm's output length, per the PBKDF2 specification.
 ///
+/// # FIPS
+/// FIPS users should utilize this method when meeting the following conditions
+/// * Algorithms: `HMAC_SHA1_FOR_LEGACY_USE_ONLY`, `HMAC_SHA224`, `HMAC_SHA256`, `HMAC_SHA384`, or `HMAC_SHA512`.
+/// * `salt.len()` >= 16
+/// * `sercet.len()` >= 14
+/// * `iterations` >= 1000
 #[inline]
 pub fn verify(
     algorithm: Algorithm,

--- a/aws-lc-rs/src/rand.rs
+++ b/aws-lc-rs/src/rand.rs
@@ -30,7 +30,7 @@
 //!
 //! // Using `rand::generate`
 //! let random_array = rand::generate(&rng).unwrap();
-//! let more_rand_bytes : [u8; 64] = random_array.expose();
+//! let more_rand_bytes: [u8; 64] = random_array.expose();
 //! ```
 use aws_lc::RAND_bytes;
 use std::fmt::Debug;
@@ -45,7 +45,6 @@ pub trait SecureRandom: sealed::SecureRandom {
     ///
     /// # Errors
     /// `error::Unspecified` if unable to fill `dest`.
-    ///
     fn fill(&self, dest: &mut [u8]) -> Result<(), Unspecified>;
 }
 
@@ -77,7 +76,6 @@ impl<T: RandomlyConstructable> Random<T> {
 ///
 /// # Errors
 /// `error::Unspecified` if unable to fill buffer.
-///
 #[inline]
 pub fn generate<T: RandomlyConstructable>(
     rng: &dyn SecureRandom,
@@ -123,6 +121,9 @@ impl<T> RandomlyConstructable for T where T: sealed::RandomlyConstructable {}
 /// underlying *AWS-LC* libcrypto.
 ///
 /// A single `SystemRandom` may be shared across multiple threads safely.
+///
+/// # FIPS
+/// This implementation uses a DRBG design following FIPS implementation guidance.
 #[derive(Clone, Debug)]
 pub struct SystemRandom(());
 
@@ -153,6 +154,9 @@ impl sealed::SecureRandom for SystemRandom {
 /// Fills `dest` with random bytes.
 /// # Errors
 /// `error::Unspecified` if unable to fill `dest`.
+///
+/// # FIPS
+/// This implementation uses a DRBG design following FIPS implementation guidance.
 pub fn fill(dest: &mut [u8]) -> Result<(), error::Unspecified> {
     if 1 != indicator_check!(unsafe { RAND_bytes(dest.as_mut_ptr(), dest.len()) }) {
         return Err(Unspecified);

--- a/aws-lc-rs/src/rsa.rs
+++ b/aws-lc-rs/src/rsa.rs
@@ -230,6 +230,11 @@ impl RsaKeyPair {
     /// # Errors
     /// `error::Unspecified` on error.
     /// With "fips" feature enabled, errors if digest length is greater than `u32::MAX`.
+    ///
+    /// # FIPS
+    /// FIPS users should utilize this method when meeting the following conditions:
+    /// * RSA Key Sizes: 2048, 3072, 4096
+    /// * Digest Algorithms: SHA256, SHA384, SHA512
     pub fn sign(
         &self,
         padding_alg: &'static dyn RsaEncoding,

--- a/aws-lc-rs/src/signature.rs
+++ b/aws-lc-rs/src/signature.rs
@@ -184,9 +184,10 @@
 //! ```
 //! use aws_lc_rs::{rand, signature};
 //!
-//! fn sign_and_verify_rsa(private_key_path: &std::path::Path,
-//!                        public_key_path: &std::path::Path)
-//!                        -> Result<(), MyError> {
+//! fn sign_and_verify_rsa(
+//!     private_key_path: &std::path::Path,
+//!     public_key_path: &std::path::Path,
+//! ) -> Result<(), MyError> {
 //!     // Create an `RsaKeyPair` from the DER-encoded bytes. This example uses
 //!     // a 2048-bit key, but larger keys are also supported.
 //!     let private_key_der = read_file(private_key_path)?;
@@ -198,23 +199,26 @@
 //!     const MESSAGE: &'static [u8] = b"hello, world";
 //!     let rng = rand::SystemRandom::new();
 //!     let mut signature = vec![0; key_pair.public_modulus_len()];
-//!     key_pair.sign(&signature::RSA_PKCS1_SHA256, &rng, MESSAGE, &mut signature)
+//!     key_pair
+//!         .sign(&signature::RSA_PKCS1_SHA256, &rng, MESSAGE, &mut signature)
 //!         .map_err(|_| MyError::OOM)?;
 //!
 //!     // Verify the signature.
-//!     let public_key =
-//!         signature::UnparsedPublicKey::new(&signature::RSA_PKCS1_2048_8192_SHA256,
-//!                                       read_file(public_key_path)?);
-//!     public_key.verify(MESSAGE, &signature)
+//!     let public_key = signature::UnparsedPublicKey::new(
+//!         &signature::RSA_PKCS1_2048_8192_SHA256,
+//!         read_file(public_key_path)?,
+//!     );
+//!     public_key
+//!         .verify(MESSAGE, &signature)
 //!         .map_err(|_| MyError::BadSignature)
 //! }
 //!
 //! #[derive(Debug)]
 //! enum MyError {
-//!    IO(std::io::Error),
-//!    BadPrivateKey,
-//!    OOM,
-//!    BadSignature,
+//!     IO(std::io::Error),
+//!     BadPrivateKey,
+//!     OOM,
+//!     BadSignature,
 //! }
 //!
 //! fn read_file(path: &std::path::Path) -> Result<Vec<u8>, MyError> {
@@ -222,7 +226,8 @@
 //!
 //!     let mut file = std::fs::File::open(path).map_err(|e| MyError::IO(e))?;
 //!     let mut contents: Vec<u8> = Vec::new();
-//!     file.read_to_end(&mut contents).map_err(|e| MyError::IO(e))?;
+//!     file.read_to_end(&mut contents)
+//!         .map_err(|e| MyError::IO(e))?;
 //!     Ok(contents)
 //! }
 //!
@@ -316,6 +321,12 @@ pub trait VerificationAlgorithm: Debug + Sync + sealed::Sealed {
     ///
     /// # Errors
     /// `error::Unspecified` if inputs not verified.
+    ///
+    /// # FIPS
+    /// FIPS users should utilize this method when meeting the following conditions:
+    /// * RSA Key Sizes: 1024, 2048, 3072, 4096
+    /// * NIST Elliptic Curves: P256, P384, P521
+    /// * Digest Algorithms: SHA1, SHA256, SHA384, SHA512
     fn verify_sig(
         &self,
         public_key: &[u8],
@@ -359,7 +370,6 @@ impl<B: AsRef<[u8]>> UnparsedPublicKey<B> {
     ///
     /// # Errors
     /// `error::Unspecified` if inputs not verified.
-    ///
     #[inline]
     pub fn verify(&self, message: &[u8], signature: &[u8]) -> Result<(), error::Unspecified> {
         self.algorithm

--- a/aws-lc-rs/src/signature/tests/fips/keys.rs
+++ b/aws-lc-rs/src/signature/tests/fips/keys.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-
 // Only needed if you need to add additional test cases for signature verifications
 #[allow(dead_code)]
 pub const TEST_P256_PRIVATE_DER: [u8; 121] = [

--- a/aws-lc-rs/src/signature/tests/fips/keys.rs
+++ b/aws-lc-rs/src/signature/tests/fips/keys.rs
@@ -1,3 +1,7 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+
 // Only needed if you need to add additional test cases for signature verifications
 #[allow(dead_code)]
 pub const TEST_P256_PRIVATE_DER: [u8; 121] = [

--- a/aws-lc-rs/src/test.rs
+++ b/aws-lc-rs/src/test.rs
@@ -293,7 +293,6 @@ pub struct File<'a> {
 ///
 /// # Panics
 /// Panics on test failure.
-///
 #[allow(clippy::needless_pass_by_value)]
 pub fn run<F>(test_file: File, mut f: F)
 where


### PR DESCRIPTION
Add & Cleanup Documentation

* Fixed naming of types with `TLS` prefix to `Tls` following API guidelines. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
