### PR TITLE
Specify minimum required fs_extra as 1.3

### DIFF
--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -60,7 +60,7 @@ ssl = []
 [build-dependencies]
 cmake = "0.1.48"
 dunce = "1.0"
-fs_extra = "1"
+fs_extra = "1.3"
 
 [target.'cfg(any(all(target_os = "linux", target_arch = "x86_64"), all(target_os = "linux", target_arch = "aarch64")))'.build-dependencies]
 bindgen = { version = "0.69.1", optional = true }

--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -52,7 +52,7 @@ bindgen = ["dep:bindgen"] # Generate the bindings on the targetted platform as a
 [build-dependencies]
 cmake = "0.1.48"
 dunce = "1.0"
-fs_extra = "1"
+fs_extra = "1.3"
 
 [target.'cfg(any(all(target_os = "macos", target_arch = "x86_64"), all(target_os = "linux", target_arch = "x86"), all(target_os = "linux", target_arch = "x86_64"), all(target_os = "linux", target_arch = "aarch64")))'.build-dependencies]
 bindgen = { version = "0.69.1", optional = true }


### PR DESCRIPTION
We are using `CopyOptions::skip_exist()` introduced in 1.3.

### Description of changes: 
This fixes the build for any downstream crates that test that the minimum versions in their Cargo.toml cover the APIs that they rely on (using `cargo update -Z minimal-versions`).

Note that rustls isn't one of those any more; we just moved to `-Z direct-minimal-versions`: see [docs](https://doc.rust-lang.org/cargo/reference/unstable.html#minimal-versions)). Therefore, this fix isn't blocking us.

### Call-outs:
#284 would defend/validate this change.

### Testing:
I manually ran:

```shell
$ cargo +nightly update -Z minimal-versions
$ cargo --locked check
```

Prior to this fix; this fails with:

```
error[E0599]: no method named `skip_exist` found for struct `fs_extra::dir::CopyOptions` in the current scope
   --> aws-lc-fips-sys/builder/main.rs:432:18
    |
431 |               let options = fs_extra::dir::CopyOptions::new()
    |  ___________________________-
432 | |                 .skip_exist(true)
    | |                 -^^^^^^^^^^------ help: remove the arguments
    | |                 ||
    | |_________________|field, not a method
    | 

For more information about this error, try `rustc --explain E0599`.
error: could not compile `aws-lc-fips-sys` (build script) due to previous error
warning: build failed, waiting for other jobs to finish...
```

After, it fails with:

```
    Checking aws-lc-rs v1.5.1 (/home/jbp/aws-lc-rs/aws-lc-rs)
error[E0599]: the method `zeroize` exists for struct `Box<[T]>`, but its trait bounds were not satisfied
   --> aws-lc-rs/src/hkdf.rs:288:16
    |
288 |           self.0.zeroize();
    |                  ^^^^^^^ method cannot be called on `Box<[T]>` due to unsatisfied trait bounds
   --> /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/alloc/src/boxed.rs:195:1
   ::: /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/alloc/src/boxed.rs:198:1
    |
    = note: doesn't satisfy `Box<[T]>: DefaultIsZeroes`
    |
    = note: doesn't satisfy `Box<[T]>: Zeroize`
    |
    = note: the following trait bounds were not satisfied:
            `Box<[T]>: DefaultIsZeroes`
            which is required by `Box<[T]>: Zeroize`


```

Which is a separate issue, that `aws-lc-rs/Cargo.toml` specifies `zeroize = "1"` but uses an API introduced in 1.3.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
