### PR TITLE
Set debug for CMAKE_BUILD_TYPE

### DIFF
--- a/aws-lc-fips-sys/builder/main.rs
+++ b/aws-lc-fips-sys/builder/main.rs
@@ -168,6 +168,10 @@ fn prepare_cmake_build(manifest_dir: &PathBuf, build_prefix: String) -> cmake::C
         } else {
             cmake_cfg.define("CMAKE_BUILD_TYPE", "release");
         }
+    } else if target_os() != "windows" {
+        // The Windows/FIPS build rejects "debug" profile
+        // https://github.com/aws/aws-lc/blob/main/CMakeLists.txt#L656
+        cmake_cfg.define("CMAKE_BUILD_TYPE", "debug");
     }
 
     cmake_cfg.define("BORINGSSL_PREFIX", build_prefix);

--- a/aws-lc-sys/builder/main.rs
+++ b/aws-lc-sys/builder/main.rs
@@ -162,6 +162,8 @@ fn prepare_cmake_build(manifest_dir: &PathBuf, build_prefix: String) -> cmake::C
         } else {
             cmake_cfg.define("CMAKE_BUILD_TYPE", "release");
         }
+    } else {
+        cmake_cfg.define("CMAKE_BUILD_TYPE", "debug");
     }
 
     cmake_cfg.define("BORINGSSL_PREFIX", build_prefix);


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
Set the debug flags for CMake when we run a "debug" build.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
