### PR TITLE
Include gcc linker scripts

### DIFF
--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -22,6 +22,7 @@ include = [
     "/aws-lc/**/*.go",
     "/aws-lc/go.mod",
     "/aws-lc/go.sum",
+    "/aws-lc/**/*.lds",
     "!/aws-lc/bindings/**",
     "!/aws-lc/docs/**",
     "!/aws-lc/fuzz/**",

--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -19,6 +19,7 @@ include = [
     "/aws-lc/**/CMakeLists.txt",
     "/aws-lc/**/*.cmake",
     "/aws-lc/**/*.errordata",
+    "/aws-lc/**/*.lds",
     "!/aws-lc/bindings/**",
     "!/aws-lc/docs/**",
     "!/aws-lc/fuzz/**",


### PR DESCRIPTION
### Description of changes: 
* Include [gcc linker script](https://github.com/aws/aws-lc/blob/main/crypto/fipsmodule/gcc_fips_shared.lds) in sys crates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
