### PR TITLE
fix(aws-lc-sys): add `links` attribute to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ members = [
     "aws-lc-rs",
     "aws-lc-sys",
     "aws-lc-fips-sys",
-    "aws-lc-rs-testing"
+    "aws-lc-rs-testing",
+    "aws-lc-sys-testing",
 ]
 resolver = "2"
 

--- a/aws-lc-sys-testing/Cargo.toml
+++ b/aws-lc-sys-testing/Cargo.toml
@@ -9,3 +9,6 @@ aws-lc-sys = { path = "../aws-lc-sys" }
 
 [build-dependencies]
 cc = "1"
+
+[package.metadata.cargo-udeps.ignore]
+normal = [ "aws-lc-sys" ] # the sys crate is only used through a C library build

--- a/aws-lc-sys-testing/Cargo.toml
+++ b/aws-lc-sys-testing/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "aws-lc-sys-testing"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+aws-lc-sys = { path = "../aws-lc-sys" }
+
+[build-dependencies]
+cc = "1"

--- a/aws-lc-sys-testing/Cargo.toml
+++ b/aws-lc-sys-testing/Cargo.toml
@@ -9,6 +9,7 @@ aws-lc-sys = { path = "../aws-lc-sys" }
 
 [build-dependencies]
 cc = "1"
+toml_edit = "0.21"
 
 [package.metadata.cargo-udeps.ignore]
 normal = [ "aws-lc-sys" ] # the sys crate is only used through a C library build

