### PR TITLE
Build scripts send cargo cmds to stdout

### DIFF
--- a/aws-lc-fips-sys/builder/main.rs
+++ b/aws-lc-fips-sys/builder/main.rs
@@ -61,7 +61,7 @@ fn cargo_env<N: AsRef<str>>(name: N) -> String {
 }
 fn option_env<N: AsRef<str>>(name: N) -> Option<String> {
     let name = name.as_ref();
-    eprintln!("cargo:rerun-if-env-changed={name}");
+    println!("cargo:rerun-if-env-changed={name}");
     std::env::var(name).ok()
 }
 

--- a/aws-lc-sys/builder/main.rs
+++ b/aws-lc-sys/builder/main.rs
@@ -62,7 +62,7 @@ fn cargo_env<N: AsRef<str>>(name: N) -> String {
 }
 fn option_env<N: AsRef<str>>(name: N) -> Option<String> {
     let name = name.as_ref();
-    eprintln!("cargo:rerun-if-env-changed={name}");
+    println!("cargo:rerun-if-env-changed={name}");
     std::env::var(name).ok()
 }
 


### PR DESCRIPTION
### Description of changes: 
* We are sending `cargo:rerun-if-env-changed` to stderr, but cargo commands should be [sent to stdout](https://doc.rust-lang.org/cargo/reference/build-scripts.html#life-cycle-of-a-build-script).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
