### PR TITLE
Validate EC_KEY created from public point

### DIFF
--- a/aws-lc-rs/src/ec.rs
+++ b/aws-lc-rs/src/ec.rs
@@ -6,7 +6,7 @@
 use crate::error::{KeyRejected, Unspecified};
 use core::fmt;
 
-use crate::ptr::{ConstPointer, DetachableLcPtr, LcPtr};
+use crate::ptr::{ConstPointer, DetachableLcPtr, LcPtr, Pointer};
 
 use crate::signature::{Signature, VerificationAlgorithm};
 use crate::{digest, sealed, test};
@@ -228,14 +228,16 @@ pub(crate) fn marshal_public_key(ec_key: &ConstPointer<EC_KEY>) -> Result<Public
 pub(crate) unsafe fn ec_key_from_public_point(
     ec_group: &LcPtr<EC_GROUP>,
     public_ec_point: &LcPtr<EC_POINT>,
-) -> Result<DetachableLcPtr<EC_KEY>, Unspecified> {
-    let ec_key = DetachableLcPtr::new(EC_KEY_new())?;
+) -> Result<LcPtr<EC_KEY>, Unspecified> {
+    let nid = EC_GROUP_get_curve_name(ec_group.as_const_ptr());
+    let ec_key = LcPtr::new(EC_KEY_new())?;
     if 1 != EC_KEY_set_group(*ec_key, **ec_group) {
         return Err(Unspecified);
     }
     if 1 != EC_KEY_set_public_key(*ec_key, **public_ec_point) {
         return Err(Unspecified);
     }
+    validate_ec_key(&ec_key.as_const(), nid)?;
     Ok(ec_key)
 }
 

--- a/aws-lc-rs/src/ec.rs
+++ b/aws-lc-rs/src/ec.rs
@@ -293,17 +293,19 @@ unsafe fn ec_key_from_public_private(
     ec_group: &LcPtr<EC_GROUP>,
     public_ec_point: &LcPtr<EC_POINT>,
     private_bignum: &DetachableLcPtr<BIGNUM>,
-) -> Result<LcPtr<EC_KEY>, ()> {
+) -> Result<LcPtr<EC_KEY>, KeyRejected> {
     let ec_key = LcPtr::new(EC_KEY_new())?;
     if 1 != EC_KEY_set_group(*ec_key, **ec_group) {
-        return Err(());
+        return Err(KeyRejected::unexpected_error());
     }
     if 1 != EC_KEY_set_public_key(*ec_key, **public_ec_point) {
-        return Err(());
+        return Err(KeyRejected::unexpected_error());
     }
     if 1 != EC_KEY_set_private_key(*ec_key, **private_bignum) {
-        return Err(());
+        return Err(KeyRejected::unexpected_error());
     }
+    let nid = EC_GROUP_get_curve_name(ec_group.as_const_ptr());
+    validate_ec_key(&ec_key.as_const(), nid)?;
     Ok(ec_key)
 }
 

--- a/aws-lc-rs/src/ec/key_pair.rs
+++ b/aws-lc-rs/src/ec/key_pair.rs
@@ -157,7 +157,6 @@ impl EcdsaKeyPair {
                 .map_err(|_| KeyRejected::invalid_encoding())?;
             let private_bn = DetachableLcPtr::try_from(private_key)?;
             let ec_key = ec::ec_key_from_public_private(&ec_group, &public_ec_point, &private_bn)?;
-            validate_ec_key(&ec_key.as_const(), alg.id.nid())?;
             let key_pair = Self::new(alg, ec_key)?;
             Ok(key_pair)
         }


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Validate a public EC key at time of creation.
* Construct `LcPtr` instead of `DetachableLcPtr`.

### Call-outs:
N/A

### Testing:
Tests pass locally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
