### PR TITLE
Improve how vcvarsall is located

### DIFF
--- a/.github/workflows/fips.yml
+++ b/.github/workflows/fips.yml
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ stable ]
-        os: [ windows-2019, windows-2022 ]
+        os: [ windows-2019, windows-latest ]
         args:
           - --all-targets --features fips,unstable
           - --all-targets --features fips,bindgen,unstable

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -57,3 +57,36 @@ jobs:
         working-directory: ./aws-lc-rs
         run: |
           ./scripts/run-rustls-integration.sh
+
+  sys-crate-tests:
+    if: github.repository == 'aws/aws-lc-rs'
+    name: sys crate tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-12, macos-13-xlarge, windows-latest ]
+        features: [ aws-lc-sys, aws-lc-fips-sys ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - uses: dtolnay/rust-toolchain@stable
+        id: toolchain
+      - name: Set Rust toolchain override
+        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install NASM on Windows
+        if: runner.os == 'Windows'
+        uses: ilammy/setup-nasm@v1
+      - name: Setup Go >=v1.18
+        uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.18'
+      - name: Install ninja-build tool
+        uses: seanmiddleditch/gha-setup-ninja@v4
+      - name: Run cargo test
+        working-directory: ./sys-testing
+        run: cargo test --features ${{ matrix.features }} --no-default-features
+      - name: Run cargo run
+        working-directory: ./sys-testing
+        run: cargo run --features ${{ matrix.features }} --no-default-features

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,29 +14,6 @@ env:
   RUST_NIGHTLY_TOOLCHAIN: nightly
 
 jobs:
-  sys-crate-tests:
-    if: github.repository == 'aws/aws-lc-rs'
-    name: sys crate tests
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-latest, macos-12 ]
-        features: [ aws-lc-sys, aws-lc-fips-sys ]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
-        id: toolchain
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
-      - name: Run cargo test
-        working-directory: ./sys-testing
-        run: cargo test --features ${{ matrix.features }} --no-default-features
-      - name: Run cargo run
-        working-directory: ./sys-testing
-        run: cargo run --features ${{ matrix.features }} --no-default-features
 
   aws-lc-rs-test:
     if: github.repository == 'aws/aws-lc-rs'

--- a/aws-lc-fips-sys/builder/cmake_builder.rs
+++ b/aws-lc-fips-sys/builder/cmake_builder.rs
@@ -162,6 +162,7 @@ impl CmakeBuilder {
         let script_path = self.manifest_dir.join("builder").join("printenv.bat");
         let result = test_command(script_path.as_os_str(), &[]);
         if !result.status {
+            eprintln!("{}", result.output);
             return Err("Failed to run vccarsall.bat.".to_owned());
         }
         let lines = result.output.lines();

--- a/aws-lc-fips-sys/builder/cmake_builder.rs
+++ b/aws-lc-fips-sys/builder/cmake_builder.rs
@@ -165,6 +165,7 @@ impl CmakeBuilder {
             eprintln!("{}", result.output);
             return Err("Failed to run vccarsall.bat.".to_owned());
         }
+        eprintln!("{}", result.output);
         let lines = result.output.lines();
         for line in lines {
             if let Some((var, val)) = line.split_once('=') {

--- a/aws-lc-fips-sys/builder/printenv.bat
+++ b/aws-lc-fips-sys/builder/printenv.bat
@@ -2,6 +2,7 @@
 setlocal EnableDelayedExpansion
 for /f "usebackq tokens=* delims=" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do (
     set "VS_PATH=%%i\VC\Auxiliary\Build\"
+    echo FOUND: "!VS_PATH!"
     goto FoundVS
 )
 

--- a/aws-lc-fips-sys/builder/printenv.bat
+++ b/aws-lc-fips-sys/builder/printenv.bat
@@ -1,13 +1,22 @@
 @echo off
 setlocal EnableDelayedExpansion
+
+set "TOP_DIR=%ProgramFiles(x86)%\Microsoft Visual Studio"
 for /f "usebackq tokens=* delims=" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do (
-    set "VS_PATH=%%i\VC\Auxiliary\Build\"
-    echo FOUND: "!VS_PATH!"
-    goto FoundVS
+    set "TOP_DIR=%%i"
+    echo VS Installation: "!TOP_DIR!"
+    if exist "!TOP_DIR!\VC\Auxiliary\Build\vcvarsall.bat" (
+        set "VS_PATH=!TOP_DIR!\VC\Auxiliary\Build\"
+        echo FOUND in Installation: "!VS_PATH!"
+        goto FoundVS
+    )
+    goto SearchVS
 )
 
 echo Visual Studio installation not found using vswhere. Searching in default directories...
-for /R "%ProgramFiles(x86)%\Microsoft Visual Studio" %%a in (vcvarsall.bat) do (
+
+:SearchVS
+for /R "%TOP_DIR%" %%a in (vcvarsall.bat) do (
     if exist "%%~fa" (
         set "VS_PATH=%%~dpa"
         echo FOUND: "!VS_PATH!"

--- a/aws-lc-fips-sys/builder/printenv.bat
+++ b/aws-lc-fips-sys/builder/printenv.bat
@@ -1,7 +1,34 @@
 @echo off
+setlocal EnableDelayedExpansion
 for /f "usebackq tokens=* delims=" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do (
-    set "VS_PATH=%%i"
+    set "VS_PATH=%%i\VC\Auxiliary\Build\"
+    goto FoundVS
 )
-call "%VS_PATH%\VC\Auxiliary\Build\vcvarsall.bat" x64
+
+echo Visual Studio installation not found using vswhere. Searching in default directories...
+for /R "%ProgramFiles(x86)%\Microsoft Visual Studio" %%a in (vcvarsall.bat) do (
+    if exist "%%~fa" (
+        set "VS_PATH=%%~dpa"
+        echo FOUND: "!VS_PATH!"
+        goto FoundVS
+    )
+)
+echo vcvarsall.bat not found.
+goto End
+
+:FoundVS
+call "!VS_PATH!vcvarsall.bat" x64
+if !ERRORLEVEL! neq 0 (
+    echo Failed to set Visual Studio environment variables.
+    echo PATH: "!VS_PATH!vcvarsall.bat"
+    goto End
+)
+echo Visual Studio environment variables set for x64.
 
 set
+endlocal
+exit /b 0
+
+:End
+endlocal
+exit /b 1


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* For the Windows/FIPS build, add fallback logic for locating `vcvarsall.bat` when `vswhere.exe` fails.
* Increase verbosity of failures.

### Call-outs:
N/A

### Testing:
* I'm still not sure of the root cause for the [build failure seen here](https://github.com/rustls/rustls/actions/runs/7694846379/job/20966481181?pr=1732#step:7:205).  However, this change should provide more logging to diagnose the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
