### PR TITLE
KEM: Cleanup Types and Documentation

### DIFF
--- a/aws-lc-rs-testing/benches/kem_benchmark.rs
+++ b/aws-lc-rs-testing/benches/kem_benchmark.rs
@@ -46,9 +46,9 @@ mod aws_lc_rs_benchmarks {
     use aws_lc_rs::kem;
 
     use crate::{Algorithm, KemConfig};
-    use kem::{KemAlgorithm, KemPrivateKey, KemPublicKey, KYBER1024_R3, KYBER512_R3, KYBER768_R3};
+    use kem::{PrivateKey, PublicKey, KYBER1024_R3, KYBER512_R3, KYBER768_R3};
 
-    fn algorithm(config: &KemConfig) -> &'static KemAlgorithm {
+    fn algorithm(config: &KemConfig) -> &'static kem::Algorithm {
         match config.algorithm {
             Algorithm::KYBER512_R3 => &KYBER512_R3,
             Algorithm::KYBER768_R3 => &KYBER768_R3,
@@ -56,26 +56,26 @@ mod aws_lc_rs_benchmarks {
         }
     }
 
-    pub fn new_private_key(config: &KemConfig) -> KemPrivateKey {
-        KemPrivateKey::new(algorithm(config), &config.secret_key).unwrap()
+    pub fn new_private_key(config: &KemConfig) -> PrivateKey {
+        PrivateKey::new(algorithm(config), &config.secret_key).unwrap()
     }
 
-    pub fn new_public_key(config: &KemConfig) -> KemPublicKey {
-        KemPublicKey::new(algorithm(config), &config.public_key).unwrap()
+    pub fn new_public_key(config: &KemConfig) -> PublicKey {
+        PublicKey::new(algorithm(config), &config.public_key).unwrap()
     }
 
     pub fn keygen(config: &KemConfig) {
-        let private_key = KemPrivateKey::generate(algorithm(config)).unwrap();
+        let private_key = PrivateKey::generate(algorithm(config)).unwrap();
         let _public_key = private_key.compute_public_key().unwrap();
     }
 
-    pub fn encapsulate(public_key: &KemPublicKey) {
+    pub fn encapsulate(public_key: &PublicKey) {
         public_key
             .encapsulate((), |ct, ss| Ok((Vec::from(ct), Vec::from(ss))))
             .unwrap();
     }
 
-    pub fn decapsulate(config: &KemConfig, secret_key: &KemPrivateKey) {
+    pub fn decapsulate(config: &KemConfig, secret_key: &PrivateKey) {
         let mut ciphertext = config.ciphertext.clone();
         secret_key
             .decapsulate(&mut ciphertext, (), |ss| Ok(Vec::from(ss)))

--- a/aws-lc-rs/tests/kem_tests.rs
+++ b/aws-lc-rs/tests/kem_tests.rs
@@ -3,13 +3,13 @@
 
 use aws_lc_rs::{
     error::Unspecified,
-    kem::{KemPrivateKey, KemPublicKey, KYBER1024_R3, KYBER512_R3, KYBER768_R3},
+    kem::{PrivateKey, PublicKey, KYBER1024_R3, KYBER512_R3, KYBER768_R3},
 };
 
 #[test]
 fn test_kem_e2e() {
     for algorithm in [&KYBER512_R3, &KYBER768_R3, &KYBER1024_R3] {
-        let priv_key = KemPrivateKey::generate(algorithm).unwrap();
+        let priv_key = PrivateKey::generate(algorithm).unwrap();
         assert_eq!(priv_key.algorithm(), algorithm);
 
         let pub_key = priv_key.compute_public_key().unwrap();
@@ -38,7 +38,7 @@ fn test_kem_e2e() {
 #[test]
 fn test_serialized_kem_e2e() {
     for algorithm in [&KYBER512_R3, &KYBER768_R3, &KYBER1024_R3] {
-        let priv_key = KemPrivateKey::generate(algorithm).unwrap();
+        let priv_key = PrivateKey::generate(algorithm).unwrap();
         assert_eq!(priv_key.algorithm(), algorithm);
 
         // Generate private key bytes to possibly save for later
@@ -52,7 +52,7 @@ fn test_serialized_kem_e2e() {
         let mut ciphertext: Vec<u8> = vec![];
         let mut bob_shared_secret: Vec<u8> = vec![];
 
-        let retrieved_pub_key = KemPublicKey::new(algorithm, pub_key_bytes).unwrap();
+        let retrieved_pub_key = PublicKey::new(algorithm, pub_key_bytes).unwrap();
         let bob_result = retrieved_pub_key.encapsulate(Unspecified, |ct, ss| {
             ciphertext.extend_from_slice(ct);
             bob_shared_secret.extend_from_slice(ss);
@@ -63,7 +63,7 @@ fn test_serialized_kem_e2e() {
         let mut alice_shared_secret: Vec<u8> = vec![];
 
         // Retrieve private key from stored raw bytes
-        let retrieved_priv_key = KemPrivateKey::new(algorithm, privkey_raw_bytes).unwrap();
+        let retrieved_priv_key = PrivateKey::new(algorithm, privkey_raw_bytes).unwrap();
 
         let alice_result = retrieved_priv_key.decapsulate(&mut ciphertext, Unspecified, |ss| {
             alice_shared_secret.extend_from_slice(ss);


### PR DESCRIPTION
Took a pass at cleaning up the types to remove the module stutter (and to be consistent with other project modules), reduced the scope of `unsafe` blocks, took a pass at the documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
