### PR TITLE
Add check for sys crate publish; Script cleanup

### DIFF
--- a/scripts/generate/_generate_all_bindings_flavors.sh
+++ b/scripts/generate/_generate_all_bindings_flavors.sh
@@ -52,8 +52,8 @@ pushd "${REPO_ROOT}" &>/dev/null
 pids=""
 if [[ "${GENERATE_FIPS}" -eq 0 ]]; then
   ## macOS bindings
-  IS_MACOS_HOST=$(check_running_on_macos [[ $IGNORE_MACOS -eq 0 ]])
-  if [[ $IS_MACOS_HOST -eq 0 ]]; then
+  IS_MACOS_HOST=$(check_running_on_macos ${IGNORE_MACOS})
+  if [[ $IS_MACOS_HOST -eq 1 ]]; then
     ${GEN_BINDINGS_SCRIPT} -c "${RELATIVE_CRATE_PATH}" &
   else
     echo Script is not running on macOS.

--- a/scripts/generate/_run_supported_symbol_builds.sh
+++ b/scripts/generate/_run_supported_symbol_builds.sh
@@ -55,8 +55,8 @@ pushd "${REPO_ROOT}" &>/dev/null
 pids=''
 if [[ "${GENERATE_FIPS}" -eq 0 ]]; then
   ## macOS symbols
-  IS_MACOS_HOST=$(check_running_on_macos [[ $IGNORE_MACOS -eq 0 ]])
-  if [[ $IS_MACOS_HOST -eq 0 ]]; then
+  IS_MACOS_HOST=$(check_running_on_macos ${IGNORE_MACOS})
+  if [[ $IS_MACOS_HOST -eq 1 ]]; then
     ${COLLECT_SYMBOLS_SCRIPT} -c "${RELATIVE_CRATE_PATH}" &
   else
     echo Script is not running on macOS.

--- a/scripts/generate/_test_supported_builds.sh
+++ b/scripts/generate/_test_supported_builds.sh
@@ -21,24 +21,6 @@ IGNORE_MACOS=0
 RELATIVE_CRATE_PATH=""
 CRATE_TEST_SCRIPT="${SCRIPT_DIR}/_crate_test_build.sh"
 
-while getopts c:f option; do
-  case $option in
-  c)
-    RELATIVE_CRATE_PATH="${OPTARG}"
-    ;;
-  f)
-    GENERATE_FIPS=1
-    ;;
-  m)
-    IGNORE_MACOS=1
-    ;;
-  ?)
-    usage
-    exit 1
-    ;;
-  esac
-done
-
 if [[ -z "${RELATIVE_CRATE_PATH}" ]]; then
   echo "Relative crate path must be provided"
   exit 1
@@ -51,8 +33,8 @@ pushd "${REPO_ROOT}" &>/dev/null
 pids=''
 if [[ "${GENERATE_FIPS}" -eq 0 ]]; then
   ### Test crate on Mac
-  IS_MACOS_HOST=$(check_running_on_macos [[ $IGNORE_MACOS -eq 0 ]])
-  if [[ $IS_MACOS_HOST -eq 0 ]]; then
+  IS_MACOS_HOST=$(check_running_on_macos ${IGNORE_MACOS})
+  if [[ $IS_MACOS_HOST -eq 1 ]]; then
     ${CRATE_TEST_SCRIPT} -c "${RELATIVE_CRATE_PATH}" &
   else
     echo Script is not running on macOS.

--- a/scripts/generate/_test_supported_builds.sh
+++ b/scripts/generate/_test_supported_builds.sh
@@ -21,6 +21,24 @@ IGNORE_MACOS=0
 RELATIVE_CRATE_PATH=""
 CRATE_TEST_SCRIPT="${SCRIPT_DIR}/_crate_test_build.sh"
 
+while getopts c:f option; do
+  case $option in
+  c)
+    RELATIVE_CRATE_PATH="${OPTARG}"
+    ;;
+  f)
+    GENERATE_FIPS=1
+    ;;
+  m)
+    IGNORE_MACOS=1
+    ;;
+  ?)
+    usage
+    exit 1
+    ;;
+  esac
+done
+
 if [[ -z "${RELATIVE_CRATE_PATH}" ]]; then
   echo "Relative crate path must be provided"
   exit 1

