### PR TITLE
Improve exposure of dry-run publish failures

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -90,3 +90,38 @@ jobs:
       - name: Run cargo run
         working-directory: ./sys-testing
         run: cargo run --features ${{ matrix.features }} --no-default-features
+
+  publish-dry-run:
+    if: github.repository == 'aws/aws-lc-rs'
+    name: publish dry-run
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [ stable ]
+        os: [ windows-latest, ubuntu-latest, macos-12, macos-13-xlarge ]
+        crate: [ aws-lc-sys, aws-lc-rs, aws-lc-fips-sys ]
+        args:
+          - publish --dry-run
+    steps:
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.18'
+      - run: go version
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - if: ${{ matrix.os == 'windows-latest' }}
+        uses: ilammy/setup-nasm@v1
+      - name: Install ninja-build tool
+        if: ${{ matrix.os == 'windows-latest' }}
+        uses: seanmiddleditch/gha-setup-ninja@v4
+      - uses: dtolnay/rust-toolchain@master
+        id: toolchain
+        with:
+          toolchain: ${{ matrix.rust }}
+      - name: Set Rust toolchain override
+        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: ${{ matrix.crate }}
+        working-directory: ./${{ matrix.crate }}
+        run: cargo ${{ matrix.args }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,44 +106,6 @@ jobs:
         working-directory: ./aws-lc-rs
         run: cargo test ${{ matrix.args }}
 
-  publish-dry-run:
-    if: github.repository == 'aws/aws-lc-rs'
-    name: publish dry-run
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        rust: [ stable ]
-        os: [ windows-2019, ubuntu-latest, macos-12, macos-13-xlarge ]
-        args:
-          - publish --dry-run
-    steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: '>=1.18'
-      - run: go version
-      - if: ${{ matrix.os == 'windows-2019' }}
-        uses: ilammy/setup-nasm@v1
-      - uses: actions/checkout@v3
-        with:
-          submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: ${{ matrix.rust }}
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
-      - name: aws-lc-sys
-        working-directory: ./aws-lc-sys
-        run: cargo ${{ matrix.args }}
-      - name: aws-lc-fips-sys
-        if: ${{ matrix.os != 'windows-2019' }}
-        working-directory: ./aws-lc-fips-sys
-        run: cargo ${{ matrix.args }}
-      - name: aws-lc-rs
-        working-directory: ./aws-lc-rs
-        run: cargo ${{ matrix.args }}
-
   aws-lc-rs-coverage:
     name: aws-ls-rs coverage
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Issues:
N/A

### Description of changes: 
* Separate CI tasks to dry-run publish each crate independently.
  *  We were previously lumping all 3 crates into a single task, and then ignoring the expected failure b/c `aws-lc-rs` depended on not-yet-released versions of our sys crates.

### Call-outs:
* Motivated by #332 where we forgot to include a Windows-specific file in the crate we published.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
