### PR TITLE
Improve support for big/little-endian arrays

### DIFF
--- a/aws-lc-rs/src/aead/chacha20_poly1305_openssh.rs
+++ b/aws-lc-rs/src/aead/chacha20_poly1305_openssh.rs
@@ -208,7 +208,7 @@ mod tests {
     };
     use crate::aead::Nonce;
     use crate::cipher::chacha::ChaCha20Key;
-    use crate::endian::LittleEndian;
+    use crate::endian::{BigEndian, FromArray, LittleEndian};
     use crate::test;
 
     #[test]
@@ -229,12 +229,15 @@ mod tests {
         }
 
         {
-            let x = LittleEndian::from(45u32);
-            let y = LittleEndian::from(897);
-            let z = LittleEndian::from(4567);
-            let iv = Nonce::from(&[x, y, z]);
+            let iv = Nonce::from(&LittleEndian::<u32>::from_array(&[45u32, 897, 4567]));
             let poly1305_key = derive_poly1305_key(&chacha_key, iv);
             assert_eq!(&expected_poly1305_key, &poly1305_key.key_and_nonce);
+        }
+
+        {
+            let iv = Nonce::from(&BigEndian::<u32>::from_array(&[45u32, 897, 4567]));
+            let poly1305_key = derive_poly1305_key(&chacha_key, iv);
+            assert_ne!(&expected_poly1305_key, &poly1305_key.key_and_nonce);
         }
     }
 

--- a/aws-lc-rs/src/aead/nonce.rs
+++ b/aws-lc-rs/src/aead/nonce.rs
@@ -3,7 +3,7 @@
 // Modifications copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-use crate::endian::{ArrayEncoding, BigEndian, Encoding, LittleEndian};
+use crate::endian::{ArrayEncoding, BigEndian, Encoding, FromArray, LittleEndian};
 use crate::error;
 use crate::iv::FixedLength;
 
@@ -55,11 +55,7 @@ impl From<&[u8; NONCE_LEN]> for Nonce {
 impl From<&[u32; NONCE_LEN / 4]> for Nonce {
     #[inline]
     fn from(values: &[u32; NONCE_LEN / 4]) -> Self {
-        let mut nonce = [LittleEndian::ZERO; NONCE_LEN / 4];
-        for i in 0..(NONCE_LEN / 4) {
-            nonce[i] = LittleEndian::from(values[i]);
-        }
-        Nonce::from(&nonce)
+        Nonce::from(&LittleEndian::<u32>::from_array(values))
     }
 }
 

--- a/aws-lc-rs/src/endian.rs
+++ b/aws-lc-rs/src/endian.rs
@@ -113,7 +113,7 @@ mod tests {
     }
 
     #[test]
-    fn test_endian_from_ary() {
+    fn test_endian_from_array() {
         let be: [BigEndian<u32>; 2] =
             BigEndian::<u32>::from_array(&[0x_AABB_CCDD_u32, 0x_2233_4455_u32]);
         let le: [LittleEndian<u32>; 2] =


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Improve support for big/little-endian arrays.

### Call-outs:
* `FromByteArray` was previously unused. I renamed/repurposed it.
* Although these traits/functions are `pub` they are not (yet) visible outside the crate. These could potentially be useful to our consumers.

### Testing:
* Added/updated unit tests. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