--- a/scripts/generate/generate-aws-lc-sys.sh
+++ b/scripts/generate/generate-aws-lc-sys.sh
@@ -4,12 +4,6 @@
 
 set -e
 
-IGNORE_DIRTY=0
-IGNORE_BRANCH=0
-IGNORE_UPSTREAM=0
-IGNORE_MACOS=0
-SKIP_TEST=0
-
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
@@ -25,8 +19,8 @@ pushd "${REPO_ROOT}" &>/dev/null
 check_workspace $IGNORE_DIRTY
 check_branch $IGNORE_BRANCH $IGNORE_UPSTREAM
 
-IS_MACOS_HOST=$(check_running_on_macos [[ $IGNORE_MACOS -eq 0 ]])
-if [[ $IS_MACOS_HOST -ne 0 ]]; then
+IS_MACOS_HOST=$(check_running_on_macos ${IGNORE_MACOS})
+if [[ $IS_MACOS_HOST -ne 1 ]]; then
   echo Script is not running on macOS!
 fi
 

--- a/scripts/publish/_publish_tools.sh
+++ b/scripts/publish/_publish_tools.sh
@@ -26,7 +26,9 @@ function publish_options {
 
 # Finds the version of the crate based on current working directory
 function crate_version_prefix {
-  grep -E '^version =' ./Cargo.toml | sed -e 's/.*"\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)"/\1_\2_\3/'
+  local REPO_ROOT
+  REPO_ROOT=$(git rev-parse --show-toplevel)
+  "${REPO_ROOT}"/scripts/tools/cargo-dig.rs -v | sed -e 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\1_\2_\3/'
 }
 
 function run_prepublish_checks {

--- a/scripts/publish/_publish_tools.sh
+++ b/scripts/publish/_publish_tools.sh
@@ -32,16 +32,15 @@ function crate_version_prefix {
 }
 
 function sanity_check_sys_crate {
-  local CRATE_DIR="${1}"
-  local CRATE_NAME=$(basename "${CRATE_DIR}")
-  local PREFIX=$(echo "${CRATE_NAME}" | sed -e 's/-/_/g' | sed -e 's/^\(.*\)_sys/\1/')
+  local CRATE_DIR CRATE_NAME PREFIX
+  CRATE_DIR="${1}"
+  CRATE_NAME=$(basename "${CRATE_DIR}")
+  PREFIX=$(echo "${CRATE_NAME}" | sed -e 's/-/_/g' | sed -e 's/^\(.*\)_sys/\1/')
 
-  local CRATE_VERSION_PREFIX=$(crate_version_prefix "${CRATE_DIR}")
-  local CRATE_PREFIX="${PREFIX}_${CRATE_VERSION_PREFIX}"
-  local EXPECTED_MACRO_LINE="#define BORINGSSL_PREFIX ${CRATE_PREFIX}"
-  local PREFIX_INCLUDE_PATH="${CRATE_DIR}"/generated-include/openssl/boringssl_prefix_symbols_asm.h
-  local EXPECTED_LINKS_LINE="links = \"${CRATE_PREFIX}\""
-
+  local CRATE_VERSION_PREFIX CRATE_PREFIX EXPECTED_LINKS_LINE
+  CRATE_VERSION_PREFIX=$(crate_version_prefix "${CRATE_DIR}")
+  CRATE_PREFIX="${PREFIX}_${CRATE_VERSION_PREFIX}"
+  EXPECTED_LINKS_LINE="links = \"${CRATE_PREFIX}\""
   if ! grep "${EXPECTED_LINKS_LINE}" "${CRATE_DIR}/Cargo.toml"; then
     echo
     echo ERROR: Expected 'links' line not found in: "${CRATE_DIR}/Cargo.toml"
@@ -49,10 +48,22 @@ function sanity_check_sys_crate {
     exit 1
   fi
 
+  local EXPECTED_MACRO_LINE PREFIX_INCLUDE_PATH
+  EXPECTED_MACRO_LINE="#define BORINGSSL_PREFIX ${CRATE_PREFIX}"
+  PREFIX_INCLUDE_PATH="${CRATE_DIR}"/generated-include/openssl/boringssl_prefix_symbols_asm.h
   if ! grep "${EXPECTED_MACRO_LINE}" "${PREFIX_INCLUDE_PATH}"; then
     echo
     echo ERROR: Expected prefix macro not found in: "${PREFIX_INCLUDE_PATH}"
     echo "${EXPECTED_MACRO_LINE}"
+    exit 1
+  fi
+
+  local COMMIT_HASH
+  COMMIT_HASH=$(git submodule status -- "${CRATE_DIR}"/aws-lc | sed -e 's/.\([0-9a-f]*\).*/\1/')
+  if ! grep "${COMMIT_HASH}" "${CRATE_DIR}/Cargo.toml"; then
+    echo
+    echo ERROR: Expected 'commit-hash' line not found in: "${CRATE_DIR}/Cargo.toml"
+    echo "${COMMIT_HASH}"
     exit 1
   fi
 

--- a/scripts/publish/_publish_tools.sh
+++ b/scripts/publish/_publish_tools.sh
@@ -24,6 +24,11 @@ function publish_options {
   done
 }
 
+# Finds the version of the crate based on current working directory
+function crate_version_prefix {
+  grep -E '^version =' ./Cargo.toml | sed -e 's/.*"\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)"/\1_\2_\3/'
+}
+
 function run_prepublish_checks {
   local SCRIPT_DIR
   SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)

--- a/scripts/publish/publish-aws-lc-fips-sys.sh
+++ b/scripts/publish/publish-aws-lc-fips-sys.sh
@@ -16,17 +16,7 @@ publish_options "$@"
 
 pushd "${CRATE_DIR}" &>/dev/null
 
-CRATE_VERSION_PREFIX=$(crate_version_prefix "${CRATE_DIR}")
-CRATE_PREFIX="aws_lc_fips_${CRATE_VERSION_PREFIX}"
-EXPECTED_MACRO_LINE="#define BORINGSSL_PREFIX ${CRATE_PREFIX}"
-PREFIX_INCLUDE_PATH="${CRATE_DIR}"/generated-include/openssl/boringssl_prefix_symbols_asm.h
-
-if ! grep "${EXPECTED_MACRO_LINE}" "${PREFIX_INCLUDE_PATH}"; then
-  echo
-  echo ERROR: Expected prefix macro not found in: "${PREFIX_INCLUDE_PATH}"
-  echo "${EXPECTED_MACRO_LINE}"
-  exit 1
-fi
+sanity_check_sys_crate "${CRATE_DIR}"
 
 cat << HERE > ./aws-lc/go.mod
 module boringssl.googlesource.com/boringssl

--- a/scripts/publish/publish-aws-lc-fips-sys.sh
+++ b/scripts/publish/publish-aws-lc-fips-sys.sh
@@ -7,8 +7,8 @@ set -e
 SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 PUBLISH=0
 REPO_ROOT=$(git rev-parse --show-toplevel)
-RELATIVE_CRATE_PATH=aws-lc-fips-sys
-CRATE_DIR="${REPO_ROOT}/${RELATIVE_CRATE_PATH}"
+CRATE_NAME=aws-lc-fips-sys
+CRATE_DIR="${REPO_ROOT}/${CRATE_NAME}"
 
 source "${SCRIPT_DIR}"/_publish_tools.sh
 
@@ -16,13 +16,25 @@ publish_options "$@"
 
 pushd "${CRATE_DIR}" &>/dev/null
 
+CRATE_VERSION_PREFIX=$(crate_version_prefix "${CRATE_DIR}")
+CRATE_PREFIX="aws_lc_fips_${CRATE_VERSION_PREFIX}"
+EXPECTED_MACRO_LINE="#define BORINGSSL_PREFIX ${CRATE_PREFIX}"
+PREFIX_INCLUDE_PATH="${CRATE_DIR}"/generated-include/openssl/boringssl_prefix_symbols_asm.h
+
+if ! grep "${EXPECTED_MACRO_LINE}" "${PREFIX_INCLUDE_PATH}"; then
+  echo
+  echo ERROR: Expected prefix macro not found in: "${PREFIX_INCLUDE_PATH}"
+  echo "${EXPECTED_MACRO_LINE}"
+  exit 1
+fi
+
 cat << HERE > ./aws-lc/go.mod
 module boringssl.googlesource.com/boringssl
 
 go 1.13
 HERE
 
-run_prepublish_checks -c "${RELATIVE_CRATE_PATH}"
-publish_crate "${RELATIVE_CRATE_PATH}" ${PUBLISH}
+run_prepublish_checks -c "${CRATE_NAME}"
+publish_crate "${CRATE_NAME}" ${PUBLISH}
 git --git-dir="${CRATE_DIR}/aws-lc/.git" restore go.mod
 popd &>/dev/null

--- a/scripts/publish/publish-aws-lc-sys.sh
+++ b/scripts/publish/publish-aws-lc-sys.sh
@@ -15,17 +15,7 @@ publish_options "$@"
 
 pushd "${CRATE_DIR}" &>/dev/null
 
-CRATE_VERSION_PREFIX=$(crate_version_prefix "${CRATE_DIR}")
-CRATE_PREFIX="aws_lc_${CRATE_VERSION_PREFIX}"
-EXPECTED_MACRO_LINE="#define BORINGSSL_PREFIX ${CRATE_PREFIX}"
-PREFIX_INCLUDE_PATH="${CRATE_DIR}"/generated-include/openssl/boringssl_prefix_symbols_asm.h
-
-if ! grep "${EXPECTED_MACRO_LINE}" "${PREFIX_INCLUDE_PATH}"; then
-  echo
-  echo ERROR: Expected prefix macro not found in: "${PREFIX_INCLUDE_PATH}"
-  echo "${EXPECTED_MACRO_LINE}"
-  exit 1
-fi
+sanity_check_sys_crate "${CRATE_DIR}"
 
 run_prepublish_checks -c "${CRATE_NAME}"
 publish_crate "${CRATE_NAME}" ${PUBLISH}

--- a/scripts/publish/publish-aws-lc-sys.sh
+++ b/scripts/publish/publish-aws-lc-sys.sh
@@ -7,14 +7,26 @@ set -e
 SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 PUBLISH=0
 REPO_ROOT=$(git rev-parse --show-toplevel)
-RELATIVE_CRATE_PATH=aws-lc-sys
-CRATE_DIR="${REPO_ROOT}/${RELATIVE_CRATE_PATH}"
+CRATE_NAME=aws-lc-sys
+CRATE_DIR="${REPO_ROOT}/${CRATE_NAME}"
 
 source "${SCRIPT_DIR}"/_publish_tools.sh
-
 publish_options "$@"
 
 pushd "${CRATE_DIR}" &>/dev/null
-run_prepublish_checks -c "${RELATIVE_CRATE_PATH}"
-publish_crate "${RELATIVE_CRATE_PATH}" ${PUBLISH}
+
+CRATE_VERSION_PREFIX=$(crate_version_prefix "${CRATE_DIR}")
+CRATE_PREFIX="aws_lc_${CRATE_VERSION_PREFIX}"
+EXPECTED_MACRO_LINE="#define BORINGSSL_PREFIX ${CRATE_PREFIX}"
+PREFIX_INCLUDE_PATH="${CRATE_DIR}"/generated-include/openssl/boringssl_prefix_symbols_asm.h
+
+if ! grep "${EXPECTED_MACRO_LINE}" "${PREFIX_INCLUDE_PATH}"; then
+  echo
+  echo ERROR: Expected prefix macro not found in: "${PREFIX_INCLUDE_PATH}"
+  echo "${EXPECTED_MACRO_LINE}"
+  exit 1
+fi
+
+run_prepublish_checks -c "${CRATE_NAME}"
+publish_crate "${CRATE_NAME}" ${PUBLISH}
 popd &>/dev/null


### PR DESCRIPTION
### Description of changes: 
* Add check to sys-crate publishing script to verify expected prefix.
* Fix how generation scripts check for macOS.
* Remove generation script expectation that we're on main.
* Other cleanup in generation scripts.

### Testing:
Tested on macos and linux hosts

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
