### PR TITLE
Consider target env for pregenerated bindings

### DIFF
--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -62,10 +62,10 @@ cmake = "0.1.48"
 dunce = "1.0"
 fs_extra = "1.3"
 
-[target.'cfg(any(all(target_os = "linux", target_arch = "x86_64"), all(target_os = "linux", target_arch = "aarch64")))'.build-dependencies]
+[target.'cfg(any(all(target_os = "linux", target_arch = "x86_64", target_env="gnu"), all(target_os = "linux", target_arch = "aarch64", target_env="gnu")))'.build-dependencies]
 bindgen = { version = "0.69.1", optional = true }
 
-[target.'cfg(not(any(all(target_os = "linux", target_arch = "x86_64"), all(target_os = "linux", target_arch = "aarch64"))))'.build-dependencies]
+[target.'cfg(not(any(all(target_os = "linux", target_arch = "x86_64", target_env="gnu"), all(target_os = "linux", target_arch = "aarch64", target_env="gnu"))))'.build-dependencies]
 bindgen = { version = "0.69.1" }
 
 [dependencies]

--- a/aws-lc-fips-sys/builder/main.rs
+++ b/aws-lc-fips-sys/builder/main.rs
@@ -261,6 +261,10 @@ fn target_arch() -> String {
     env::var("CARGO_CFG_TARGET_ARCH").unwrap()
 }
 
+fn target_env() -> String {
+    env::var("CARGO_CFG_TARGET_ENV").unwrap()
+}
+
 #[allow(unused)]
 fn target_vendor() -> String {
     env::var("CARGO_CFG_TARGET_VENDOR").unwrap()
@@ -272,9 +276,9 @@ fn target() -> String {
 }
 
 macro_rules! cfg_bindgen_platform {
-    ($binding:ident, $os:literal, $arch:literal, $additional:expr) => {
+    ($binding:ident, $os:literal, $arch:literal, $env:literal, $additional:expr) => {
         let $binding = {
-            (target_os() == $os && target_arch() == $arch && $additional)
+            (target_os() == $os && target_arch() == $arch && target_env() == $env && $additional)
                 .then(|| {
                     emit_rustc_cfg(concat!($os, "_", $arch));
                     true
@@ -297,8 +301,8 @@ fn main() {
 
     let pregenerated = !is_bindgen_required || is_internal_generate;
 
-    cfg_bindgen_platform!(linux_x86_64, "linux", "x86_64", pregenerated);
-    cfg_bindgen_platform!(linux_aarch64, "linux", "aarch64", pregenerated);
+    cfg_bindgen_platform!(linux_x86_64, "linux", "x86_64", "gnu", pregenerated);
+    cfg_bindgen_platform!(linux_aarch64, "linux", "aarch64", "gnu", pregenerated);
 
     if !(linux_x86_64 || linux_aarch64) {
         emit_rustc_cfg("use_bindgen_generated");

--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -54,10 +54,10 @@ cmake = "0.1.48"
 dunce = "1.0"
 fs_extra = "1.3"
 
-[target.'cfg(any(all(target_os = "macos", target_arch = "x86_64"), all(target_os = "linux", target_arch = "x86"), all(target_os = "linux", target_arch = "x86_64"), all(target_os = "linux", target_arch = "aarch64")))'.build-dependencies]
+[target.'cfg(any(all(target_os = "macos", target_arch = "x86_64"), all(target_os = "linux", target_arch = "x86", target_env="gnu"), all(target_os = "linux", target_arch = "x86_64", target_env="gnu"), all(target_os = "linux", target_arch = "aarch64", target_env="gnu")))'.build-dependencies]
 bindgen = { version = "0.69.1", optional = true }
 
-[target.'cfg(not(any(all(target_os = "macos", target_arch = "x86_64"), all(target_os = "linux", target_arch = "x86"), all(target_os = "linux", target_arch = "x86_64"), all(target_os = "linux", target_arch = "aarch64"))))'.build-dependencies]
+[target.'cfg(not(any(all(target_os = "macos", target_arch = "x86_64"), all(target_os = "linux", target_arch = "x86", target_env="gnu"), all(target_os = "linux", target_arch = "x86_64", target_env="gnu"), all(target_os = "linux", target_arch = "aarch64", target_env="gnu"))))'.build-dependencies]
 bindgen = { version = "0.68.1" }
 
 

--- a/aws-lc-sys/builder/main.rs
+++ b/aws-lc-sys/builder/main.rs
@@ -264,6 +264,10 @@ fn target_arch() -> String {
     env::var("CARGO_CFG_TARGET_ARCH").unwrap()
 }
 
+fn target_env() -> String {
+    env::var("CARGO_CFG_TARGET_ENV").unwrap()
+}
+
 fn target_vendor() -> String {
     env::var("CARGO_CFG_TARGET_VENDOR").unwrap()
 }
@@ -273,9 +277,9 @@ fn target() -> String {
 }
 
 macro_rules! cfg_bindgen_platform {
-    ($binding:ident, $os:literal, $arch:literal, $additional:expr) => {
+    ($binding:ident, $os:literal, $arch:literal, $env:literal, $additional:expr) => {
         let $binding = {
-            (target_os() == $os && target_arch() == $arch && $additional)
+            (target_os() == $os && target_arch() == $arch && target_env() == $env && $additional)
                 .then(|| {
                     emit_rustc_cfg(concat!($os, "_", $arch));
                     true
@@ -297,10 +301,10 @@ fn main() {
 
     let pregenerated = !is_bindgen_required || is_internal_generate;
 
-    cfg_bindgen_platform!(linux_x86, "linux", "x86", pregenerated);
-    cfg_bindgen_platform!(linux_x86_64, "linux", "x86_64", pregenerated);
-    cfg_bindgen_platform!(linux_aarch64, "linux", "aarch64", pregenerated);
-    cfg_bindgen_platform!(macos_x86_64, "macos", "x86_64", pregenerated);
+    cfg_bindgen_platform!(linux_x86, "linux", "x86", "gnu", pregenerated);
+    cfg_bindgen_platform!(linux_x86_64, "linux", "x86_64", "gnu", pregenerated);
+    cfg_bindgen_platform!(linux_aarch64, "linux", "aarch64", "gnu", pregenerated);
+    cfg_bindgen_platform!(macos_x86_64, "macos", "x86_64", "", pregenerated);
 
     if !(linux_x86 || linux_x86_64 || linux_aarch64 || macos_x86_64) {
         emit_rustc_cfg("use_bindgen_generated");


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Pregenerated bindings for Linux were generated using glibc.  Need to generate/test bindings for other environments (like musl).

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
