### PR TITLE
A working FIPS build for Windows

### DIFF
--- a/.github/workflows/fips.yml
+++ b/.github/workflows/fips.yml
@@ -49,3 +49,36 @@ jobs:
         # Doc-tests fail to link with dynamic build
         # See: https://github.com/rust-lang/cargo/issues/8531
         run: cargo test --tests ${{ matrix.args }}
+  windows-fips-test:
+    name: aws-lc-rs windows-fips-tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [ stable ]
+        os: [ windows-2019, windows-2022 ]
+        args:
+          - --all-targets --features fips,unstable
+          - --all-targets --features fips,bindgen,unstable
+          - --release --all-targets --features fips,unstable
+          - --no-default-features --features fips,unstable
+          - --no-default-features --features fips,ring-io,unstable
+          - --no-default-features --features fips,ring-sig-verify,unstable
+          - --no-default-features --features fips,alloc,unstable
+    steps:
+      - uses: ilammy/setup-nasm@v1
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - uses: actions-rs/toolchain@v1.0.7
+        id: toolchain
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: Install ninja-build tool
+        uses: seanmiddleditch/gha-setup-ninja@v4
+      - name: Run cargo test
+        working-directory: ./aws-lc-rs
+        # Doc-tests fail to link with dynamic build
+        # See: https://github.com/rust-lang/cargo/issues/8531
+        run: cargo test --tests ${{ matrix.args }}

--- a/aws-lc-fips-sys/CMakeLists.txt
+++ b/aws-lc-fips-sys/CMakeLists.txt
@@ -18,9 +18,10 @@ if (BUILD_SHARED_LIBS AND FIPS)
     # as cmake crate will postfix the C/CXX flags after our disablement nullifying them.
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-function-sections -fno-data-sections")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-function-sections -fno-data-sections")
-endif ()
+endif()
 
 add_subdirectory(aws-lc aws-lc EXCLUDE_FROM_ALL)
+
 if (BUILD_LIBSSL)
     add_definitions(-DAWS_LC_RUST_INCLUDE_SSL)
 endif()
@@ -38,6 +39,7 @@ set(FINAL_ARTIFACTS_DIRECTORY ${CMAKE_BINARY_DIR}/artifacts)
 # location to find the artifacts cross-platform.
 set_my_target_properties(
         ARCHIVE_OUTPUT_DIRECTORY ${FINAL_ARTIFACTS_DIRECTORY}
+        RUNTIME_OUTPUT_DIRECTORY ${FINAL_ARTIFACTS_DIRECTORY}
         LIBRARY_OUTPUT_DIRECTORY ${FINAL_ARTIFACTS_DIRECTORY})
 
 # Based on https://stackoverflow.com/a/7750816 as some generators, like MSVC, will try to prefix the output directory
@@ -46,12 +48,14 @@ foreach (OUT_NAME ${CMAKE_CONFIGURATION_TYPES})
     string(TOUPPER ${OUT_NAME} OUT_NAME)
     set_my_target_properties(
             ARCHIVE_OUTPUT_DIRECTORY_${OUT_NAME} ${FINAL_ARTIFACTS_DIRECTORY}
+            RUNTIME_OUTPUT_DIRECTORY_${OUT_NAME} ${FINAL_ARTIFACTS_DIRECTORY}
             LIBRARY_OUTPUT_DIRECTORY_${OUT_NAME} ${FINAL_ARTIFACTS_DIRECTORY})
 endforeach ()
 
 if (BORINGSSL_PREFIX)
     if (MSVC)
         set(TARGET_PREFIX "${BORINGSSL_PREFIX}")
+        set_my_target_properties(IMPORT_PREFIX ${TARGET_PREFIX})
     else()
         set(TARGET_PREFIX "lib${BORINGSSL_PREFIX}")
     endif()

--- a/aws-lc-fips-sys/builder/cmake_builder.rs
+++ b/aws-lc-fips-sys/builder/cmake_builder.rs
@@ -106,7 +106,6 @@ impl CmakeBuilder {
                 .map_err(|x| panic!("{}", x))
                 .unwrap();
             for (key, value) in env_map {
-                println!("ENV-{}={}", key.as_str(), value.as_str());
                 cmake_cfg.env(key, value);
             }
         }
