### PR TITLE
Expose `TlsRecordOpeningKey::open_within`

### DIFF
--- a/aws-lc-rs/src/aead/tls.rs
+++ b/aws-lc-rs/src/aead/tls.rs
@@ -231,10 +231,7 @@ impl TlsRecordOpeningKey {
         })
     }
 
-    /// Accepts a Noce and Aad construction that is unique for this TLS record
-    /// opening operation.
-    ///
-    /// `nonce` must be unique for every use of the key to open data.
+    /// See [`super::OpeningKey::open_in_place()`] for details.
     ///
     /// # Errors
     /// `error::Unspecified` when ciphertext is invalid.


### PR DESCRIPTION
### Description of changes: 
This exposes `TlsRecordOpeningKey::open_within`, which avoids an extra copy in the main datapath in rustls. Ref: https://github.com/rustls/rustls/pull/1586/commits/9adee7d1f74e75860a3b996ed35f025386beb3e4#diff-04a8526fabaeaad059457dda56b5b75f77d7a33f0a02c12b14e855db60ee5ebaR270-R272

I have also adjusted the commentary on `TlsRecordOpeningKey::open_in_place`.

### Call-outs:
Unsure if https://github.com/aws/aws-lc-rs/pull/244#issuecomment-1812604894 is contentious.

### Testing:
Added to the existing tests to basically exercise `open_within`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
