### PR TITLE
Add support for signature verification using public key in X509 DER encoding format.

### DIFF
--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -53,3 +53,4 @@ regex = "1.6.0"
 lazy_static = "1.4.0"
 clap = { version = "4.1.8", features = ["derive"] }
 hex = "0.4.3"
+base64 = "0"

--- a/aws-lc-rs/src/lib.rs
+++ b/aws-lc-rs/src/lib.rs
@@ -121,6 +121,7 @@ pub mod io;
 pub mod key_wrap;
 pub mod pbkdf2;
 pub mod pkcs8;
+pub(crate) mod public_key;
 pub mod rand;
 pub mod signature;
 pub mod test;

--- a/aws-lc-rs/src/ptr.rs
+++ b/aws-lc-rs/src/ptr.rs
@@ -4,9 +4,9 @@
 use std::ops::Deref;
 
 use aws_lc::{
-    BN_free, ECDSA_SIG_free, EC_GROUP_free, EC_KEY_free, EC_POINT_free, EVP_AEAD_CTX_free,
-    EVP_PKEY_CTX_free, EVP_PKEY_free, OPENSSL_free, RSA_free, BIGNUM, ECDSA_SIG, EC_GROUP, EC_KEY,
-    EC_POINT, EVP_AEAD_CTX, EVP_PKEY, EVP_PKEY_CTX, RSA,
+    BIO_free, BN_free, ECDSA_SIG_free, EC_GROUP_free, EC_KEY_free, EC_POINT_free,
+    EVP_AEAD_CTX_free, EVP_PKEY_CTX_free, EVP_PKEY_free, OPENSSL_free, RSA_free, BIGNUM, BIO,
+    ECDSA_SIG, EC_GROUP, EC_KEY, EC_POINT, EVP_AEAD_CTX, EVP_PKEY, EVP_PKEY_CTX, RSA,
 };
 
 use mirai_annotations::verify_unreachable;
