### PR TITLE
Fix Quickstart build instructions for AL2023 #253

### DIFF
--- a/aws-lc-rs/README.md
+++ b/aws-lc-rs/README.md
@@ -98,7 +98,7 @@ a few more packages may be needed. The listing below shows the steps needed for 
 building and testing our project locally.
 ```shell
 # Install dependencies needed for build and testing
-sudo yum install -y cmake3 clang git clang-libs golang openssl-devel
+sudo yum install -y cmake3 clang git clang-libs golang openssl-devel perl-CPAN perl-FindBin
 
 # Install Rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh

--- a/aws-lc-rs/README.md
+++ b/aws-lc-rs/README.md
@@ -98,7 +98,7 @@ a few more packages may be needed. The listing below shows the steps needed for 
 building and testing our project locally.
 ```shell
 # Install dependencies needed for build and testing
-sudo yum install -y cmake3 clang git clang-libs golang openssl-devel perl-CPAN perl-FindBin
+sudo yum install -y cmake3 clang git clang-libs golang openssl-devel perl-FindBin
 
 # Install Rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh


### PR DESCRIPTION
### Issues:
Addresses #ISSUE-253

### Description of changes: 
Changes only to README.md

### Call-outs:
None

### Testing:
I launched a new EC2 AL2023 and managed to `cargo test` with these changes, without which it would fail as explained at issue #253.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
