### PR TITLE
Use classic comment style for CMakelists copyright notice

### DIFF
--- a/aws-lc-fips-sys/CMakeLists.txt
+++ b/aws-lc-fips-sys/CMakeLists.txt
@@ -1,7 +1,5 @@
-#[[
-Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-SPDX-License-Identifier: Apache-2.0 OR ISC
-]]
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
 
 cmake_minimum_required(VERSION 3.0)
 

--- a/aws-lc-sys/CMakeLists.txt
+++ b/aws-lc-sys/CMakeLists.txt
@@ -1,7 +1,5 @@
-#[[
-Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-SPDX-License-Identifier: Apache-2.0 OR ISC
-]]
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
 
 cmake_minimum_required(VERSION 3.0)
 


### PR DESCRIPTION
### Description of changes: 
The multiline comment at the top of `CMakeLists.txt` is only supported by CMake 3.0+. This means the `cmake_minimum_required(VERSION 3.0)` check on subsequent lines is not reached when using older versions of CMake, so you end up with an error such as:

```
Parse error.  Expected "(", got unquoted argument with text "Amazon.com,".
```

This change switches to using comments supported by older versions of CMake so the `cmake_minimum_required` can produce a more useful error message.

### Testing:
CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
