### PR TITLE
Upgrade the version of the `untrusted` crate

### DIFF
--- a/aws-lc-rs-testing/Cargo.toml
+++ b/aws-lc-rs-testing/Cargo.toml
@@ -15,7 +15,7 @@ asan = ["aws-lc-rs/asan"]
 
 [dependencies]
 aws-lc-rs = { version = "1.0", path = "../aws-lc-rs", features = ["ring-sig-verify", "unstable"] }
-untrusted = { version = "0.7" }
+untrusted = { version = "0.9" }
 
 [dev-dependencies]
 paste = "1.0.13"

--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -43,7 +43,7 @@ non-fips = ["aws-lc-sys"]
 fips = ["dep:aws-lc-fips-sys"]
 
 [dependencies]
-untrusted = { version = "0.7.1", optional = true }
+untrusted = { version = "0.9.0", optional = true }
 aws-lc-sys = { version = "0.13.0", path = "../aws-lc-sys", optional = true }
 aws-lc-fips-sys = { version = "0.12.0", path = "../aws-lc-fips-sys", optional = true }
 zeroize = "1.7"

--- a/aws-lc-rs/README.md
+++ b/aws-lc-rs/README.md
@@ -43,7 +43,7 @@ Enable feature to access the  `io`  module.
 
 ##### ring-sig-verify (default)
 Enable feature to preserve compatibility with ring's `signature::VerificationAlgorithm::verify`
-function. This adds a requirement on `untrusted = "0.7.1"`.
+function. This adds a requirement on the `untrusted` crate.
 
 ##### fips
 Enable this feature to have aws-lc-rs use the [*aws-lc-fips-sys*](https://crates.io/crates/aws-lc-fips-sys)


### PR DESCRIPTION
### Description of changes: 
This upgrades the version of the `untrusted` crate to the latest 0.9, to avoid
duplicate dependencies when building aws-lc-rs in a project with other
dependencies on `untrusted`.

### Call-outs:
A few deprecated functions take `untrusted::Input` as a parameter directly. This PR should wait for a new major version of aws-lc-rs that drops those deprecated functions. (Alternatively, it'd be possible to have an `untrusted07` feature flag that continues depending on `untrusted` 0.7 for the sole purpose of the API of those deprecated funtions, but that doesn't seem worthwhile here.)

As far as I can tell, no non-deprecated APIs would be affected, which means future upgrades to untrusted would not have this issue.

### Testing:
Builds and passes `cargo test`, with and without the `ring-io` and `ring-sig-verify` feature flags set.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