@@ -201,6 +201,7 @@ macro_rules! create_pointer {
 // freed. This is different than functions of the same name in OpenSSL which generally do not zero
 // memory.
 create_pointer!(u8, OPENSSL_free);
+create_pointer!(BIO, BIO_free);
 create_pointer!(EC_GROUP, EC_GROUP_free);
 create_pointer!(EC_POINT, EC_POINT_free);
 create_pointer!(EC_KEY, EC_KEY_free);

--- a/aws-lc-rs/src/public_key.rs
+++ b/aws-lc-rs/src/public_key.rs
@@ -1,0 +1,90 @@
+// Copyright 2015-2016 Hanson Char.
+// SPDX-License-Identifier: ISC
+// Modifications copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+//! Public key common construts, such as the encoding used in an `UnparsedPublicKey`.
+
+use std::ptr::null_mut;
+
+use aws_lc::{d2i_PUBKEY_bio, BIO_new, BIO_s_mem, BIO_write, EVP_PKEY};
+
+use crate::{error::Unspecified, ptr::LcPtr};
+
+/// Encoding ID.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum EncodingID {
+    /// A sequence of 8-bit bytes
+    OctetString,
+    /// X509 DER encoding
+    X509,
+}
+
+/// Encoding of bytes
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct Encoding {
+    /// Encoding ID
+    pub(crate) id: EncodingID,
+}
+
+/// Octet String encoding
+pub(crate) static OCTET_STRING: Encoding = Encoding {
+    id: EncodingID::OctetString,
+};
+
+/// X509 DER encoding
+pub(crate) static X509: Encoding = Encoding {
+    id: EncodingID::X509,
+};
+
+#[inline]
+pub(crate) fn evp_pkey_from_x509_pubkey(
+    pubkey_data: &[u8],
+) -> Result<LcPtr<EVP_PKEY>, Unspecified> {
+    // Create a memory BIO and write the public key data to it
+    let mem_bio = LcPtr::new(unsafe { BIO_new(BIO_s_mem()) })?;
+    let len = match std::os::raw::c_int::try_from(pubkey_data.len()) {
+        Ok(len) => len,
+        Err(_) => return Err(Unspecified),
+    };
+    if unsafe {
+        BIO_write(
+            *mem_bio,
+            pubkey_data.as_ptr().cast::<std::os::raw::c_void>(),
+            len,
+        )
+    } <= 0
+    {
+        return Err(Unspecified);
+    }
+    // Use d2i_PUBKEY_bio to read the public key from the memory BIO
+    Ok(LcPtr::new(unsafe { d2i_PUBKEY_bio(*mem_bio, null_mut()) })?)
+}
+
+#[cfg(test)]
+mod tests {
+    use base64::engine::general_purpose;
+    use base64::Engine;
+
+    use crate::public_key::evp_pkey_from_x509_pubkey;
+
+    #[test]
+    fn test_evp_pkey_from_x509_pubkey() {
+        // Generated using "SHA384withRSA" from BC-FIPS
+        let b64_x509_pubkey = concat!(
+            "MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA28pm7EDzXRvFmgK2/UNriVNWF4slKNDKtY",
+            "q6hEZsJstfVU/J7zOAJKjUjR/abgnLYAd6I8M9aiYNaAh/GfnIfOXhymjSqfiimCu14dJsQQLP/Thd",
+            "yR6jSKvQCkyWPWpo1S5H7qkmPpjxU6CeyYAkaNc+B1TnAblyLQ90wwY5OmAzQD0A6k1UX6NoHB/W5P",
+            "G731y16QTv34xVycXYFfp+pSyKHm5Q7YXPQLKrWPTIFoOvVHi94s+c7nqmYxfXhtzBf9WSr9so6Dgz",
+            "vlsFK4FhyOq4zKN7XQkOwAVyZ5X//bMwfzVmm7TJTvfGyMNU0YaCPLgRSWn2bDeiY9hbfERurAkBIN",
+            "/piGXl/12xv8tZGa5lAQe4fcj+O1Uc9b9tDbuba9HiYxS1OAfeAO25kqBa24qqvEMxTgDf0G6AnCzj",
+            "dQFsP4pVfRBmMVjo6Zikq+TStr0+UID2u21N3MrcLue7BzbujU/9buFtSES5QWYUdQoYb3pzYEgojJ",
+            "HriYBA1yiJAgMBAAE="
+        );
+        let x509_pubkey = general_purpose::STANDARD
+            .decode(b64_x509_pubkey)
+            .expect("Invalid base64 encoding");
+        evp_pkey_from_x509_pubkey(x509_pubkey.as_slice())
+            .expect("Failed evp_pkey_from_x509_pubkey");
+    }
+}

--- a/aws-lc-rs/src/public_key.rs
+++ b/aws-lc-rs/src/public_key.rs
@@ -22,7 +22,7 @@ pub(crate) enum EncodingID {
 
 /// Encoding of bytes
 #[derive(Debug, PartialEq, Eq)]
-pub(crate) struct Encoding {
+pub struct Encoding {
     /// Encoding ID
     pub(crate) id: EncodingID,
 }

--- a/aws-lc-rs/src/rsa/signature.rs
+++ b/aws-lc-rs/src/rsa/signature.rs
@@ -20,6 +20,7 @@ use crate::{
     error::Unspecified,
     fips::indicator_check,
     ptr::{ConstPointer, DetachableLcPtr, LcPtr},
+    public_key::evp_pkey_from_x509_pubkey,
     sealed::Sealed,
     signature::VerificationAlgorithm,
 };
@@ -92,6 +93,23 @@ impl VerificationAlgorithm for RsaParameters {
                 self.bit_size_range(),
             )
         }
+    }
+
+    fn verify_sig_with_x509_pubkey(
+        &self,
+        public_key: &[u8],
+        msg: &[u8],
+        signature: &[u8],
+    ) -> Result<(), Unspecified> {
+        let rsa = evp_pkey_from_x509_pubkey(public_key)?;
+        verify_RSA(
+            self.digest_algorithm(),
+            self.padding(),
+            &rsa,
+            msg,
+            signature,
+            self.bit_size_range(),
+        )
     }
 }
 


### PR DESCRIPTION
### Issues:
Addresses #274

### Description of changes: 

Currently signature can only be verified with public key provided in Octet String format.  This PR would additionally allow signature to be verified with public key provided in X509 DER encoding format.

### Call-outs:

This PR is built on top of https://github.com/aws/aws-lc-rs/pull/259

### Testing:
```
cargo test
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
