### PR TITLE
ENV vars for OPENSSL_NO_ASM

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -174,10 +174,12 @@ jobs:
         working-directory: ./aws-lc-rs
         run: cargo test ${{ matrix.args }} --lib --bins --tests --examples --target x86_64-unknown-linux-gnu --features asan
 
-  build-env-test:
+  build-env-static-test:
     if: github.repository_owner == 'aws'
-    name: aws-lc-rs build-env-test
+    name: aws-lc-rs build-env-static-test
     runs-on: ${{ matrix.os }}
+    env:
+      AWS_LC_SYS_STATIC: ${{ matrix.static }}
     strategy:
       fail-fast: false
       matrix:
@@ -192,10 +194,9 @@ jobs:
       - name: Set Rust toolchain override
         run: rustup override set ${{ steps.toolchain.outputs.name }}
       - name: Run cargo test
-        working-directory: ./aws-lc-rs
         # Doc-tests fail to link with dynamic build
         # See: https://github.com/rust-lang/cargo/issues/8531
-        run: AWS_LC_SYS_STATIC=${{ matrix.static }}  cargo test --tests
+        run: cargo test -p aws-lc-rs --tests
 
   build-env-external-bindgen-test:
     if: github.repository_owner == 'aws'
@@ -225,10 +226,12 @@ jobs:
       - name: Run cargo test
         run: cargo test --tests -p aws-lc-rs --no-default-features --features aws-lc-sys
 
-  build-env-fips-test:
+  build-env-fips-static-test:
     if: github.repository_owner == 'aws'
-    name: aws-lc-rs build-env-fips-test
+    name: aws-lc-rs build-env-fips-static-test
     runs-on: ${{ matrix.os }}
+    env:
+      AWS_LC_FIPS_SYS_STATIC: ${{ matrix.static }}
     strategy:
       fail-fast: false
       matrix:
@@ -246,11 +249,72 @@ jobs:
         with:
           go-version: '>=1.18'
       - name: Run cargo test
-        working-directory: ./aws-lc-rs
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.static != 1 }}
         # Doc-tests fail to link with dynamic build
         # See: https://github.com/rust-lang/cargo/issues/8531
-        run: AWS_LC_FIPS_SYS_STATIC=${{ matrix.static }} cargo test --tests --features fips
+        run: cargo test -p aws-lc-rs --tests --no-default-features --features fips
+
+  build-env-no-asm-test:
+    if: github.repository_owner == 'aws'
+    name: build-env-no-asm-test
+    runs-on: ${{ matrix.os }}
+    env:
+      AWS_LC_SYS_NO_ASM: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-12, macos-13-xlarge, windows-latest ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - uses: dtolnay/rust-toolchain@stable
+        id: toolchain
+      - name: Set Rust toolchain override
+        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Run cargo test
+        run: cargo test -p aws-lc-rs
+      - name: Release build
+        run: |
+          cargo build -p aws-lc-rs --release
+          if [[ $? -eq 0 ]]; then
+            exit 1
+          else
+            exit 0
+          fi
+
+  build-env-fips-no-asm-test:
+    if: github.repository_owner == 'aws'
+    name: aws-lc-rs build-env-fips-no-asm-test
+    runs-on: ${{ matrix.os }}
+    env:
+      AWS_LC_FIPS_SYS_NO_ASM: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-12, macos-13-xlarge, windows-latest ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - uses: dtolnay/rust-toolchain@stable
+        id: toolchain
+      - name: Set Rust toolchain override
+        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.18'
+      - name: Run cargo test
+        if: ${{ matrix.os == 'ubuntu-latest' || matrix.static != 1 }}
+        run: cargo test -p aws-lc-rs --no-default-features --features fips
+      - name: Release build
+        run: |
+          cargo build -p aws-lc-rs --release --no-default-features --features fips
+          if [[ $? -eq 0 ]]; then
+            exit 1
+          else
+            exit 0
+          fi
 
   build-env-fips-external-bindgen-test:
     if: github.repository_owner == 'aws'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -190,9 +190,6 @@ jobs:
         with:
           submodules: 'recursive'
       - uses: dtolnay/rust-toolchain@stable
-        id: toolchain
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
       - name: Run cargo test
         # Doc-tests fail to link with dynamic build
         # See: https://github.com/rust-lang/cargo/issues/8531
@@ -242,9 +239,8 @@ jobs:
         with:
           submodules: 'recursive'
       - uses: dtolnay/rust-toolchain@stable
-        id: toolchain
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install ninja-build tool
+        uses: seanmiddleditch/gha-setup-ninja@v4
       - uses: actions/setup-go@v4
         with:
           go-version: '>=1.18'
@@ -269,19 +265,25 @@ jobs:
         with:
           submodules: 'recursive'
       - uses: dtolnay/rust-toolchain@stable
-        id: toolchain
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
       - name: Run cargo test
         run: cargo test -p aws-lc-rs
       - name: Release build
+        if: ${{ matrix.os != 'windows-latest' }}
         run: |
-          cargo build -p aws-lc-rs --release
-          if [[ $? -eq 0 ]]; then
+          if cargo build -p aws-lc-rs --release; then
             exit 1
           else
             exit 0
           fi
+      - name: Release build
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: pwsh
+        run: |
+          if (cargo build -p aws-lc-rs --release) {
+            exit 1
+          } else {
+            exit 0
+          }
 
   build-env-fips-no-asm-test:
     if: github.repository_owner == 'aws'
@@ -298,23 +300,30 @@ jobs:
         with:
           submodules: 'recursive'
       - uses: dtolnay/rust-toolchain@stable
-        id: toolchain
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install ninja-build tool
+        uses: seanmiddleditch/gha-setup-ninja@v4
       - uses: actions/setup-go@v4
         with:
           go-version: '>=1.18'
       - name: Run cargo test
