### PR TITLE
Windows: include `printenv.bat` in cargo releases

### DIFF
--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -43,6 +43,7 @@ include = [
     "/aws-lc/util/godeps.go",
     "/CMakeLists.txt",
     "/builder/**/*.rs",
+    "/builder/printenv.bat",
     "/Cargo.toml",
     "/generated-include/**",
     "/include/**",

--- a/aws-lc-fips-sys/builder/cmake_builder.rs
+++ b/aws-lc-fips-sys/builder/cmake_builder.rs
@@ -163,7 +163,7 @@ impl CmakeBuilder {
         let result = test_command(script_path.as_os_str(), &[]);
         if !result.status {
             eprintln!("{}", result.output);
-            return Err("Failed to run vccarsall.bat.".to_owned());
+            return Err("Failed to run vcvarsall.bat.".to_owned());
         }
         eprintln!("{}", result.output);
         let lines = result.output.lines();


### PR DESCRIPTION
### Issues:
Working on https://github.com/rustls/rustls/actions/runs/7694846379/job/20966481181 build breakage

### Testing:
I ran `cargo package ` locally, but I haven't managed to test this in a meaningful way.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
