### PR TITLE
Check semver in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -633,4 +633,16 @@ jobs:
       - name: Build with minimal versions
         working-directory: ./aws-lc-rs
         run: cargo --locked check
+  check-semver:
+    name: Check semver for aws-lc-rs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: aws-lc-rs
+          feature-group: default-features
 


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Run semver checks on aws-lc-rs as part of CI.

### Call-outs:
N/A

### Testing:
Checks currently pass locally:
```
❯ cargo semver-checks --default-features
     Parsing aws-lc-rs v1.5.2 (current)
     Parsing aws-lc-rs v1.5.2 (baseline)
    Checking aws-lc-rs v1.5.2 -> v1.5.2 (no change)
   Completed [   0.122s] 55 checks; 55 passed, 0 unnecessary
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
