### PR TITLE
Filter out edwards25519 symbls which are not supposed to have external linkage

### DIFF
--- a/scripts/generate/_collect_symbols_build.sh
+++ b/scripts/generate/_collect_symbols_build.sh
@@ -21,9 +21,9 @@ function cmake_build_options() {
 
 function filter_symbols() {
   if [[ "${GENERATE_FIPS}" -eq 0 ]]; then
-    grep -v "^_\?bignum_" | grep -v "_\?curve25519_x25519" | grep -v "pqcrystals"
+    grep -v "^_\?bignum_" | grep -v "_\?curve25519_x25519" | grep -v "_\?edwards25519_" | grep -v "pqcrystals"
   else
-    grep -v "^_\?bignum_" | grep -v "_\?curve25519_x25519" | grep -v "pqcrystals" | grep -v "OPENSSL_armcap_P"
+    grep -v "^_\?bignum_" | grep -v "_\?curve25519_x25519" | grep -v "_\?edwards25519_" | grep -v "pqcrystals" | grep -v "OPENSSL_armcap_P"
   fi
 }
 


### PR DESCRIPTION
### Description of changes: 

https://github.com/aws/aws-lc/pull/1309 wires up a new Ed25519 backend adding a new set of symbols with a prefix not captured by the current filter script. Add a rule that captures these symbols and filters them out, since they don't have external linkage.

See problematic linkage here: https://github.com/aws/aws-lc/actions/runs/6921644361/job/18827482208?pr=1309

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
