### PR TITLE
Fix script nightly feature

### DIFF
--- a/aws-lc-rs/src/key_wrap/tests/fips.rs
+++ b/aws-lc-rs/src/key_wrap/tests/fips.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
 #![cfg(debug_assertions)]
 
 use crate::{

--- a/scripts/tools/cargo-dig.rs
+++ b/scripts/tools/cargo-dig.rs
@@ -1,11 +1,11 @@
 #!/usr/bin/env -S cargo +nightly -Zscript
-//! Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-//! SPDX-License-Identifier: Apache-2.0 OR ISC
-//! ```cargo
-//! [dependencies]
-//! toml = "0.7.2"
-//! clap = { version = "4.1.6", features = ["derive"] }
-//! ```
+```cargo
+[dependencies]
+toml = "0.8"
+clap = { version = "4", features = ["derive"] }
+```
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
 
 use clap::Parser;
 use std::fs::read_to_string;

--- a/scripts/tools/copyright_check.sh
+++ b/scripts/tools/copyright_check.sh
@@ -2,7 +2,6 @@
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-#
 
 set -e
 
@@ -11,8 +10,8 @@ AWS_LC_RS_FILES=$(find "$PWD" -type f \( -name "*.rs" -o -name "*.sh" \) -not \(
 FAILED=0
 
 for file in $AWS_LC_RS_FILES; do
-    # The word "Copyright" should appear at least once in the first 4 lines of every file
-    COUNT=`head -n 4 "${file}" | grep "Copyright" | wc -l`;
+    # The word "Copyright" should appear at least once in the first 25 lines of every file
+    COUNT=`head -n 25 "${file}" | grep "Copyright" | wc -l`;
     if [ "${COUNT}" -eq "0" ]; then
         FAILED=1;
         echo "Copyright Check Failed: $file";

--- a/scripts/tools/semver.rs
+++ b/scripts/tools/semver.rs
@@ -1,12 +1,12 @@
 #!/usr/bin/env -S cargo +nightly -Zscript
-//! Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-//! SPDX-License-Identifier: Apache-2.0 OR ISC
-//! ```cargo
-//! [dependencies]
-//! clap = { version = "4", features = ["derive"] }
-//! regex = "1"
-//! semver = "1"
-//! ```
+```cargo
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+regex = "1"
+semver = "1"
+```
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
 
 use clap::{Parser, Subcommand};
 use regex::Regex;


### PR DESCRIPTION
### Description of changes: 
Cargo nightly is experimenting with a different syntax for the Cargo manifest description in scripts (they eliminated `//!` usage). So for now update to the one documented [here](https://doc.rust-lang.org/cargo/reference/unstable.html#script). There are a few other contenders that are not officially documented, but going with the one publicly visible for now.

### Call-outs:
May break again if they land on a different syntax for the manifest portion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
