### PR TITLE
Use stable toolchain for CI cross-compilation

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [ 1.72.1 ] # TODO: return to stable
+        rust: [ stable ]
         os: [ ubuntu-latest ]
         target:
           - arm-unknown-linux-gnueabihf

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -48,6 +48,10 @@ jobs:
         run: rustup override set ${{ steps.toolchain.outputs.name }}
       - name: Install cross
         run: cargo install cross ${{ (matrix.target == 'riscv64gc-unknown-linux-gnu'  && '--locked') || '' }} --git https://github.com/cross-rs/cross
+      - if: ${{ matrix.target == 'riscv64gc-unknown-linux-gnu' }}
+        run: |
+          cargo update
+          cargo update -p clap --precise 4.4.18
       - name: Cross-compilation
         if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'i686-unknown-linux-gnu' }}
         working-directory: ./aws-lc-rs

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -21,7 +21,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [ stable ]
         os: [ ubuntu-latest ]
         target:
           - arm-unknown-linux-gnueabihf
@@ -43,12 +42,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         id: toolchain
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain:  ${{ (matrix.target == 'riscv64gc-unknown-linux-gnu'  && '1.72.1') || 'stable' }}
           target: ${{ matrix.target }}
       - name: Set Rust toolchain override
         run: rustup override set ${{ steps.toolchain.outputs.name }}
       - name: Install cross
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        run: cargo install cross ${{ (matrix.target == 'riscv64gc-unknown-linux-gnu'  && '--locked') || '' }} --git https://github.com/cross-rs/cross
       - name: Cross-compilation
         if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'i686-unknown-linux-gnu' }}
         working-directory: ./aws-lc-rs


### PR DESCRIPTION
### Description of changes: 
Use `stable` toolchain for CI cross-compilation tests.

### Call-outs:
`riscv64` still stuck at 1.72.1 due to link failure.
```
unsupported ISA subset `z'
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