--- a/aws-lc-sys-testing/build.rs
+++ b/aws-lc-sys-testing/build.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
 fn main() {
     // ensure that the include path is exported and set up correctly
     cc::Build::new()

--- a/aws-lc-sys-testing/build.rs
+++ b/aws-lc-sys-testing/build.rs
@@ -1,0 +1,16 @@
+fn main() {
+    // ensure that the include path is exported and set up correctly
+    cc::Build::new()
+        .include(env("DEP_AWS_LC_0_12_0_INCLUDE"))
+        .file("src/testing.c")
+        .compile("aws_ls_sys_testing");
+
+    // ensure the libcrypto artifact is linked
+    println!("cargo:rustc-link-lib=aws_lc_0_12_0_crypto");
+}
+
+fn env<S: AsRef<str>>(s: S) -> String {
+    let s = s.as_ref();
+    println!("cargo:rerun-if-env-changed={s}");
+    std::env::var(s).unwrap_or_else(|_| panic!("missing env var {s}"))
+}

--- a/aws-lc-sys-testing/build.rs
+++ b/aws-lc-sys-testing/build.rs
@@ -1,15 +1,22 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
+use toml_edit::Document;
+
 fn main() {
+    let cargo_toml = std::fs::read_to_string("../aws-lc-sys/Cargo.toml").unwrap();
+    let cargo_toml = cargo_toml.parse::<Document>().unwrap();
+
+    let links = cargo_toml["package"]["links"].as_str().unwrap();
+
     // ensure that the include path is exported and set up correctly
     cc::Build::new()
-        .include(env("DEP_AWS_LC_0_12_0_INCLUDE"))
+        .include(env(format!("DEP_{}_INCLUDE", links.to_uppercase())))
         .file("src/testing.c")
         .compile("aws_ls_sys_testing");
 
     // ensure the libcrypto artifact is linked
-    println!("cargo:rustc-link-lib=aws_lc_0_12_0_crypto");
+    println!("cargo:rustc-link-lib={}_crypto", links);
 }
 
 fn env<S: AsRef<str>>(s: S) -> String {

--- a/aws-lc-sys-testing/src/main.rs
+++ b/aws-lc-sys-testing/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
 use std::ffi::c_int;
 
 extern "C" {

--- a/aws-lc-sys-testing/src/main.rs
+++ b/aws-lc-sys-testing/src/main.rs
@@ -1,0 +1,15 @@
+use std::ffi::c_int;
+
+extern "C" {
+    fn testing_evp_key_type(nid: c_int) -> c_int;
+}
+
+fn main() {
+    let v = unsafe { testing_evp_key_type(123) };
+    println!("Hello EVP {v}!");
+}
+
+#[test]
+fn link_test() {
+    let _ = unsafe { testing_evp_key_type(123) };
+}

--- a/aws-lc-sys-testing/src/testing.c
+++ b/aws-lc-sys-testing/src/testing.c
@@ -1,0 +1,7 @@
+#include <openssl/is_awslc.h>
+#include <openssl/evp.h>
+
+int testing_evp_key_type(int nid)
+{
+    return EVP_PKEY_type(nid);
+}

--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aws-lc-sys"
 description = "AWS-LC is a general-purpose cryptographic library maintained by the AWS Cryptography team for AWS and their customers. It іs based on code from the Google BoringSSL project and the OpenSSL project."
 version = "0.12.0"
+links = "aws_lc_0_12_0"
 authors = ["AWS-LC"]
 edition = "2021"
 repository = "https://github.com/aws/aws-lc-rs"
@@ -51,6 +52,7 @@ bindgen = ["dep:bindgen"] # Generate the bindings on the targetted platform as a
 [build-dependencies]
 cmake = "0.1.48"
 dunce = "1.0"
+fs_extra = "1"
 
 [target.'cfg(any(all(target_os = "macos", target_arch = "x86_64"), all(target_os = "linux", target_arch = "x86"), all(target_os = "linux", target_arch = "x86_64"), all(target_os = "linux", target_arch = "aarch64")))'.build-dependencies]
 bindgen = { version = "0.69.1", optional = true }

--- a/aws-lc-sys/builder/main.rs
+++ b/aws-lc-sys/builder/main.rs
@@ -84,17 +84,16 @@ impl OutputLibType {
 
 impl OutputLib {
     fn libname(self, prefix: Option<&str>) -> String {
-        format!(
-            "{}{}",
-            if let Some(pfix) = prefix { pfix } else { "" },
-            match self {
-                OutputLib::Crypto => "crypto",
-                OutputLib::Ssl => "ssl",
-                OutputLib::RustWrapper => {
-                    "rust_wrapper"
-                }
-            }
-        )
+        let name = match self {
+            OutputLib::Crypto => "crypto",
+            OutputLib::Ssl => "ssl",
+            OutputLib::RustWrapper => "rust_wrapper",
+        };
+        if let Some(prefix) = prefix {
+            format!("{prefix}_{name}")
+        } else {
+            name.to_string()
+        }
     }
 }
 
@@ -200,7 +199,7 @@ fn prepare_cmake_build(manifest_dir: &PathBuf, build_prefix: String) -> cmake::C
 }
 
 fn build_rust_wrapper(manifest_dir: &PathBuf) -> PathBuf {
-    prepare_cmake_build(manifest_dir, prefix_string())
+    prepare_cmake_build(manifest_dir, prefix_string() + "_")
         .configure_arg("--no-warn-unused-cli")
         .build()
 }
@@ -374,18 +373,10 @@ fn main() {
         RustWrapper.libname(Some(&prefix))
     );
 
-    for include_path in [
-        get_rust_include_path(&manifest_dir),
-        get_generated_include_path(&manifest_dir),
-        get_aws_lc_include_path(&manifest_dir),
-    ] {
-        println!("cargo:include={}", include_path.display());
-    }
-    if let Some(include_paths) = get_aws_lc_sys_includes_path() {
-        for path in include_paths {
-            println!("cargo:include={}", path.display());
-        }
-    }
+    println!(
+        "cargo:include={}",
+        setup_include_paths(&out_dir, &manifest_dir).display()
+    );
 
     println!("cargo:rerun-if-changed=builder/");
     println!("cargo:rerun-if-changed=aws-lc/");
@@ -406,4 +397,40 @@ fn check_dependencies() {
         !missing_dependency,
         "Required build dependency is missing. Halting build."
     );
+}
+
+fn setup_include_paths(out_dir: &Path, manifest_dir: &Path) -> PathBuf {
+    let mut include_paths = vec![
+        get_rust_include_path(manifest_dir),
+        get_generated_include_path(manifest_dir),
+        get_aws_lc_include_path(manifest_dir),
+    ];
+
+    if let Some(extra_paths) = get_aws_lc_sys_includes_path() {
+        include_paths.extend(extra_paths);
+    }
+
+    let include_dir = out_dir.join("include");
+    std::fs::create_dir_all(&include_dir).unwrap();
+
+    // iterate over all of the include paths and copy them into the final output
+    for path in include_paths {
+        for child in std::fs::read_dir(path).into_iter().flatten().flatten() {
+            if child.file_type().map_or(false, |t| t.is_file()) {
+                let _ = std::fs::copy(
+                    child.path(),
+                    include_dir.join(child.path().file_name().unwrap()),
+                );
+                continue;
+            }
+
+            // prefer the earliest paths
+            let options = fs_extra::dir::CopyOptions::new()
+                .skip_exist(true)
+                .copy_inside(true);
+            let _ = fs_extra::dir::copy(child.path(), &include_dir, &options);
+        }
+    }
+
+    include_dir
 }


### PR DESCRIPTION
### Description of changes: 

The `aws-lc-sys` crate does not currently set the `links` attribute in the Cargo.toml. This prevents other crates from reading the `include` path and using it in other C libraries.

This change adds the `links` attribute and adds an integration test to ensure this functionality is preserved.

### Call-outs:

I did not refactor the `aws-lc-fips-sys` crate. There's quite a bit of copy/paste between the build scripts and could probably use a refactor.

### Testing:

I've added an integration test crate (`aws-lc-sys-testing`) showing that the change is now working and will be preserved in the future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
