### PR TITLE
Update version to v1.6.0

### DIFF
--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-lc-rs"
 authors = ["AWS-LibCrypto"]
-version = "1.5.2"
+version = "1.6.0"
 edition = "2021"
 rust-version = "1.60"
 keywords = ["crypto", "cryptography", "security"]


### PR DESCRIPTION
## Highlights
* AES Key Wrap Algorithm Support by @skmcgrail in https://github.com/aws/aws-lc-rs/pull/250
* Expose accessors for private/public key on elliptic curve keys by @justsmth in https://github.com/aws/aws-lc-rs/pull/259
* KEM: Key-Encapsulation Mechanisms API Support by @skmcgrail in https://github.com/aws/aws-lc-rs/pull/260
* RSA Module Refactor by @skmcgrail in https://github.com/aws/aws-lc-rs/pull/273
* Support for PowerPC big-endian by @justsmth in https://github.com/aws/aws-lc-rs/pull/295
* Persistent private keys for agreement by @justsmth in https://github.com/aws/aws-lc-rs/pull/302
* A working FIPS build for Windows by @justsmth in https://github.com/aws/aws-lc-rs/pull/309
* RSA Key Generation Support by @skmcgrail in https://github.com/aws/aws-lc-rs/pull/315

## Other Changes
* Update rustls integration test by @skmcgrail in https://github.com/aws/aws-lc-rs/pull/291
* CI for minimal dependency versions by @justsmth in https://github.com/aws/aws-lc-rs/pull/290
* Enable exhaustive_enums lint by @skmcgrail in https://github.com/aws/aws-lc-rs/pull/289
* Move hex functions out of test mod by @justsmth in https://github.com/aws/aws-lc-rs/pull/293
* Updated aws-lc-fips-sys and fips feature messaging by @skmcgrail in https://github.com/aws/aws-lc-rs/pull/282
* Consider target env for pregenerated bindings by @justsmth in https://github.com/aws/aws-lc-rs/pull/283
* Set debug for CMAKE_BUILD_TYPE by @justsmth in https://github.com/aws/aws-lc-rs/pull/298
* Improve support for big/little-endian arrays by @justsmth in https://github.com/aws/aws-lc-rs/pull/299
* Use classic comment style for CMakelists copyright notice by @WesleyRosenblum in https://github.com/aws/aws-lc-rs/pull/304
* Refactor sys-crate Cmake build logic by @justsmth in https://github.com/aws/aws-lc-rs/pull/301
* RSA Module Tidying by @skmcgrail in https://github.com/aws/aws-lc-rs/pull/305
* Fix script nightly feature by @skmcgrail in https://github.com/aws/aws-lc-rs/pull/307
* Migrate actions-rs/* to dtolnay/rust-toolchain by @skmcgrail in https://github.com/aws/aws-lc-rs/pull/308
* Add CI test with musl by @justsmth in https://github.com/aws/aws-lc-rs/pull/310
* Update to AWS-LC-FIPS-2.0.5 by @justsmth in https://github.com/aws/aws-lc-rs/pull/313
* Update bindgen requirement from 0.68.1 to 0.69.2 by @dependabot in https://github.com/aws/aws-lc-rs/pull/311
* Update aws-lc-sys/aws-lc to v1.20.0 by @skmcgrail in https://github.com/aws/aws-lc-rs/pull/314
* Use cargo-careful w/ CI tests by @justsmth in https://github.com/aws/aws-lc-rs/pull/312
* Split CI configuration across multiple files by @justsmth in https://github.com/aws/aws-lc-rs/pull/316
* Update to latest FIPS-2.0.6 by @justsmth in https://github.com/aws/aws-lc-rs/pull/318
* Rust Docs + GH workflow cleanup by @justsmth in https://github.com/aws/aws-lc-rs/pull/320
* Minor adjustments to key_wrap module API by @skmcgrail in https://github.com/aws/aws-lc-rs/pull/321
* Fix GH doc deploy by @justsmth in https://github.com/aws/aws-lc-rs/pull/323
* Encoding docs cleanup by @justsmth in https://github.com/aws/aws-lc-rs/pull/319
* Fix doc deploy 2 by @justsmth in https://github.com/aws/aws-lc-rs/pull/324

## New Contributors
* @WesleyRosenblum made their first contribution in https://github.com/aws/aws-lc-rs/pull/304

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
