### PR TITLE
Refactor CBB usage

### DIFF
--- a/aws-lc-rs/src/cbb.rs
+++ b/aws-lc-rs/src/cbb.rs
@@ -1,29 +1,74 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-use aws_lc::{CBB_cleanup, CBB_init, CBB};
+use crate::buffer::Buffer;
+use crate::error::Unspecified;
+use crate::ptr::LcPtr;
+use aws_lc::{CBB_cleanup, CBB_finish, CBB_init, CBB_init_fixed, CBB};
+use std::marker::PhantomData;
 use std::mem::MaybeUninit;
+use std::ptr::null_mut;
 
-pub(crate) struct LcCBB(CBB);
+pub(crate) struct LcCBB<'a>(CBB, PhantomData<&'a CBB>);
 
-impl LcCBB {
+#[allow(dead_code)]
+impl LcCBB<'static> {
+    pub(crate) fn new(initial_capacity: usize) -> LcCBB<'static> {
+        let mut cbb = MaybeUninit::<CBB>::uninit();
+        let cbb = unsafe {
+            CBB_init(cbb.as_mut_ptr(), initial_capacity);
+            cbb.assume_init()
+        };
+        Self(cbb, PhantomData)
+    }
+
+    pub(crate) fn into_buffer<'a, T>(mut self) -> Result<Buffer<'a, T>, Unspecified> {
+        let mut out_data = null_mut::<u8>();
+        let mut out_len: usize = 0;
+
+        if 1 != unsafe { CBB_finish(self.as_mut_ptr(), &mut out_data, &mut out_len) } {
+            return Err(Unspecified);
+        };
+
+        let out_data = LcPtr::new(out_data)?;
+
+        // TODO: Need a type to just hold the owned pointer from CBB rather then copying
+        Ok(Buffer::take_from_slice(unsafe {
+            out_data.as_slice_mut(out_len)
+        }))
+    }
+}
+
+impl<'a> LcCBB<'a> {
+    pub(crate) fn new_fixed<const N: usize>(buffer: &'a mut [u8; N]) -> LcCBB<'a> {
+        let mut cbb = MaybeUninit::<CBB>::uninit();
+        let cbb = unsafe {
+            CBB_init_fixed(cbb.as_mut_ptr(), buffer.as_mut_ptr(), N);
+            cbb.assume_init()
+        };
+        Self(cbb, PhantomData)
+    }
+
+    pub(crate) fn finish(mut self) -> Result<(), Unspecified> {
+        let mut pkcs8_bytes_ptr = null_mut::<u8>();
+        let mut out_len: usize = 0;
+        if 1 == unsafe { CBB_finish(self.as_mut_ptr(), &mut pkcs8_bytes_ptr, &mut out_len) } {
+            Ok(())
+        } else {
+            Err(Unspecified)
+        }
+    }
+}
+impl LcCBB<'_> {
     pub(crate) fn as_mut_ptr(&mut self) -> *mut CBB {
         &mut self.0
     }
 }
 
-impl Drop for LcCBB {
+impl Drop for LcCBB<'_> {
     fn drop(&mut self) {
         unsafe {
             CBB_cleanup(&mut self.0);
         }
     }
-}
-
-#[inline]
-#[allow(non_snake_case)]
-pub(crate) unsafe fn build_CBB(initial_capacity: usize) -> LcCBB {
-    let mut cbb = MaybeUninit::<CBB>::uninit();
-    CBB_init(cbb.as_mut_ptr(), initial_capacity);
-    LcCBB(cbb.assume_init())
 }

--- a/aws-lc-rs/src/pkcs8.rs
+++ b/aws-lc-rs/src/pkcs8.rs
@@ -7,25 +7,29 @@
 //!
 //! [RFC 5208]: https://tools.ietf.org/html/rfc5208.
 
-use crate::ec;
 use zeroize::Zeroize;
 
 /// A generated PKCS#8 document.
 pub struct Document {
-    pub(crate) bytes: [u8; ec::PKCS8_DOCUMENT_MAX_LEN],
-    pub(crate) len: usize,
+    bytes: Box<[u8]>,
+}
+
+impl Document {
+    pub(crate) fn new(bytes: Box<[u8]>) -> Self {
+        Self { bytes }
+    }
 }
 
 impl AsRef<[u8]> for Document {
     #[inline]
     fn as_ref(&self) -> &[u8] {
-        &self.bytes[..self.len]
+        &self.bytes
     }
 }
 
 impl Drop for Document {
     fn drop(&mut self) {
-        self.bytes.zeroize();
+        self.bytes.as_mut().zeroize();
     }
 }
 

--- a/aws-lc-rs/src/ptr.rs
+++ b/aws-lc-rs/src/ptr.rs
@@ -40,6 +40,11 @@ impl<P: Pointer> ManagedPointer<P> {
     pub unsafe fn as_slice(&self, len: usize) -> &[P::T] {
         std::slice::from_raw_parts(self.pointer.as_const_ptr(), len)
     }
+
+    #[allow(clippy::mut_from_ref)]
+    pub unsafe fn as_slice_mut(&self, len: usize) -> &mut [P::T] {
+        std::slice::from_raw_parts_mut(self.pointer.as_mut_ptr(), len)
+    }
 }
 
 impl<P: Pointer> Drop for ManagedPointer<P> {
@@ -160,6 +165,7 @@ pub(crate) trait Pointer {
 
     fn free(&mut self);
     fn as_const_ptr(&self) -> *const Self::T;
+    fn as_mut_ptr(&self) -> *mut Self::T;
 }
 
 pub(crate) trait IntoPointer<P> {
@@ -191,6 +197,10 @@ macro_rules! create_pointer {
             }
 
             fn as_const_ptr(&self) -> *const Self::T {
+                self.cast()
+            }
+
+            fn as_mut_ptr(&self) -> *mut Self::T {
                 self.cast()
             }
         }


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Simplify CBB usage when marshalling
* `pkcs8::Document` holds `Box`
* LcCBB<'static> is not yet used, but will be needed with RSA refactoring.

### Call-outs:
N/A

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
