### PR TITLE
Support for PowerPC big-endian

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,8 @@ jobs:
           - arm-linux-androideabi
           - armv7-linux-androideabi
           - aarch64-linux-android
+          - powerpc64-unknown-linux-gnu
+          - powerpc-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v3
         with:

--- a/aws-lc-rs/src/aead/chacha20_poly1305_openssh.rs
+++ b/aws-lc-rs/src/aead/chacha20_poly1305_openssh.rs
@@ -208,6 +208,7 @@ mod tests {
     };
     use crate::aead::Nonce;
     use crate::cipher::chacha::ChaCha20Key;
+    use crate::endian::LittleEndian;
     use crate::test;
 
     #[test]
@@ -221,10 +222,20 @@ mod tests {
         let chacha_key = chacha_key.as_slice();
         let chacha_key_bytes: [u8; 32] = <[u8; 32]>::try_from(chacha_key).unwrap();
         let chacha_key = ChaCha20Key::from(chacha_key_bytes);
-        let iv = Nonce::from(&[45u32, 897, 4567]);
-        let poly1305_key = derive_poly1305_key(&chacha_key, iv);
+        {
+            let iv = Nonce::from(&[45u32, 897, 4567]);
+            let poly1305_key = derive_poly1305_key(&chacha_key, iv);
+            assert_eq!(&expected_poly1305_key, &poly1305_key.key_and_nonce);
+        }
 
-        assert_eq!(&expected_poly1305_key, &poly1305_key.key_and_nonce);
+        {
+            let x = LittleEndian::from(45u32);
+            let y = LittleEndian::from(897);
+            let z = LittleEndian::from(4567);
+            let iv = Nonce::from(&[x, y, z]);
+            let poly1305_key = derive_poly1305_key(&chacha_key, iv);
+            assert_eq!(&expected_poly1305_key, &poly1305_key.key_and_nonce);
+        }
     }
 
     #[test]

--- a/aws-lc-sys/builder/main.rs
+++ b/aws-lc-sys/builder/main.rs
@@ -142,6 +142,13 @@ fn get_cmake_config(manifest_dir: &PathBuf) -> cmake::Config {
 fn prepare_cmake_build(manifest_dir: &PathBuf, build_prefix: String) -> cmake::Config {
     let mut cmake_cfg = get_cmake_config(manifest_dir);
 
+    if ["powerpc64", "powerpc"]
+        .iter()
+        .any(|arch| target_arch().eq_ignore_ascii_case(arch))
+    {
+        cmake_cfg.define("ENABLE_EXPERIMENTAL_BIG_ENDIAN_SUPPORT", "1");
+    }
+
     if OutputLibType::default() == OutputLibType::Dynamic {
         cmake_cfg.define("BUILD_SHARED_LIBS", "1");
     } else {


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Fix bug in Nonce construction affecting big-endian CPUs.
* Impl `From<&[BigEndian<u32>; 3]>` and `From<&[LittleEndian<u32>; 3]>` for Nonce
* Add CI for powerpc and powerpc64 (big-endian).

### Call-outs:
* Current behavior when converting a`[u32; 3]` to a Nonce implicitly assumes the `u32` values are `LittleEndian`. To avoid ambiguity, it's better for the endian-ness of the values to be explicit. This PR (attempts to) mark the existing implicit implementation as deprecated in favor of new explicit alternatives.

### Testing:
* Tests succeed locally on Linux host.  The cross-compilation of the tests on Mac host has a link failure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