-        if: ${{ matrix.os == 'ubuntu-latest' || matrix.static != 1 }}
-        run: cargo test -p aws-lc-rs --no-default-features --features fips
+        run: cargo test -p aws-lc-rs --tests --no-default-features --features fips
       - name: Release build
+        if: ${{ matrix.os != 'windows-latest' }}
         run: |
-          cargo build -p aws-lc-rs --release --no-default-features --features fips
-          if [[ $? -eq 0 ]]; then
+          if cargo build -p aws-lc-rs --release --no-default-features --features fips; then
             exit 1
           else
             exit 0
           fi
+      - name: Release build
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: pwsh
+        run: |
+          if (cargo build -p aws-lc-rs --release --no-default-features --features fips) {
+            exit 1
+          } else {
+            exit 0
+          }
 
   build-env-fips-external-bindgen-test:
     if: github.repository_owner == 'aws'

--- a/aws-lc-fips-sys/builder/main.rs
+++ b/aws-lc-fips-sys/builder/main.rs
@@ -275,7 +275,7 @@ static mut PREGENERATED: bool = false;
 static mut AWS_LC_FIPS_SYS_NO_PREFIX: bool = false;
 static mut AWS_LC_FIPS_SYS_INTERNAL_BINDGEN: bool = false;
 static mut AWS_LC_FIPS_SYS_EXTERNAL_BINDGEN: bool = false;
-
+static mut AWS_LC_FIPS_SYS_NO_ASM: bool = false;
 fn initialize() {
     unsafe {
         AWS_LC_FIPS_SYS_NO_PREFIX = env_var_to_bool("AWS_LC_FIPS_SYS_NO_PREFIX").unwrap_or(false);
@@ -283,6 +283,7 @@ fn initialize() {
             env_var_to_bool("AWS_LC_FIPS_SYS_INTERNAL_BINDGEN").unwrap_or(false);
         AWS_LC_FIPS_SYS_EXTERNAL_BINDGEN =
             env_var_to_bool("AWS_LC_FIPS_SYS_EXTERNAL_BINDGEN").unwrap_or(false);
+        AWS_LC_FIPS_SYS_NO_ASM = env_var_to_bool("AWS_LC_FIPS_SYS_NO_ASM").unwrap_or(false);
     }
 
     if !is_external_bindgen() && (is_internal_bindgen() || !has_bindgen_feature()) {
@@ -323,6 +324,10 @@ fn is_internal_bindgen() -> bool {
 
 fn is_external_bindgen() -> bool {
     unsafe { AWS_LC_FIPS_SYS_EXTERNAL_BINDGEN }
+}
+
+fn is_no_asm() -> bool {
+    unsafe { AWS_LC_FIPS_SYS_NO_ASM }
 }
 
 fn has_bindgen_feature() -> bool {

--- a/aws-lc-sys/builder/main.rs
+++ b/aws-lc-sys/builder/main.rs
@@ -283,6 +283,10 @@ fn get_builder(prefix: &Option<String>, manifest_dir: &Path, out_dir: &Path) -> 
         };
         builder.check_dependencies().unwrap();
         return builder;
+    } else if is_no_asm() {
+        let builder = cmake_builder_builder();
+        builder.check_dependencies().unwrap();
+        return builder;
     } else if !is_bindgen_required() {
         let cc_builder = cc_builder_builder();
         if cc_builder.check_dependencies().is_ok() {
@@ -303,6 +307,7 @@ static mut PREGENERATED: bool = false;
 static mut AWS_LC_SYS_NO_PREFIX: bool = false;
 static mut AWS_LC_SYS_INTERNAL_BINDGEN: bool = false;
 static mut AWS_LC_SYS_EXTERNAL_BINDGEN: bool = false;
+static mut AWS_LC_SYS_NO_ASM: bool = false;
 
 fn initialize() {
     unsafe {
@@ -311,6 +316,7 @@ fn initialize() {
             env_var_to_bool("AWS_LC_SYS_INTERNAL_BINDGEN").unwrap_or(false);
         AWS_LC_SYS_EXTERNAL_BINDGEN =
             env_var_to_bool("AWS_LC_SYS_EXTERNAL_BINDGEN").unwrap_or(false);
+        AWS_LC_SYS_NO_ASM = env_var_to_bool("AWS_LC_SYS_NO_ASM").unwrap_or(false);
     }
 
     if !is_external_bindgen() && (is_internal_bindgen() || !has_bindgen_feature()) {
@@ -352,6 +358,10 @@ fn is_internal_bindgen() -> bool {
 
 fn is_external_bindgen() -> bool {
     unsafe { AWS_LC_SYS_EXTERNAL_BINDGEN }
+}
+
+fn is_no_asm() -> bool {
+    unsafe { AWS_LC_SYS_NO_ASM }
 }
 
 fn has_bindgen_feature() -> bool {


### PR DESCRIPTION
### Issues:
* Provides workaround for #376 (or for other platforms where AWS-LC assembly fails to build)

### Description of changes: 
* AWS-LC contains optimized assembly language implementations for many primitive cryptographic operations. As a fall-back, these operations also have a C-implementation provided.
* For most platforms, CMake correctly detects whether/which assembly files should be built. However, CMake's detection is sometimes inadequate or the build environment lacks an assembler (such as NASM), and the `OPENSSL_NO_ASM` flag must be passed to avoid build failures.
* The `OPENSSL_NO_ASM` flag may also be useful for debugging failing cryptographic operations.

### Call-outs:
* The C-implementations are significantly slower than their assembly-language counterparts.
* The `OPENSSL_NO_ASM` flag is only allowed for un-optimized/debug builds.

### Testing:
* Updated CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