@@ -178,7 +177,7 @@ impl CmakeBuilder {
 impl crate::Builder for CmakeBuilder {
     fn check_dependencies(&self) -> Result<(), String> {
         let mut missing_dependency = false;
-        if target_os() == "windows" && test_ninja_command() {
+        if target_os() == "windows" && !test_ninja_command() {
             eprintln!("Missing dependency: Ninja is required for FIPS on Windows.");
             missing_dependency = true;
         }

--- a/aws-lc-fips-sys/builder/printenv.bat
+++ b/aws-lc-fips-sys/builder/printenv.bat
@@ -1,0 +1,7 @@
+@echo off
+for /f "usebackq tokens=* delims=" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do (
+    set "VS_PATH=%%i"
+)
+call "%VS_PATH%\VC\Auxiliary\Build\vcvarsall.bat" x64
+
+set

--- a/aws-lc-fips-sys/include/rust_wrapper.h
+++ b/aws-lc-fips-sys/include/rust_wrapper.h
@@ -8,6 +8,9 @@
 
 #ifdef _WIN32
 #define BORINGSSL_SHARED_LIBRARY
+#define AWS_LC_FIPS_SYS_EXPORT __declspec(dllexport)
+#else
+#define AWS_LC_FIPS_SYS_EXPORT __attribute__((visibility("default")))
 #endif
 
 #include <openssl/err.h>
@@ -20,9 +23,9 @@ extern "C" {
 // The following functions are wrappers over inline functions and macros in
 // BoringSSL, which bindgen cannot currently correctly bind. These wrappers
 // ensure changes to the functions remain in lockstep with the Rust versions.
-int ERR_GET_LIB_RUST(uint32_t packed_error);
-int ERR_GET_REASON_RUST(uint32_t packed_error);
-int ERR_GET_FUNC_RUST(uint32_t packed_error);
+AWS_LC_FIPS_SYS_EXPORT int ERR_GET_LIB_RUST(uint32_t packed_error);
+AWS_LC_FIPS_SYS_EXPORT int ERR_GET_REASON_RUST(uint32_t packed_error);
+AWS_LC_FIPS_SYS_EXPORT int ERR_GET_FUNC_RUST(uint32_t packed_error);
 
 
 #if defined(__cplusplus)

--- a/aws-lc-sys/CMakeLists.txt
+++ b/aws-lc-sys/CMakeLists.txt
@@ -18,6 +18,7 @@ add_subdirectory(aws-lc aws-lc EXCLUDE_FROM_ALL)
 if (BUILD_LIBSSL)
     add_definitions(-DAWS_LC_RUST_INCLUDE_SSL)
 endif()
+
 add_library(rust_wrapper rust_wrapper.c)
 target_include_directories(rust_wrapper PRIVATE include)
 target_link_libraries(rust_wrapper PUBLIC crypto)
@@ -31,6 +32,7 @@ set(FINAL_ARTIFACTS_DIRECTORY ${CMAKE_BINARY_DIR}/artifacts)
 # location to find the artifacts cross-platform.
 set_my_target_properties(
         ARCHIVE_OUTPUT_DIRECTORY ${FINAL_ARTIFACTS_DIRECTORY}
+        RUNTIME_OUTPUT_DIRECTORY ${FINAL_ARTIFACTS_DIRECTORY}
         LIBRARY_OUTPUT_DIRECTORY ${FINAL_ARTIFACTS_DIRECTORY})
 
 # Based on https://stackoverflow.com/a/7750816 as some generators, like MSVC, will try to prefix the output directory
@@ -39,12 +41,14 @@ foreach (OUT_NAME ${CMAKE_CONFIGURATION_TYPES})
     string(TOUPPER ${OUT_NAME} OUT_NAME)
     set_my_target_properties(
             ARCHIVE_OUTPUT_DIRECTORY_${OUT_NAME} ${FINAL_ARTIFACTS_DIRECTORY}
+            RUNTIME_OUTPUT_DIRECTORY_${OUT_NAME} ${FINAL_ARTIFACTS_DIRECTORY}
             LIBRARY_OUTPUT_DIRECTORY_${OUT_NAME} ${FINAL_ARTIFACTS_DIRECTORY})
 endforeach ()
 
 if (BORINGSSL_PREFIX)
     if (MSVC)
         set(TARGET_PREFIX "${BORINGSSL_PREFIX}")
+        set_my_target_properties(IMPORT_PREFIX ${TARGET_PREFIX})
     else()
         set(TARGET_PREFIX "lib${BORINGSSL_PREFIX}")
     endif()

--- a/aws-lc-sys/builder/cmake_builder.rs
+++ b/aws-lc-sys/builder/cmake_builder.rs
@@ -15,9 +15,9 @@ pub(crate) struct CmakeBuilder {
 }
 
 fn find_cmake_command() -> Option<&'static OsStr> {
-    if test_command("cmake3".as_ref(), &["--version".as_ref()]) {
+    if test_command("cmake3".as_ref(), &["--version".as_ref()]).status {
         Some("cmake3".as_ref())
-    } else if test_command("cmake".as_ref(), &["--version".as_ref()]) {
+    } else if test_command("cmake".as_ref(), &["--version".as_ref()]).status {
         Some("cmake".as_ref())
     } else {
         None

--- a/aws-lc-sys/include/rust_wrapper.h
+++ b/aws-lc-sys/include/rust_wrapper.h
@@ -8,9 +8,9 @@
 
 #ifdef _WIN32
 #define BORINGSSL_SHARED_LIBRARY
-#define AWS_LC_FIPS_SYS_EXPORT __declspec(dllexport)
+#define AWS_LC_SYS_EXPORT __declspec(dllexport)
 #else
-#define AWS_LC_FIPS_SYS_EXPORT __attribute__((visibility("default")))
+#define AWS_LC_SYS_EXPORT __attribute__((visibility("default")))
 #endif
 
 #include <openssl/err.h>
@@ -23,9 +23,9 @@ extern "C" {
 // The following functions are wrappers over inline functions and macros in
 // BoringSSL, which bindgen cannot currently correctly bind. These wrappers
 // ensure changes to the functions remain in lockstep with the Rust versions.
-AWS_LC_FIPS_SYS_EXPORT int ERR_GET_LIB_RUST(uint32_t packed_error);
-AWS_LC_FIPS_SYS_EXPORT int ERR_GET_REASON_RUST(uint32_t packed_error);
-AWS_LC_FIPS_SYS_EXPORT int ERR_GET_FUNC_RUST(uint32_t packed_error);
+AWS_LC_SYS_EXPORT int ERR_GET_LIB_RUST(uint32_t packed_error);
+AWS_LC_SYS_EXPORT int ERR_GET_REASON_RUST(uint32_t packed_error);
+AWS_LC_SYS_EXPORT int ERR_GET_FUNC_RUST(uint32_t packed_error);
 
 
 #if defined(__cplusplus)

--- a/aws-lc-sys/include/rust_wrapper.h
+++ b/aws-lc-sys/include/rust_wrapper.h
@@ -8,6 +8,9 @@
 
 #ifdef _WIN32
 #define BORINGSSL_SHARED_LIBRARY
+#define AWS_LC_FIPS_SYS_EXPORT __declspec(dllexport)
+#else
+#define AWS_LC_FIPS_SYS_EXPORT __attribute__((visibility("default")))
 #endif
 
 #include <openssl/err.h>
@@ -20,9 +23,9 @@ extern "C" {
 // The following functions are wrappers over inline functions and macros in
 // BoringSSL, which bindgen cannot currently correctly bind. These wrappers
 // ensure changes to the functions remain in lockstep with the Rust versions.
-int ERR_GET_LIB_RUST(uint32_t packed_error);
-int ERR_GET_REASON_RUST(uint32_t packed_error);
-int ERR_GET_FUNC_RUST(uint32_t packed_error);
+AWS_LC_FIPS_SYS_EXPORT int ERR_GET_LIB_RUST(uint32_t packed_error);
+AWS_LC_FIPS_SYS_EXPORT int ERR_GET_REASON_RUST(uint32_t packed_error);
+AWS_LC_FIPS_SYS_EXPORT int ERR_GET_FUNC_RUST(uint32_t packed_error);
 
 
 #if defined(__cplusplus)


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* A working FIPS build for Windows.
* This change uses a Windows batch script to execute `vcvarsall.bat` and then display all of the environment variables that were set.
  * Our build-script parses environment variables from the output of the script and sets those variables to be available for CMake.

### Call-outs:
N/A

### Testing:
* Test succeeded on my Windows host.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
