### PR TITLE
Remove openssl as dev-dependency

### DIFF
--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -63,8 +63,5 @@ bindgen = { version = "0.68.1" }
 libc = "0.2"
 paste = "1.0.11"
 
-[dev-dependencies]
-openssl = { version = "0.10" }
-
 [package.metadata.aws-lc-sys]
 commit-hash = "aa90e509f2e940916fbe9fdd469a4c90c51824f6"

--- a/aws-lc-sys/tests/sanity-tests.rs
+++ b/aws-lc-sys/tests/sanity-tests.rs
@@ -1,28 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-use std::mem::MaybeUninit;
-
-fn sha1_tester(input: &[u8]) -> [u8; 20] {
-    let mut hash = MaybeUninit::<[u8; 20]>::uninit();
-
-    unsafe {
-        aws_lc_sys::SHA1(input.as_ptr(), input.len(), hash.as_mut_ptr().cast());
-        hash.assume_init()
-    }
-}
-
-fn compare(result: &[u8], expected_result: &[u8]) {
-    println!("Comparing: {result:?} to {expected_result:?}");
-    assert_eq!(result, expected_result);
-}
-
 #[test]
-fn sha1() {
-    let input1 = b"hello";
-    let result1 = sha1_tester(input1);
-    let openssl_result1 = openssl::sha::sha1(input1);
-    compare(&result1, &openssl_result1);
+fn test_fips_mode() {
+    unsafe {
+        assert_eq!(aws_lc_sys::FIPS_mode(), 0);
+    }
 }
 
 #[test]


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Remove openssl from aws-lc-sys's dev-dependencies. (The `aws-lc-rs-testing` package build links to both aws-lc-sys and openssl to verify there are no symbol conflicts.)

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
