### PR TITLE
fix: improve ring compat for digest::Algorithm

### DIFF
--- a/aws-lc-rs/src/digest.rs
+++ b/aws-lc-rs/src/digest.rs
@@ -268,6 +268,35 @@ pub struct Algorithm {
 
 unsafe impl Send for Algorithm {}
 
+impl Algorithm {
+    /// The length of a finalized digest.
+    #[inline]
+    pub fn output_len(&self) -> usize {
+        self.output_len
+    }
+
+    /// The size of the chaining value of the digest function, in bytes. For
+    /// non-truncated algorithms (SHA-1, SHA-256, SHA-512), this is equal to
+    /// `output_len`. For truncated algorithms (e.g. SHA-224, SHA-384, SHA-512/256),
+    /// this is equal to the length before truncation. This is mostly helpful
+    /// for determining the size of an HMAC key that is appropriate for the
+    /// digest algorithm.
+    ///
+    /// This function isn't actually used in *aws-lc-rs*, and is only
+    /// kept for compatibility with the original *ring* implementation.
+    #[deprecated]
+    #[inline]
+    pub fn chaining_len(&self) -> usize {
+        self.chaining_len
+    }
+
+    /// The internal block length.
+    #[inline]
+    pub fn block_len(&self) -> usize {
+        self.block_len
+    }
+}
+
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum AlgorithmID {
     SHA1,

--- a/aws-lc-rs/src/digest.rs
+++ b/aws-lc-rs/src/digest.rs
@@ -271,6 +271,7 @@ unsafe impl Send for Algorithm {}
 impl Algorithm {
     /// The length of a finalized digest.
     #[inline]
+    #[must_use]
     pub fn output_len(&self) -> usize {
         self.output_len
     }
@@ -286,12 +287,16 @@ impl Algorithm {
     /// kept for compatibility with the original *ring* implementation.
     #[deprecated]
     #[inline]
+    #[must_use]
     pub fn chaining_len(&self) -> usize {
+        // clippy warns on deprecated functions accessing deprecated fields
+        #![allow(deprecated)]
         self.chaining_len
     }
 
     /// The internal block length.
     #[inline]
+    #[must_use]
     pub fn block_len(&self) -> usize {
         self.block_len
     }


### PR DESCRIPTION
### Description of changes: 

In 0.17, ring made the `digest::Algorithm` fields private and changed them to getter functions:

https://github.com/briansmith/ring/commit/a26925cd1efd323a3ff6f8daf13a197caa3c179e

This change keeps the fields public (to avoid breaking changes) and also includes the functions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
