### PR TITLE
CI for minimal dependency versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -608,3 +608,24 @@ jobs:
       - name: Verify msrv
         working-directory: ./aws-lc-rs
         run: cargo msrv verify
+
+  minimal-versions:
+    name: Resolve the dependencies to the minimum SemVer version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+          lfs: true
+      - uses: actions-rs/toolchain@v1.0.7
+        id: toolchain
+        with:
+          toolchain: nightly
+          override: true
+      - name: Setup to use minimal versions
+        working-directory: ./aws-lc-rs
+        run: cargo update -Z minimal-versions
+      - name: Build with minimal versions
+        working-directory: ./aws-lc-rs
+        run: cargo --locked check
+

--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -44,7 +44,7 @@ fips = ["dep:aws-lc-fips-sys"]
 untrusted = { version = "0.7.1", optional = true }
 aws-lc-sys = { version = "0.12.1", path = "../aws-lc-sys", optional = true }
 aws-lc-fips-sys = { version = "0.11.2", path = "../aws-lc-fips-sys", optional = true }
-zeroize = "1"
+zeroize = "1.7"
 mirai-annotations = "1.12.0"
 
 [dev-dependencies]


### PR DESCRIPTION
### Issues:
Resolves https://github.com/aws/aws-lc-rs/issues/284

### Description of changes: 
* CI to verify minimal dependency version are actually supported.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
