### PR TITLE
Minor cleanup; clippy w/ no features

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -33,7 +33,7 @@ jobs:
         run: rustup override set ${{ steps.toolchain.outputs.name }}
 
       - name: Run cargo fmt
-        run : cargo fmt -- --check --verbose
+        run: cargo fmt -- --check --verbose
 
   clippy:
     runs-on: ubuntu-latest
@@ -41,10 +41,11 @@ jobs:
       fail-fast: false
       matrix:
         # By default, Clippy will lint he dependencies
-        crate_dir: ["aws-lc-rs"]
+        crate_dir: [ "aws-lc-rs" ]
         features:
           - "--features bindgen,unstable"
           - "--features bindgen,unstable,fips"
+          - "--no-default-features --features aws-lc-sys"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/aws-lc-rs/src/rsa/key.rs
+++ b/aws-lc-rs/src/rsa/key.rs
@@ -20,11 +20,13 @@ use crate::{
 
 #[cfg(feature = "fips")]
 use aws_lc::RSA_check_fips;
+#[cfg(feature = "ring-io")]
+use aws_lc::RSA_get0_n;
 use aws_lc::{
     EVP_DigestSignInit, EVP_PKEY_assign_RSA, EVP_PKEY_new, RSA_generate_key_ex,
-    RSA_generate_key_fips, RSA_get0_e, RSA_get0_n, RSA_get0_p, RSA_get0_q, RSA_new,
-    RSA_parse_private_key, RSA_parse_public_key, RSA_public_key_to_bytes, RSA_set0_key, RSA_size,
-    BIGNUM, EVP_PKEY, EVP_PKEY_CTX, RSA,
+    RSA_generate_key_fips, RSA_get0_e, RSA_get0_p, RSA_get0_q, RSA_new, RSA_parse_private_key,
+    RSA_parse_public_key, RSA_public_key_to_bytes, RSA_set0_key, RSA_size, BIGNUM, EVP_PKEY,
+    EVP_PKEY_CTX, RSA,
 };
 
 use mirai_annotations::verify_unreachable;

--- a/aws-lc-rs/tests/basic_aead_test.rs
+++ b/aws-lc-rs/tests/basic_aead_test.rs
@@ -119,7 +119,7 @@ fn test_chacha20_poly1305() {
         &from_hex("070000004041424344454647").unwrap(),
         "123456789abcdef",
     );
-    let mut in_out = from_hex("123456789abcdef0").unwrap();
+    let in_out = from_hex("123456789abcdef0").unwrap();
 
     #[cfg(feature = "alloc")]
     test_aead_separate_in_place(&config, &mut in_out).unwrap();

--- a/aws-lc-rs/tests/basic_aead_test.rs
+++ b/aws-lc-rs/tests/basic_aead_test.rs
@@ -120,10 +120,13 @@ fn test_chacha20_poly1305() {
         "123456789abcdef",
     );
     let in_out = from_hex("123456789abcdef0").unwrap();
+    test_aead_append_within(&config, &in_out).unwrap();
 
     #[cfg(feature = "alloc")]
-    test_aead_separate_in_place(&config, &mut in_out).unwrap();
-    test_aead_append_within(&config, &in_out).unwrap();
+    {
+        let mut in_out = in_out.clone();
+        test_aead_separate_in_place(&config, &mut in_out).unwrap();
+    }
 }
 
 fn test_aead_separate_in_place(


### PR DESCRIPTION
### Description of changes: 
* Minor cleanup of `use` and `mut`
* Also run clippy CI with `--no-default-features`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
