### PR TITLE
Add arm32; Rust 1.72.1 for cross-compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,9 +148,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [ stable ]
+        rust: [ 1.72.1 ] # TODO: return to stable
         os: [ ubuntu-latest ]
         target:
+          - arm-unknown-linux-gnueabihf
           - aarch64-unknown-linux-gnu
           - i686-unknown-linux-gnu
           - powerpc64le-unknown-linux-gnu


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Add a Linux/arm32 target to our cross-compilation tests.
* Due to failing riscv64gc build, use Rust 1.72.1 from cross-compilation until resolved.

### Call-outs:
N/A

### Testing:
Successfully cross-compiled locally the affected platforms.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
