### PR TITLE
Update aws-lc-fips-sys to v0.12.7

### DIFF
--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-lc-fips-sys"
 description = "AWS-LC is a general-purpose cryptographic library maintained by the AWS Cryptography team for AWS and their customers. This is the FIPS validated version of AWS-LC."
-version = "0.12.6"
+version = "0.12.7"
 links = "aws_lc_fips_0_12_6"
 authors = ["AWS-LC"]
 edition = "2021"

--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aws-lc-fips-sys"
 description = "AWS-LC is a general-purpose cryptographic library maintained by the AWS Cryptography team for AWS and their customers. This is the FIPS validated version of AWS-LC."
 version = "0.12.7"
-links = "aws_lc_fips_0_12_6"
+links = "aws_lc_fips_0_12_7"
 authors = ["AWS-LC"]
 edition = "2021"
 repository = "https://github.com/aws/aws-lc-rs"

--- a/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols.h
+++ b/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols.h
@@ -17,7 +17,7 @@
 #define BORINGSSL_PREFIX_SYMBOLS_H	
 
 #ifndef BORINGSSL_PREFIX
-#define BORINGSSL_PREFIX aws_lc_fips_0_12_6
+#define BORINGSSL_PREFIX aws_lc_fips_0_12_7
 #endif // BORINGSSL_PREFIX
 
 

--- a/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols_asm.h
+++ b/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols_asm.h
@@ -20,7 +20,7 @@
 #define BORINGSSL_PREFIX_SYMBOLS_ASM_H
 
 #ifndef BORINGSSL_PREFIX
-#define BORINGSSL_PREFIX aws_lc_fips_0_12_6
+#define BORINGSSL_PREFIX aws_lc_fips_0_12_7
 #endif // BORINGSSL_PREFIX
 
 // On iOS and macOS, we need to treat assembly symbols differently from other

--- a/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols_nasm.inc
+++ b/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols_nasm.inc
@@ -17,7 +17,7 @@
 %define BORINGSSL_PREFIX_SYMBOLS_NASM_INC
 
 %ifndef BORINGSSL_PREFIX
-%define BORINGSSL_PREFIX aws_lc_fips_0_12_6
+%define BORINGSSL_PREFIX aws_lc_fips_0_12_7
 %endif ; BORINGSSL_PREFIX
 
 ; 32-bit Windows adds underscores to C functions, while 64-bit Windows does not.

--- a/aws-lc-fips-sys/src/aarch64_apple_darwin_crypto.rs
+++ b/aws-lc-fips-sys/src/aarch64_apple_darwin_crypto.rs
@@ -4551,38 +4551,38 @@ pub type X509_STORE = x509_store_st;
 pub type X509_TRUST = x509_trust_st;
 pub type OPENSSL_BLOCK = *mut ::std::os::raw::c_void;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_free_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_get_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_get_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4591,18 +4591,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4611,18 +4611,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_last_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4631,7 +4631,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_error_string_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -4639,11 +4639,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_lib_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_reason_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -4654,30 +4654,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_print_errors_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_print_errors_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_clear_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_set_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_pop_to_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_get_next_error_library"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -4716,30 +4716,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_remove_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_remove_thread_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_func_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_clear_system_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_put_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -4749,15 +4749,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_add_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_add_error_dataf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_set_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -4821,7 +4821,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_set_encrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4829,7 +4829,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_set_decrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4837,15 +4837,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4857,7 +4857,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4866,7 +4866,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4877,7 +4877,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4888,7 +4888,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4900,7 +4900,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_wrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4910,7 +4910,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_unwrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4920,7 +4920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_wrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4931,7 +4931,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5152,27 +5152,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_grow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_append"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5180,29 +5180,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5210,7 +5210,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5342,27 +5342,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_new_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -5370,11 +5370,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_pop_free_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -5382,22 +5382,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_insert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_delete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_delete_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_delete_if"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -5406,7 +5406,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_find"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -5415,35 +5415,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_shift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_is_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_set_cmp_func"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_deep_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -5453,7 +5453,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_pop_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -5513,7 +5513,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -5569,19 +5569,19 @@ impl Default for crypto_ex_data_st {
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_num_locks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5594,7 +5594,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5608,7 +5608,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5619,29 +5619,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -5697,7 +5697,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5708,7 +5708,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5721,7 +5721,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5733,7 +5733,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -5742,7 +5742,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5753,7 +5753,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -5780,23 +5780,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_vfree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -5804,7 +5804,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -5812,7 +5812,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5820,7 +5820,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_write_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5828,15 +5828,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5845,7 +5845,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5853,7 +5853,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_int_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5862,67 +5862,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_eof"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_should_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_should_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_should_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_should_io_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_retry_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_retry_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_method_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -5948,7 +5948,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5956,68 +5956,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_ctrl_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_wpending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_close"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_number_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_number_written"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_callback_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_next"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_free_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_find_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_copy_next_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_printf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6025,7 +6025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_indent"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6033,7 +6033,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_hexdump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6042,11 +6042,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_print_errors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_read_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -6055,15 +6055,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_s_mem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_mem_contents"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -6071,11 +6071,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -6083,22 +6083,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_s_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -6106,30 +6106,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_s_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -6137,89 +6137,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_read_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_write_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_append_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_rw_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_tell"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_seek"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_s_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_s_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_conn_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_nbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_do_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_bio_pair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -6228,34 +6228,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_shutdown_wr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -6264,13 +6264,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -6279,13 +6279,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -6298,7 +6298,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -6311,7 +6311,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -6324,7 +6324,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6336,7 +6336,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -6350,7 +6350,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6363,7 +6363,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -6376,7 +6376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6388,23 +6388,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -6414,7 +6414,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -6422,37 +6422,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_f_base64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_retry_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -6464,7 +6464,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6834,193 +6834,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_value_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_set_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_set_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_set_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bin2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2bin"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_le2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2le_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2bin_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2hex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_hex2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2dec"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_dec2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_asc2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_marshal_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_CTX_start"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_CTX_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_CTX_end"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_uadd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_add_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_usub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_sub_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7029,15 +7029,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mul_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_div"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7047,11 +7047,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_div_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -7059,47 +7059,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_cmp_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_ucmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_equal_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_abs_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7107,11 +7107,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_rshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7119,43 +7119,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_rshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_clear_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_bit_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mask_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_nnmod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_nnmod"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -7164,7 +7164,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7174,7 +7174,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_add_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7183,7 +7183,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7193,7 +7193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_sub_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7202,7 +7202,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7212,7 +7212,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7221,7 +7221,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7231,7 +7231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7240,7 +7240,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7249,7 +7249,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7257,7 +7257,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7266,7 +7266,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7275,7 +7275,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_pseudo_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7284,11 +7284,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_rand_range_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -7296,7 +7296,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -7356,15 +7356,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_GENCB_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_GENCB_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_GENCB_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -7378,7 +7378,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_GENCB_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -7386,11 +7386,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_generate_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7405,7 +7405,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -7415,7 +7415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -7426,7 +7426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7436,7 +7436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7445,7 +7445,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_gcd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7454,7 +7454,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_inverse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7463,7 +7463,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7473,7 +7473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7483,23 +7483,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_to_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7508,7 +7508,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_from_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7517,7 +7517,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7527,7 +7527,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7536,7 +7536,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7546,7 +7546,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_exp_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7557,7 +7557,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7568,15 +7568,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2mpi"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mpi2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -7587,7 +7587,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -7600,11 +7600,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -7612,7 +7612,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2binpad"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -7620,7 +7620,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_secure_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -7768,15 +7768,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_num_bits_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_tag2bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_tag2str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -7800,15 +7800,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7817,7 +7817,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -7825,14 +7825,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -7840,7 +7840,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -7848,7 +7848,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -7856,7 +7856,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -7864,14 +7864,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_unpack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_pack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -7879,7 +7879,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7887,22 +7887,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -7978,54 +7978,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8033,7 +8033,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8041,79 +8041,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -8121,7 +8121,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -8129,7 +8129,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -8137,7 +8137,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -8145,7 +8145,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -8153,7 +8153,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -8161,7 +8161,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -8169,7 +8169,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -8177,7 +8177,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -8185,117 +8185,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -8303,14 +8303,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8320,7 +8320,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8332,7 +8332,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -8342,7 +8342,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -8352,15 +8352,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8368,26 +8368,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8395,23 +8395,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8419,14 +8419,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8434,25 +8434,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -8460,7 +8460,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -8468,14 +8468,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -8504,19 +8504,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -8524,11 +8524,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -8536,54 +8536,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -8591,59 +8591,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -8651,23 +8651,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, t: time_t) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         t: time_t,
@@ -8676,26 +8676,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -8703,29 +8703,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
@@ -8734,22 +8734,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -8757,15 +8757,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_diff"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -8774,11 +8774,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, t: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         t: time_t,
@@ -8787,41 +8787,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_NULL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_NULL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -8829,11 +8829,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_NULL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8858,7 +8858,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -8868,11 +8868,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8880,11 +8880,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8892,7 +8892,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9226,15 +9226,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -9242,19 +9242,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ANY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9262,7 +9262,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9270,12 +9270,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9283,14 +9283,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9298,33 +9298,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -9332,7 +9332,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -9340,19 +9340,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -9360,7 +9360,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -9368,7 +9368,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -9378,7 +9378,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_put_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -9388,11 +9388,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_put_eoc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_object_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -9400,33 +9400,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9434,34 +9434,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -10071,7 +10071,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10096,19 +10096,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodeBase64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -10118,19 +10118,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10140,7 +10140,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10148,11 +10148,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10162,7 +10162,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10170,7 +10170,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -10380,11 +10380,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BLAKE2B256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BLAKE2B256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -10392,11 +10392,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BLAKE2B256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BLAKE2B256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -10451,19 +10451,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BF_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BF_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BF_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BF_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10472,7 +10472,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BF_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10533,23 +10533,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_skip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_stow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -10557,82 +10557,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_mem_equal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_last_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_copy_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_until_first"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10640,7 +10640,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10648,11 +10648,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_any_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10660,7 +10660,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10669,7 +10669,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10680,22 +10680,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10704,7 +10704,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10713,7 +10713,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -10722,7 +10722,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -10731,33 +10731,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10765,7 +10765,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_parse_utc_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10773,7 +10773,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -11080,23 +11080,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_init_fixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11104,40 +11104,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -11145,15 +11145,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_zeros"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_space"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11161,55 +11161,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_did_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_discard_child"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -11217,11 +11217,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -11229,7 +11229,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -11237,11 +11237,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -11249,11 +11249,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -11264,114 +11264,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_rc4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ede"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ede3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_xts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_enc_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_rc2_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11382,7 +11382,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11392,7 +11392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11402,7 +11402,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11412,7 +11412,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11420,7 +11420,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11430,7 +11430,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11438,7 +11438,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CipherUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11448,7 +11448,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11456,47 +11456,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -11505,45 +11505,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_BytesToKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -11556,23 +11556,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CipherInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11582,7 +11582,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11591,7 +11591,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11600,7 +11600,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CipherFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11608,7 +11608,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11616,7 +11616,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11624,7 +11624,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_Cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11633,118 +11633,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_bf_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_bf_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_bf_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_cast5_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_cast5_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -11981,7 +11981,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_CMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -11991,19 +11991,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12013,15 +12013,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_Reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -12116,15 +12116,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_load"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -12132,7 +12132,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_load_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -12140,14 +12140,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_get_section"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_get_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -12155,7 +12155,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CONF_modules_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -12163,23 +12163,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CONF_modules_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_no_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA1_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA1_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12187,15 +12187,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA1_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA1_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12282,11 +12282,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA224_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA224_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12294,19 +12294,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA224_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12314,19 +12314,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -12424,11 +12424,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA384_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA384_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12436,19 +12436,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA384_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12456,15 +12456,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12562,11 +12562,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12574,34 +12574,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_memcmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -12609,34 +12609,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_hash32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strhash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_tolower"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -12644,7 +12644,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_snprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12653,7 +12653,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_vsnprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12662,7 +12662,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12670,7 +12670,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_asprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12678,21 +12678,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12700,7 +12700,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12708,7 +12708,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -12716,7 +12716,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -12725,7 +12725,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -12733,11 +12733,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -12764,51 +12764,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_secure_used"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_library_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_has_asm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BORINGSSL_self_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_FIPS_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -12818,70 +12818,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_FIPS_read_counter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OpenSSL_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSLeay_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OpenSSL_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_awslc_api_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_FIPS_mode_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X25519"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -12889,15 +12889,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X25519_public_from_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ED25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ED25519_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -12906,7 +12906,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ED25519_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -12915,7 +12915,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -12926,7 +12926,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -12936,11 +12936,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -12951,7 +12951,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SPAKE2_process_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13024,15 +13024,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_set_odd_parity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13041,7 +13041,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13052,7 +13052,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13063,7 +13063,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13076,7 +13076,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13088,7 +13088,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_decrypt3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13097,7 +13097,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_encrypt3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13106,43 +13106,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13150,7 +13150,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13158,7 +13158,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13167,7 +13167,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13176,40 +13176,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_set_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13218,11 +13218,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_compute_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13230,7 +13230,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_compute_key_hashed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13241,19 +13241,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_check_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13261,19 +13261,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DHparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_generate_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13288,7 +13288,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13296,14 +13296,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13311,114 +13311,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get_2048_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_md4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_md5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_ripemd160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha3_224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha3_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha3_384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha3_512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_blake2b256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_md5_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_get_digestbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13426,11 +13426,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13438,7 +13438,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13446,7 +13446,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13454,7 +13454,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_Digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13465,75 +13465,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_add_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_get_digestbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13541,19 +13541,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -13645,15 +13645,15 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -13661,11 +13661,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -13673,15 +13673,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_METHOD_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_METHOD_unref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -13727,43 +13727,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -13771,7 +13771,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -13780,7 +13780,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -13788,7 +13788,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -13797,7 +13797,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -13809,11 +13809,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSAparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13867,28 +13867,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -13897,7 +13897,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_do_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13907,7 +13907,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13918,7 +13918,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13929,7 +13929,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13940,47 +13940,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_dup_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -13990,7 +13990,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -13998,14 +13998,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14013,11 +14013,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14025,11 +14025,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14037,11 +14037,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14049,7 +14049,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14205,19 +14205,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14225,19 +14225,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14245,7 +14245,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14255,53 +14255,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_curve_nid2nist"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_curve_nist2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14309,7 +14309,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14318,7 +14318,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14328,7 +14328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14338,7 +14338,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14348,7 +14348,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14358,7 +14358,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_point2oct"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14369,7 +14369,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14379,7 +14379,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_oct2point"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14389,7 +14389,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14399,7 +14399,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14409,7 +14409,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_dbl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14418,7 +14418,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_invert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14426,7 +14426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14437,7 +14437,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14446,7 +14446,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14455,7 +14455,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14463,11 +14463,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14477,15 +14477,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_method_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -14539,92 +14539,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_get_builtin_curves"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get0_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -14632,7 +14632,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_key2buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -14641,15 +14641,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -14657,11 +14657,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -14669,22 +14669,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14694,7 +14694,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14702,7 +14702,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14824,11 +14824,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14836,11 +14836,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14848,11 +14848,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_o2i_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14860,14 +14860,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2o_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -14884,7 +14884,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -14893,7 +14893,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14904,7 +14904,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14915,7 +14915,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -14969,23 +14969,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -14993,7 +14993,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15001,7 +15001,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15009,7 +15009,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15018,19 +15018,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15038,11 +15038,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15052,7 +15052,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15060,83 +15060,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15274,11 +15274,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15287,11 +15287,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15302,11 +15302,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15321,7 +15321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15336,7 +15336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15354,7 +15354,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15369,66 +15369,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15439,7 +15439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15447,7 +15447,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15456,7 +15456,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15464,102 +15464,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_assign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -15567,40 +15567,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15609,7 +15609,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15618,7 +15618,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15626,7 +15626,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15634,7 +15634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestSignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15644,7 +15644,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15652,7 +15652,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15660,7 +15660,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestSign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15670,7 +15670,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15680,7 +15680,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15688,7 +15688,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15696,7 +15696,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestVerify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15706,7 +15706,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_SignInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15714,11 +15714,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_SignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_SignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15726,7 +15726,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_SignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -15735,7 +15735,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15743,11 +15743,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_VerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15755,7 +15755,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_VerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15764,7 +15764,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15773,7 +15773,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15782,7 +15782,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15791,7 +15791,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15804,7 +15804,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15816,7 +15816,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15831,31 +15831,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -15865,11 +15865,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -15879,11 +15879,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15893,11 +15893,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15907,11 +15907,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15921,18 +15921,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_derive"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -15940,18 +15940,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -15961,7 +15961,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -15971,102 +15971,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16074,28 +16074,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16103,7 +16103,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16111,7 +16111,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16121,31 +16121,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16159,7 +16159,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16173,15 +16173,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16190,7 +16190,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16198,7 +16198,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16207,22 +16207,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16230,40 +16230,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16271,11 +16271,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16283,11 +16283,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16295,11 +16295,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16307,14 +16307,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -16488,7 +16488,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HKDF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16502,7 +16502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HKDF_extract"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16514,7 +16514,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HKDF_expand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -16526,11 +16526,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD5_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD5_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16538,15 +16538,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD5_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD5_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -16633,7 +16633,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -16645,27 +16645,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_Init_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16675,7 +16675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -16683,7 +16683,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16691,23 +16691,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16716,7 +16716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -16892,82 +16892,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -16976,18 +16976,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -16996,7 +16996,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17005,23 +17005,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17037,7 +17037,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17055,7 +17055,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17068,7 +17068,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17081,7 +17081,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17094,7 +17094,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17104,19 +17104,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17375,7 +17375,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HRSS_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17383,7 +17383,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HRSS_encap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17392,7 +17392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HRSS_decap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17401,22 +17401,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HRSS_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD4_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD4_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17424,15 +17424,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD4_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD4_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17519,66 +17519,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_obj2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_cbs2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_sn2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_ln2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_txt2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_nid2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_nid2sn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_nid2ln"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_nid2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_txt2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_obj2txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -17587,7 +17587,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -17595,7 +17595,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -17603,7 +17603,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -17684,7 +17684,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -17703,7 +17703,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -17711,47 +17711,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_get_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18045,51 +18045,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18115,15 +18115,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18131,18 +18131,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18150,79 +18150,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_dmp1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_dmq1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_iqmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18231,11 +18231,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18244,7 +18244,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18253,12 +18253,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_set0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_set0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18267,7 +18267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_generate_key_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18276,7 +18276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18284,7 +18284,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18296,7 +18296,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18308,7 +18308,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_public_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -18318,7 +18318,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_private_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -18328,7 +18328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18339,7 +18339,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18353,7 +18353,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_sign_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18365,7 +18365,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18376,7 +18376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -18389,7 +18389,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_verify_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18401,7 +18401,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_private_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -18411,7 +18411,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_public_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -18421,31 +18421,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSAPublicKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18456,7 +18456,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18467,7 +18467,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -18480,7 +18480,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -18491,19 +18491,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18511,19 +18511,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18531,7 +18531,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -18541,7 +18541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -18549,26 +18549,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_blinding_on"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -18577,7 +18577,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18585,11 +18585,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18597,11 +18597,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18611,7 +18611,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18621,7 +18621,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -18632,7 +18632,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -18640,7 +18640,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_pss_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -19141,27 +19141,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_chain_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19169,51 +19169,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_parse_from_buffer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_uids"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19226,15 +19226,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19242,7 +19242,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19250,7 +19250,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19258,15 +19258,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19274,68 +19274,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set1_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set1_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_getm_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_getm_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19343,7 +19343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19351,25 +19351,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19377,14 +19377,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -19392,7 +19392,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_alias_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -19400,7 +19400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_keyid_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -19408,14 +19408,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_alias_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_keyid_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -19437,23 +19437,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19461,23 +19461,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -19486,19 +19486,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19506,7 +19506,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -19514,7 +19514,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -19522,11 +19522,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19534,55 +19534,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -19590,7 +19590,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -19598,25 +19598,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -19624,19 +19624,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -19644,23 +19644,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19668,33 +19668,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -19702,22 +19702,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -19767,19 +19767,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -19787,15 +19787,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get0_der"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -19803,15 +19803,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_entry_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19819,7 +19819,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19827,21 +19827,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_add_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -19850,7 +19850,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19862,7 +19862,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19874,7 +19874,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -19886,19 +19886,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -19906,33 +19906,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -19941,11 +19941,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -19955,7 +19955,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -19965,7 +19965,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -19975,19 +19975,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -19995,18 +19995,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20015,7 +20015,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20024,33 +20024,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20074,11 +20074,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20086,18 +20086,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20105,7 +20105,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20113,7 +20113,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20121,21 +20121,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -20164,23 +20164,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -20188,11 +20188,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -20201,7 +20201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -20210,15 +20210,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_signature_dump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -20226,7 +20226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_signature_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -20234,7 +20234,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_pubkey_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20243,7 +20243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20252,7 +20252,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -20261,7 +20261,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -20270,7 +20270,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -20279,259 +20279,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -20539,11 +20539,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_find_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20553,7 +20553,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -20561,14 +20561,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20578,7 +20578,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -20586,42 +20586,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20630,7 +20630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -21203,11 +21203,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_pathlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -21215,7 +21215,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_SIG_getm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -21223,54 +21223,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21278,23 +21278,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_cmp_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_cmp_current_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_time_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -21302,7 +21302,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_time_adj_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -21311,44 +21311,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_gmtime_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_cert_area"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_private_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21356,34 +21356,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21391,26 +21391,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_SIG_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21418,18 +21418,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21437,38 +21437,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_add1_trust_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_add1_reject_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_trust_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_reject_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21476,25 +21476,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21502,7 +21502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21510,23 +21510,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21534,26 +21534,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21561,26 +21561,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_oneline"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -21588,7 +21588,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -21598,7 +21598,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -21608,7 +21608,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -21618,7 +21618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21630,7 +21630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21641,15 +21641,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -21657,18 +21657,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21676,7 +21676,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21684,28 +21684,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21715,7 +21715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21725,7 +21725,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -21735,37 +21735,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_diff"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -21775,66 +21775,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_issuer_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_subject_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_subject_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_match"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -21843,19 +21843,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -21864,7 +21864,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -21872,7 +21872,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -21881,7 +21881,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -21890,15 +21890,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -21907,11 +21907,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -21920,7 +21920,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -21930,7 +21930,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21939,7 +21939,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21949,11 +21949,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21961,7 +21961,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -21969,7 +21969,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -21977,21 +21977,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -21999,7 +21999,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22008,7 +22008,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22018,11 +22018,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_get_attr_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22030,7 +22030,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22038,28 +22038,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_get_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_delete_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_add1_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22069,7 +22069,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22079,7 +22079,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22089,7 +22089,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22099,7 +22099,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22109,7 +22109,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22119,14 +22119,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -22135,7 +22135,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -22144,34 +22144,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_verify_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22179,26 +22179,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -22209,7 +22209,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -22219,11 +22219,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -22231,19 +22231,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -22260,19 +22260,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22359,15 +22359,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22375,14 +22375,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -22501,18 +22501,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22520,7 +22520,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22528,202 +22528,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set1_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -22731,15 +22731,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -22748,50 +22748,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_add_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_add_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -22800,7 +22800,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -22810,7 +22810,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_load_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22818,7 +22818,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_load_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22826,7 +22826,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22834,19 +22834,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -22855,11 +22855,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_load_locations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -22867,81 +22867,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -22950,11 +22950,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -22962,7 +22962,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -22974,105 +22974,105 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23080,7 +23080,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23088,20 +23088,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -23109,7 +23109,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -23117,42 +23117,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -23164,14 +23164,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_do_header"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -23181,7 +23181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23191,7 +23191,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -23201,7 +23201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -23213,7 +23213,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23224,7 +23224,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23238,7 +23238,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -23247,7 +23247,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23257,7 +23257,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -23267,7 +23267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_ASN1_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23278,7 +23278,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_ASN1_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23292,7 +23292,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -23301,7 +23301,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_def_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -23310,11 +23310,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_proc_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_dek_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -23323,7 +23323,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23332,7 +23332,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23341,15 +23341,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23358,7 +23358,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23367,15 +23367,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -23384,7 +23384,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -23393,23 +23393,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -23418,7 +23418,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -23427,15 +23427,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -23444,7 +23444,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -23453,15 +23453,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -23470,7 +23470,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -23479,15 +23479,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23496,7 +23496,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23505,21 +23505,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23528,7 +23528,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23537,7 +23537,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -23549,7 +23549,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -23561,7 +23561,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23570,7 +23570,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23579,15 +23579,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23596,7 +23596,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23605,15 +23605,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23622,7 +23622,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23631,7 +23631,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -23643,7 +23643,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -23655,7 +23655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23664,7 +23664,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23673,15 +23673,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23690,7 +23690,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23699,15 +23699,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23716,7 +23716,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23725,7 +23725,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -23737,7 +23737,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -23749,7 +23749,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23758,7 +23758,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23767,15 +23767,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -23784,7 +23784,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -23793,15 +23793,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23810,7 +23810,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23819,7 +23819,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23831,7 +23831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23843,7 +23843,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23852,7 +23852,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23861,15 +23861,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23881,7 +23881,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -23893,7 +23893,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23905,7 +23905,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23917,7 +23917,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23926,7 +23926,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23938,7 +23938,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23950,7 +23950,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23962,7 +23962,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23971,7 +23971,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23983,7 +23983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -23996,7 +23996,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -24010,7 +24010,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -24018,7 +24018,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -24026,7 +24026,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -24035,11 +24035,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_PBE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -24047,27 +24047,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24077,7 +24077,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_verify_mac"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24085,7 +24085,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -24100,74 +24100,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_file_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_egd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_poll"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24268,19 +24268,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_OpenSSL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_get_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_set_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24345,11 +24345,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RC4_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RC4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -24436,11 +24436,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RIPEMD160_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RIPEMD160_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -24448,42 +24448,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RIPEMD160_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RIPEMD160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_awslc_version_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SIPHASH_24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -24558,15 +24558,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24579,7 +24579,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24594,18 +24594,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24614,14 +24614,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24630,7 +24630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24641,7 +24641,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24650,7 +24650,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24662,7 +24662,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -24674,18 +24674,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24693,14 +24693,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24708,7 +24708,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24722,7 +24722,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24737,7 +24737,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24750,7 +24750,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24765,7 +24765,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -26473,15 +26473,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_POLICY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_POLICY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26489,26 +26489,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_POLICY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26516,14 +26516,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -26755,15 +26755,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26771,26 +26771,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26798,26 +26798,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26825,29 +26825,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -26855,19 +26855,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26875,18 +26875,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -26894,7 +26894,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -26902,15 +26902,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OTHERNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OTHERNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_OTHERNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26918,26 +26918,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_OTHERNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OTHERNAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26945,22 +26945,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OTHERNAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -26968,14 +26968,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -26983,7 +26983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -26991,14 +26991,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27006,15 +27006,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27022,33 +27022,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27056,26 +27056,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27083,26 +27083,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27110,26 +27110,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_USERNOTICE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_USERNOTICE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27137,26 +27137,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_USERNOTICE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NOTICEREF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NOTICEREF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27164,26 +27164,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NOTICEREF_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27191,26 +27191,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27218,26 +27218,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27245,26 +27245,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27272,38 +27272,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27311,26 +27311,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27338,70 +27338,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27412,7 +27412,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27420,7 +27420,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27430,7 +27430,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_conf_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -27528,7 +27528,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_set_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -27539,11 +27539,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_set_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27552,7 +27552,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27561,7 +27561,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -27570,7 +27570,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27579,7 +27579,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27588,7 +27588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27597,7 +27597,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27606,67 +27606,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_parse_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_get_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27675,14 +27675,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -27690,7 +27690,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_add1_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27700,7 +27700,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -27709,7 +27709,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -27718,7 +27718,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -27727,7 +27727,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_extensions_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -27737,11 +27737,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_ca"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -27749,70 +27749,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_supported_extension"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_akid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_extension_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_authority_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -27830,43 +27830,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_email_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get1_ocsp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27876,7 +27876,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27885,7 +27885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -27894,7 +27894,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -27902,15 +27902,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_a2i_IPADDRESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,

--- a/aws-lc-fips-sys/src/aarch64_apple_darwin_crypto_ssl.rs
+++ b/aws-lc-fips-sys/src/aarch64_apple_darwin_crypto_ssl.rs
@@ -5503,38 +5503,38 @@ pub type X509_STORE = x509_store_st;
 pub type X509_TRUST = x509_trust_st;
 pub type OPENSSL_BLOCK = *mut ::std::os::raw::c_void;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_free_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_get_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_get_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5543,18 +5543,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5563,18 +5563,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_last_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5583,7 +5583,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_error_string_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -5591,11 +5591,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_lib_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_reason_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -5606,30 +5606,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_print_errors_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_print_errors_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_clear_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_set_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_pop_to_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_get_next_error_library"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -5668,30 +5668,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_remove_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_remove_thread_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_func_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_clear_system_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_put_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -5701,15 +5701,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_add_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_add_error_dataf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_set_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -5773,7 +5773,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_set_encrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5781,7 +5781,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_set_decrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5789,15 +5789,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5809,7 +5809,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5818,7 +5818,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5829,7 +5829,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5840,7 +5840,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5852,7 +5852,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_wrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5862,7 +5862,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_unwrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5872,7 +5872,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_wrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5883,7 +5883,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -6104,27 +6104,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_grow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_append"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -6132,29 +6132,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -6162,7 +6162,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -6294,27 +6294,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_new_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -6322,11 +6322,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_pop_free_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6334,22 +6334,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_insert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_delete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_delete_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_delete_if"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6358,7 +6358,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_find"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -6367,35 +6367,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_shift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_is_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_set_cmp_func"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_deep_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6405,7 +6405,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_pop_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6465,7 +6465,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6521,19 +6521,19 @@ impl Default for crypto_ex_data_st {
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_num_locks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6546,7 +6546,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6560,7 +6560,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6571,29 +6571,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6649,7 +6649,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6660,7 +6660,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6673,7 +6673,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6685,7 +6685,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6694,7 +6694,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6705,7 +6705,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6732,23 +6732,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_vfree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6756,7 +6756,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6764,7 +6764,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6772,7 +6772,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_write_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6780,15 +6780,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6797,7 +6797,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6805,7 +6805,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_int_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6814,67 +6814,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_eof"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_should_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_should_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_should_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_should_io_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_retry_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_retry_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_method_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6900,7 +6900,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6908,68 +6908,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_ctrl_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_wpending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_close"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_number_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_number_written"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_callback_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_next"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_free_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_find_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_copy_next_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_printf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6977,7 +6977,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_indent"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6985,7 +6985,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_hexdump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6994,11 +6994,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_print_errors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_read_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -7007,15 +7007,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_s_mem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_mem_contents"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -7023,11 +7023,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -7035,22 +7035,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_s_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -7058,30 +7058,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_s_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -7089,89 +7089,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_read_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_write_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_append_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_rw_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_tell"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_seek"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_s_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_s_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_conn_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_nbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_do_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_bio_pair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -7180,34 +7180,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_shutdown_wr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -7216,13 +7216,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -7231,13 +7231,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7250,7 +7250,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7263,7 +7263,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7276,7 +7276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7288,7 +7288,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7302,7 +7302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7315,7 +7315,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7328,7 +7328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7340,23 +7340,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7366,7 +7366,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7374,37 +7374,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_f_base64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_retry_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7416,7 +7416,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7786,193 +7786,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_value_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_set_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_set_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_set_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bin2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2bin"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_le2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2le_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2bin_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2hex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_hex2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2dec"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_dec2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_asc2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_marshal_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_CTX_start"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_CTX_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_CTX_end"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_uadd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_add_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_usub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_sub_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7981,15 +7981,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mul_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_div"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7999,11 +7999,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_div_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -8011,47 +8011,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_cmp_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_ucmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_equal_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_abs_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8059,11 +8059,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_rshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8071,43 +8071,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_rshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_clear_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_bit_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mask_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_nnmod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_nnmod"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -8116,7 +8116,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8126,7 +8126,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_add_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8135,7 +8135,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8145,7 +8145,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_sub_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8154,7 +8154,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8164,7 +8164,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8173,7 +8173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8183,7 +8183,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8192,7 +8192,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8201,7 +8201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8209,7 +8209,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8218,7 +8218,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8227,7 +8227,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_pseudo_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8236,11 +8236,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_rand_range_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8248,7 +8248,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8308,15 +8308,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_GENCB_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_GENCB_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_GENCB_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8330,7 +8330,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_GENCB_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8338,11 +8338,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_generate_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8357,7 +8357,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8367,7 +8367,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8378,7 +8378,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8388,7 +8388,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8397,7 +8397,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_gcd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8406,7 +8406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_inverse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8415,7 +8415,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8425,7 +8425,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8435,23 +8435,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_to_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8460,7 +8460,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_from_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8469,7 +8469,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8479,7 +8479,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8488,7 +8488,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8498,7 +8498,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_exp_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8509,7 +8509,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8520,15 +8520,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2mpi"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mpi2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8539,7 +8539,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8552,11 +8552,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8564,7 +8564,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2binpad"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8572,7 +8572,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_secure_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -8720,15 +8720,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_num_bits_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_tag2bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_tag2str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8752,15 +8752,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8769,7 +8769,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8777,14 +8777,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8792,7 +8792,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8800,7 +8800,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8808,7 +8808,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8816,14 +8816,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_unpack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_pack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8831,7 +8831,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8839,22 +8839,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8930,54 +8930,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8985,7 +8985,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8993,79 +8993,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -9073,7 +9073,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -9081,7 +9081,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -9089,7 +9089,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -9097,7 +9097,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -9105,7 +9105,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -9113,7 +9113,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -9121,7 +9121,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -9129,7 +9129,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -9137,117 +9137,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9255,14 +9255,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9272,7 +9272,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9284,7 +9284,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9294,7 +9294,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9304,15 +9304,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9320,26 +9320,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9347,23 +9347,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9371,14 +9371,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9386,25 +9386,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9412,7 +9412,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9420,14 +9420,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9456,19 +9456,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9476,11 +9476,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9488,54 +9488,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9543,59 +9543,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9603,23 +9603,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, t: time_t) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         t: time_t,
@@ -9628,26 +9628,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9655,29 +9655,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
@@ -9686,22 +9686,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9709,15 +9709,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_diff"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9726,11 +9726,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, t: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         t: time_t,
@@ -9739,41 +9739,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_NULL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_NULL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9781,11 +9781,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_NULL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9810,7 +9810,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9820,11 +9820,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9832,11 +9832,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9844,7 +9844,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10178,15 +10178,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10194,19 +10194,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ANY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10214,7 +10214,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10222,12 +10222,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10235,14 +10235,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10250,33 +10250,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10284,7 +10284,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10292,19 +10292,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10312,7 +10312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10320,7 +10320,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10330,7 +10330,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_put_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10340,11 +10340,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_put_eoc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_object_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10352,33 +10352,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10386,34 +10386,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -11023,7 +11023,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -11048,19 +11048,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodeBase64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -11070,19 +11070,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11092,7 +11092,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11100,11 +11100,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11114,7 +11114,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11122,7 +11122,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11332,11 +11332,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BLAKE2B256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BLAKE2B256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11344,11 +11344,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BLAKE2B256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BLAKE2B256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11403,19 +11403,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BF_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BF_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BF_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BF_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11424,7 +11424,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BF_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11485,23 +11485,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_skip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_stow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11509,82 +11509,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_mem_equal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_last_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_copy_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_until_first"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11592,7 +11592,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11600,11 +11600,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_any_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11612,7 +11612,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11621,7 +11621,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11632,22 +11632,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11656,7 +11656,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11665,7 +11665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11674,7 +11674,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11683,33 +11683,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11717,7 +11717,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_parse_utc_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11725,7 +11725,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -12032,23 +12032,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_init_fixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12056,40 +12056,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -12097,15 +12097,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_zeros"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_space"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12113,55 +12113,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_did_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_discard_child"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -12169,11 +12169,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -12181,7 +12181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12189,11 +12189,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12201,11 +12201,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12216,114 +12216,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_rc4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ede"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ede3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_xts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_enc_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_rc2_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12334,7 +12334,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12344,7 +12344,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12354,7 +12354,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12364,7 +12364,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12372,7 +12372,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12382,7 +12382,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12390,7 +12390,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CipherUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12400,7 +12400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12408,47 +12408,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12457,45 +12457,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_BytesToKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12508,23 +12508,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CipherInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12534,7 +12534,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12543,7 +12543,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12552,7 +12552,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CipherFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12560,7 +12560,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12568,7 +12568,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12576,7 +12576,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_Cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12585,118 +12585,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_bf_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_bf_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_bf_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_cast5_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_cast5_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -12933,7 +12933,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_CMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -12943,19 +12943,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12965,15 +12965,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_Reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -13068,15 +13068,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_load"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -13084,7 +13084,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_load_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -13092,14 +13092,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_get_section"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_get_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -13107,7 +13107,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CONF_modules_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -13115,23 +13115,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CONF_modules_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_no_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA1_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA1_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13139,15 +13139,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA1_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA1_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13234,11 +13234,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA224_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA224_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13246,19 +13246,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA224_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13266,19 +13266,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -13376,11 +13376,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA384_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA384_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13388,19 +13388,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA384_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13408,15 +13408,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13514,11 +13514,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13526,11 +13526,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 #[repr(C)]
@@ -13575,26 +13575,26 @@ fn bindgen_test_layout_timeval() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_memcmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -13602,34 +13602,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_hash32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strhash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_tolower"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13637,7 +13637,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_snprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13646,7 +13646,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_vsnprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13655,7 +13655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13663,7 +13663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_asprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13671,21 +13671,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13693,7 +13693,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13701,7 +13701,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -13709,7 +13709,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -13718,7 +13718,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -13726,11 +13726,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -13757,51 +13757,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_secure_used"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_library_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_has_asm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BORINGSSL_self_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_FIPS_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -13811,70 +13811,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_FIPS_read_counter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OpenSSL_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSLeay_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OpenSSL_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_awslc_api_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_FIPS_mode_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X25519"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13882,15 +13882,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X25519_public_from_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ED25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ED25519_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13899,7 +13899,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ED25519_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13908,7 +13908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13919,7 +13919,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13929,11 +13929,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13944,7 +13944,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SPAKE2_process_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -14017,15 +14017,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_set_odd_parity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -14034,7 +14034,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14045,7 +14045,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -14056,7 +14056,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14069,7 +14069,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14081,7 +14081,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_decrypt3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -14090,7 +14090,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_encrypt3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -14099,43 +14099,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -14143,7 +14143,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -14151,7 +14151,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -14160,7 +14160,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -14169,40 +14169,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_set_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -14211,11 +14211,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_compute_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14223,7 +14223,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_compute_key_hashed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -14234,19 +14234,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_check_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -14254,19 +14254,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DHparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_generate_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -14281,7 +14281,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -14289,14 +14289,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14304,114 +14304,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get_2048_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_md4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_md5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_ripemd160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha3_224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha3_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha3_384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha3_512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_blake2b256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_md5_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_get_digestbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -14419,11 +14419,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -14431,7 +14431,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14439,7 +14439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14447,7 +14447,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_Digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -14458,75 +14458,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_add_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_get_digestbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -14534,19 +14534,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14638,15 +14638,15 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -14654,11 +14654,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -14666,15 +14666,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_METHOD_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_METHOD_unref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -14720,43 +14720,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14764,7 +14764,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14773,7 +14773,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14781,7 +14781,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14790,7 +14790,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14802,11 +14802,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSAparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14860,28 +14860,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14890,7 +14890,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_do_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14900,7 +14900,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14911,7 +14911,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14922,7 +14922,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14933,47 +14933,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_dup_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14983,7 +14983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14991,14 +14991,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -15006,11 +15006,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15018,11 +15018,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15030,11 +15030,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15042,7 +15042,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15198,19 +15198,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -15218,19 +15218,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -15238,7 +15238,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -15248,53 +15248,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_curve_nid2nist"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_curve_nist2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15302,7 +15302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -15311,7 +15311,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15321,7 +15321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15331,7 +15331,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15341,7 +15341,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15351,7 +15351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_point2oct"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15362,7 +15362,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -15372,7 +15372,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_oct2point"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15382,7 +15382,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15392,7 +15392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15402,7 +15402,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_dbl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15411,7 +15411,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_invert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -15419,7 +15419,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15430,7 +15430,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -15439,7 +15439,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -15448,7 +15448,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -15456,11 +15456,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15470,15 +15470,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_method_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -15532,92 +15532,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_get_builtin_curves"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get0_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -15625,7 +15625,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_key2buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15634,15 +15634,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15650,11 +15650,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15662,22 +15662,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15687,7 +15687,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15695,7 +15695,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15817,11 +15817,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15829,11 +15829,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15841,11 +15841,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_o2i_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15853,14 +15853,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2o_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15877,7 +15877,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15886,7 +15886,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15897,7 +15897,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15908,7 +15908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15962,23 +15962,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15986,7 +15986,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15994,7 +15994,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -16002,7 +16002,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -16011,19 +16011,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -16031,11 +16031,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -16045,7 +16045,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -16053,83 +16053,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -16267,11 +16267,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -16280,11 +16280,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16295,11 +16295,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16314,7 +16314,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16329,7 +16329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16347,7 +16347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16362,66 +16362,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16432,7 +16432,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -16440,7 +16440,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -16449,7 +16449,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -16457,102 +16457,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_assign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16560,40 +16560,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16602,7 +16602,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16611,7 +16611,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16619,7 +16619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16627,7 +16627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestSignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16637,7 +16637,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16645,7 +16645,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16653,7 +16653,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestSign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16663,7 +16663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16673,7 +16673,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16681,7 +16681,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16689,7 +16689,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestVerify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16699,7 +16699,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_SignInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16707,11 +16707,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_SignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_SignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16719,7 +16719,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_SignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16728,7 +16728,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16736,11 +16736,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_VerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16748,7 +16748,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_VerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16757,7 +16757,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16766,7 +16766,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16775,7 +16775,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16784,7 +16784,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16797,7 +16797,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16809,7 +16809,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16824,31 +16824,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16858,11 +16858,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16872,11 +16872,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16886,11 +16886,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16900,11 +16900,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16914,18 +16914,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_derive"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16933,18 +16933,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16954,7 +16954,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16964,102 +16964,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -17067,28 +17067,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -17096,7 +17096,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -17104,7 +17104,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -17114,31 +17114,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -17152,7 +17152,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -17166,15 +17166,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -17183,7 +17183,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -17191,7 +17191,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -17200,22 +17200,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -17223,40 +17223,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -17264,11 +17264,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -17276,11 +17276,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -17288,11 +17288,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -17300,14 +17300,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -17481,7 +17481,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HKDF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -17495,7 +17495,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HKDF_extract"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -17507,7 +17507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HKDF_expand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -17519,11 +17519,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD5_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD5_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17531,15 +17531,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD5_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD5_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17626,7 +17626,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17638,27 +17638,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_Init_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17668,7 +17668,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17676,7 +17676,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17684,23 +17684,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17709,7 +17709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17885,82 +17885,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17969,18 +17969,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17989,7 +17989,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17998,23 +17998,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -18030,7 +18030,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -18048,7 +18048,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -18061,7 +18061,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -18074,7 +18074,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -18087,7 +18087,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -18097,19 +18097,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -18368,7 +18368,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HRSS_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -18376,7 +18376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HRSS_encap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -18385,7 +18385,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HRSS_decap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -18394,22 +18394,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HRSS_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD4_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD4_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18417,15 +18417,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD4_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD4_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18512,66 +18512,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_obj2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_cbs2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_sn2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_ln2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_txt2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_nid2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_nid2sn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_nid2ln"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_nid2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_txt2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_obj2txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -18580,7 +18580,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -18588,7 +18588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -18596,7 +18596,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -18677,7 +18677,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -18696,7 +18696,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18704,47 +18704,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_get_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -19038,51 +19038,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19108,15 +19108,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -19124,18 +19124,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -19143,79 +19143,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_dmp1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_dmq1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_iqmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -19224,11 +19224,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -19237,7 +19237,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -19246,12 +19246,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_set0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_set0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -19260,7 +19260,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_generate_key_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19269,7 +19269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19277,7 +19277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19289,7 +19289,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19301,7 +19301,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_public_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19311,7 +19311,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_private_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19321,7 +19321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19332,7 +19332,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19346,7 +19346,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_sign_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19358,7 +19358,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19369,7 +19369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19382,7 +19382,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_verify_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19394,7 +19394,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_private_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19404,7 +19404,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_public_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19414,31 +19414,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSAPublicKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19449,7 +19449,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19460,7 +19460,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19473,7 +19473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19484,19 +19484,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19504,19 +19504,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19524,7 +19524,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19534,7 +19534,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19542,26 +19542,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_blinding_on"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19570,7 +19570,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19578,11 +19578,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19590,11 +19590,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19604,7 +19604,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19614,7 +19614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19625,7 +19625,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19633,7 +19633,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_pss_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -20134,27 +20134,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_chain_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -20162,51 +20162,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_parse_from_buffer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_uids"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -20219,15 +20219,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -20235,7 +20235,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -20243,7 +20243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -20251,15 +20251,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -20267,68 +20267,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set1_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set1_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_getm_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_getm_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -20336,7 +20336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -20344,25 +20344,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -20370,14 +20370,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -20385,7 +20385,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_alias_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -20393,7 +20393,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_keyid_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -20401,14 +20401,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_alias_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_keyid_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -20430,23 +20430,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -20454,23 +20454,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -20479,19 +20479,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20499,7 +20499,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20507,7 +20507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20515,11 +20515,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20527,55 +20527,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20583,7 +20583,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20591,25 +20591,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20617,19 +20617,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20637,23 +20637,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20661,33 +20661,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20695,22 +20695,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20760,19 +20760,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20780,15 +20780,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get0_der"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20796,15 +20796,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_entry_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20812,7 +20812,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20820,21 +20820,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_add_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20843,7 +20843,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20855,7 +20855,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20867,7 +20867,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20879,19 +20879,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20899,33 +20899,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20934,11 +20934,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20948,7 +20948,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20958,7 +20958,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20968,19 +20968,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20988,18 +20988,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -21008,7 +21008,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -21017,33 +21017,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -21067,11 +21067,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -21079,18 +21079,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -21098,7 +21098,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -21106,7 +21106,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -21114,21 +21114,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21157,23 +21157,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21181,11 +21181,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21194,7 +21194,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21203,15 +21203,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_signature_dump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -21219,7 +21219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_signature_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -21227,7 +21227,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_pubkey_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -21236,7 +21236,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -21245,7 +21245,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -21254,7 +21254,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -21263,7 +21263,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -21272,259 +21272,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -21532,11 +21532,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_find_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21546,7 +21546,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -21554,14 +21554,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21571,7 +21571,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -21579,42 +21579,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -21623,7 +21623,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -22196,11 +22196,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_pathlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22208,7 +22208,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_SIG_getm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22216,54 +22216,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -22271,23 +22271,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_cmp_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_cmp_current_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_time_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22295,7 +22295,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_time_adj_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22304,44 +22304,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_gmtime_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_cert_area"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_private_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22349,34 +22349,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22384,26 +22384,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_SIG_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22411,18 +22411,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -22430,38 +22430,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_add1_trust_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_add1_reject_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_trust_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_reject_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22469,25 +22469,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22495,7 +22495,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22503,23 +22503,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22527,26 +22527,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22554,26 +22554,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_oneline"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22581,7 +22581,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22591,7 +22591,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22601,7 +22601,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22611,7 +22611,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22623,7 +22623,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22634,15 +22634,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -22650,18 +22650,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22669,7 +22669,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22677,28 +22677,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22708,7 +22708,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22718,7 +22718,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -22728,37 +22728,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_diff"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -22768,66 +22768,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_issuer_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_subject_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_subject_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_match"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -22836,19 +22836,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22857,7 +22857,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22865,7 +22865,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22874,7 +22874,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22883,15 +22883,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22900,11 +22900,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -22913,7 +22913,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -22923,7 +22923,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22932,7 +22932,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22942,11 +22942,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22954,7 +22954,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -22962,7 +22962,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -22970,21 +22970,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -22992,7 +22992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -23001,7 +23001,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -23011,11 +23011,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_get_attr_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23023,7 +23023,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23031,28 +23031,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_get_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_delete_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_add1_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23062,7 +23062,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23072,7 +23072,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -23082,7 +23082,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23092,7 +23092,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23102,7 +23102,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -23112,14 +23112,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -23128,7 +23128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -23137,34 +23137,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_verify_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23172,26 +23172,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -23202,7 +23202,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -23212,11 +23212,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -23224,19 +23224,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -23253,19 +23253,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23352,15 +23352,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23368,14 +23368,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -23494,18 +23494,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23513,7 +23513,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23521,202 +23521,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set1_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23724,15 +23724,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -23741,50 +23741,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_add_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_add_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23793,7 +23793,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23803,7 +23803,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_load_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23811,7 +23811,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_load_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23819,7 +23819,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23827,19 +23827,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -23848,11 +23848,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_load_locations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23860,81 +23860,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -23943,11 +23943,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23955,7 +23955,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23967,105 +23967,105 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -24073,7 +24073,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -24081,20 +24081,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -24102,7 +24102,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -24110,42 +24110,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -24157,14 +24157,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_do_header"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -24174,7 +24174,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -24184,7 +24184,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -24194,7 +24194,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -24206,7 +24206,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24217,7 +24217,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24231,7 +24231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -24240,7 +24240,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -24250,7 +24250,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -24260,7 +24260,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_ASN1_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24271,7 +24271,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_ASN1_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24285,7 +24285,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -24294,7 +24294,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_def_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -24303,11 +24303,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_proc_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_dek_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -24316,7 +24316,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24325,7 +24325,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24334,15 +24334,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24351,7 +24351,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24360,15 +24360,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -24377,7 +24377,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -24386,23 +24386,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -24411,7 +24411,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -24420,15 +24420,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -24437,7 +24437,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -24446,15 +24446,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -24463,7 +24463,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -24472,15 +24472,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24489,7 +24489,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24498,21 +24498,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24521,7 +24521,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24530,7 +24530,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -24542,7 +24542,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -24554,7 +24554,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24563,7 +24563,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24572,15 +24572,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24589,7 +24589,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24598,15 +24598,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24615,7 +24615,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24624,7 +24624,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -24636,7 +24636,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -24648,7 +24648,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24657,7 +24657,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24666,15 +24666,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24683,7 +24683,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24692,15 +24692,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24709,7 +24709,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24718,7 +24718,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -24730,7 +24730,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -24742,7 +24742,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24751,7 +24751,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24760,15 +24760,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -24777,7 +24777,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -24786,15 +24786,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24803,7 +24803,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24812,7 +24812,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24824,7 +24824,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24836,7 +24836,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24845,7 +24845,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24854,15 +24854,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24874,7 +24874,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -24886,7 +24886,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24898,7 +24898,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24910,7 +24910,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24919,7 +24919,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24931,7 +24931,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24943,7 +24943,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24955,7 +24955,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24964,7 +24964,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24976,7 +24976,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -24989,7 +24989,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -25003,7 +25003,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -25011,7 +25011,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -25019,7 +25019,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -25028,11 +25028,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_PBE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -25040,27 +25040,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -25070,7 +25070,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_verify_mac"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -25078,7 +25078,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -25093,74 +25093,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_file_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_egd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_poll"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25261,19 +25261,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_OpenSSL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_get_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_set_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25338,11 +25338,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RC4_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RC4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -25429,11 +25429,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RIPEMD160_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RIPEMD160_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -25441,42 +25441,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RIPEMD160_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RIPEMD160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_awslc_version_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SIPHASH_24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -25551,15 +25551,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25572,7 +25572,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25587,18 +25587,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25607,14 +25607,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25623,7 +25623,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25634,7 +25634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25643,7 +25643,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25655,7 +25655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -25667,18 +25667,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25686,14 +25686,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25701,7 +25701,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25715,7 +25715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25730,7 +25730,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25743,7 +25743,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25758,7 +25758,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -27466,15 +27466,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_POLICY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_POLICY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27482,26 +27482,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_POLICY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27509,14 +27509,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -27748,15 +27748,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27764,26 +27764,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27791,26 +27791,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27818,29 +27818,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -27848,19 +27848,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27868,18 +27868,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -27887,7 +27887,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27895,15 +27895,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OTHERNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OTHERNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_OTHERNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27911,26 +27911,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_OTHERNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OTHERNAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27938,22 +27938,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OTHERNAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -27961,14 +27961,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -27976,7 +27976,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -27984,14 +27984,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27999,15 +27999,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28015,33 +28015,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28049,26 +28049,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28076,26 +28076,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28103,26 +28103,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_USERNOTICE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_USERNOTICE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28130,26 +28130,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_USERNOTICE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NOTICEREF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NOTICEREF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28157,26 +28157,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NOTICEREF_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28184,26 +28184,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28211,26 +28211,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28238,26 +28238,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28265,38 +28265,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28304,26 +28304,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28331,70 +28331,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28405,7 +28405,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -28413,7 +28413,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28423,7 +28423,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_conf_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -28521,7 +28521,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_set_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -28532,11 +28532,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_set_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28545,7 +28545,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28554,7 +28554,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -28563,7 +28563,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28572,7 +28572,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28581,7 +28581,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28590,7 +28590,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28599,67 +28599,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_parse_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_get_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28668,14 +28668,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -28683,7 +28683,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_add1_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28693,7 +28693,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -28702,7 +28702,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -28711,7 +28711,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -28720,7 +28720,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_extensions_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -28730,11 +28730,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_ca"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -28742,70 +28742,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_supported_extension"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_akid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_extension_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_authority_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -28823,43 +28823,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_email_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get1_ocsp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28869,7 +28869,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28878,7 +28878,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -28887,7 +28887,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -28895,11 +28895,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_a2i_IPADDRESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -28965,119 +28965,119 @@ impl static_assertion_at_line_255_error_is_max_overheads_are_inconsistent {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLS_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLS_method"]
     pub fn TLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLS_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLS_method"]
     pub fn DTLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLS_with_buffers_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLS_with_buffers_method"]
     pub fn TLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLS_with_buffers_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLS_with_buffers_method"]
     pub fn DTLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_new"]
     pub fn SSL_CTX_new(method: *const SSL_METHOD) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_up_ref"]
     pub fn SSL_CTX_up_ref(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_free"]
     pub fn SSL_CTX_free(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_new"]
     pub fn SSL_new(ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_free"]
     pub fn SSL_free(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_SSL_CTX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_SSL_CTX"]
     pub fn SSL_get_SSL_CTX(ssl: *const SSL) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_connect_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_connect_state"]
     pub fn SSL_set_connect_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_accept_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_accept_state"]
     pub fn SSL_set_accept_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_is_server"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_is_server"]
     pub fn SSL_is_server(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_is_dtls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_is_dtls"]
     pub fn SSL_is_dtls(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_bio"]
     pub fn SSL_set_bio(ssl: *mut SSL, rbio: *mut BIO, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set0_rbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set0_rbio"]
     pub fn SSL_set0_rbio(ssl: *mut SSL, rbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set0_wbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set0_wbio"]
     pub fn SSL_set0_wbio(ssl: *mut SSL, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_rbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_rbio"]
     pub fn SSL_get_rbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_wbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_wbio"]
     pub fn SSL_get_wbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_fd"]
     pub fn SSL_get_fd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_rfd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_rfd"]
     pub fn SSL_get_rfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_wfd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_wfd"]
     pub fn SSL_get_wfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_fd"]
     pub fn SSL_set_fd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_rfd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_rfd"]
     pub fn SSL_set_rfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_wfd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_wfd"]
     pub fn SSL_set_wfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_do_handshake"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_do_handshake"]
     pub fn SSL_do_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_connect"]
     pub fn SSL_connect(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_accept"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_accept"]
     pub fn SSL_accept(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_read"]
     pub fn SSL_read(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -29085,7 +29085,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_peek"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_peek"]
     pub fn SSL_peek(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -29093,15 +29093,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_pending"]
     pub fn SSL_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_has_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_has_pending"]
     pub fn SSL_has_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_write"]
     pub fn SSL_write(
         ssl: *mut SSL,
         buf: *const ::std::os::raw::c_void,
@@ -29109,220 +29109,220 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_key_update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_key_update"]
     pub fn SSL_key_update(
         ssl: *mut SSL,
         request_type: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_shutdown"]
     pub fn SSL_shutdown(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_quiet_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_quiet_shutdown"]
     pub fn SSL_CTX_set_quiet_shutdown(ctx: *mut SSL_CTX, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_quiet_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_quiet_shutdown"]
     pub fn SSL_CTX_get_quiet_shutdown(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_quiet_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_quiet_shutdown"]
     pub fn SSL_set_quiet_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_quiet_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_quiet_shutdown"]
     pub fn SSL_get_quiet_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_error"]
     pub fn SSL_get_error(ssl: *const SSL, ret_code: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_error_description"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_error_description"]
     pub fn SSL_error_description(err: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_mtu"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_mtu"]
     pub fn SSL_set_mtu(ssl: *mut SSL, mtu: ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLSv1_set_initial_timeout_duration"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLSv1_set_initial_timeout_duration"]
     pub fn DTLSv1_set_initial_timeout_duration(ssl: *mut SSL, duration_ms: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLSv1_get_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLSv1_get_timeout"]
     pub fn DTLSv1_get_timeout(ssl: *const SSL, out: *mut timeval) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLSv1_handle_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLSv1_handle_timeout"]
     pub fn DTLSv1_handle_timeout(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_min_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_min_proto_version"]
     pub fn SSL_CTX_set_min_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_max_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_max_proto_version"]
     pub fn SSL_CTX_set_max_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_min_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_min_proto_version"]
     pub fn SSL_CTX_get_min_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_max_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_max_proto_version"]
     pub fn SSL_CTX_get_max_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_min_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_min_proto_version"]
     pub fn SSL_set_min_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_max_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_max_proto_version"]
     pub fn SSL_set_max_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_min_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_min_proto_version"]
     pub fn SSL_get_min_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_max_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_max_proto_version"]
     pub fn SSL_get_max_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_version"]
     pub fn SSL_version(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_options"]
     pub fn SSL_CTX_set_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_clear_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_clear_options"]
     pub fn SSL_CTX_clear_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_options"]
     pub fn SSL_CTX_get_options(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_options"]
     pub fn SSL_set_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_clear_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_clear_options"]
     pub fn SSL_clear_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_options"]
     pub fn SSL_get_options(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_mode"]
     pub fn SSL_CTX_set_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_clear_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_clear_mode"]
     pub fn SSL_CTX_clear_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_mode"]
     pub fn SSL_CTX_get_mode(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_mode"]
     pub fn SSL_set_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_clear_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_clear_mode"]
     pub fn SSL_clear_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_mode"]
     pub fn SSL_get_mode(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set0_buffer_pool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set0_buffer_pool"]
     pub fn SSL_CTX_set0_buffer_pool(ctx: *mut SSL_CTX, pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_certificate"]
     pub fn SSL_CTX_use_certificate(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_use_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_use_certificate"]
     pub fn SSL_use_certificate(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_PrivateKey"]
     pub fn SSL_CTX_use_PrivateKey(ctx: *mut SSL_CTX, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_use_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_use_PrivateKey"]
     pub fn SSL_use_PrivateKey(ssl: *mut SSL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set0_chain"]
     pub fn SSL_CTX_set0_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_chain"]
     pub fn SSL_CTX_set1_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set0_chain"]
     pub fn SSL_set0_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_chain"]
     pub fn SSL_set1_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_add0_chain_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_add0_chain_cert"]
     pub fn SSL_CTX_add0_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_add1_chain_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_add1_chain_cert"]
     pub fn SSL_CTX_add1_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_add0_chain_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_add0_chain_cert"]
     pub fn SSL_add0_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_add_extra_chain_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_add_extra_chain_cert"]
     pub fn SSL_CTX_add_extra_chain_cert(
         ctx: *mut SSL_CTX,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_add1_chain_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_add1_chain_cert"]
     pub fn SSL_add1_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_clear_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_clear_chain_certs"]
     pub fn SSL_CTX_clear_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_clear_extra_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_clear_extra_chain_certs"]
     pub fn SSL_CTX_clear_extra_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_clear_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_clear_chain_certs"]
     pub fn SSL_clear_chain_certs(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_cert_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_cert_cb"]
     pub fn SSL_CTX_set_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -29335,7 +29335,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_cert_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_cert_cb"]
     pub fn SSL_set_cert_cb(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -29348,71 +29348,71 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_certificate_types"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_certificate_types"]
     pub fn SSL_get0_certificate_types(ssl: *const SSL, out_types: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_peer_verify_algorithms"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_peer_verify_algorithms"]
     pub fn SSL_get0_peer_verify_algorithms(ssl: *const SSL, out_sigalgs: *mut *const u16) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_peer_delegation_algorithms"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_peer_delegation_algorithms"]
     pub fn SSL_get0_peer_delegation_algorithms(
         ssl: *const SSL,
         out_sigalgs: *mut *const u16,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_certs_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_certs_clear"]
     pub fn SSL_certs_clear(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_check_private_key"]
     pub fn SSL_CTX_check_private_key(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_check_private_key"]
     pub fn SSL_check_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get0_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get0_certificate"]
     pub fn SSL_CTX_get0_certificate(ctx: *const SSL_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_certificate"]
     pub fn SSL_get_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get0_privatekey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get0_privatekey"]
     pub fn SSL_CTX_get0_privatekey(ctx: *const SSL_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_privatekey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_privatekey"]
     pub fn SSL_get_privatekey(ssl: *const SSL) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get0_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get0_chain_certs"]
     pub fn SSL_CTX_get0_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_extra_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_extra_chain_certs"]
     pub fn SSL_CTX_get_extra_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_chain_certs"]
     pub fn SSL_get0_chain_certs(
         ssl: *const SSL,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_signed_cert_timestamp_list"]
     pub fn SSL_CTX_set_signed_cert_timestamp_list(
         ctx: *mut SSL_CTX,
         list: *const u8,
@@ -29420,7 +29420,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_signed_cert_timestamp_list"]
     pub fn SSL_set_signed_cert_timestamp_list(
         ctx: *mut SSL,
         list: *const u8,
@@ -29428,7 +29428,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_ocsp_response"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_ocsp_response"]
     pub fn SSL_CTX_set_ocsp_response(
         ctx: *mut SSL_CTX,
         response: *const u8,
@@ -29436,7 +29436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_ocsp_response"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_ocsp_response"]
     pub fn SSL_set_ocsp_response(
         ssl: *mut SSL,
         response: *const u8,
@@ -29444,26 +29444,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_signature_algorithm_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_signature_algorithm_name"]
     pub fn SSL_get_signature_algorithm_name(
         sigalg: u16,
         include_curve: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_signature_algorithm_key_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_signature_algorithm_key_type"]
     pub fn SSL_get_signature_algorithm_key_type(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_signature_algorithm_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_signature_algorithm_digest"]
     pub fn SSL_get_signature_algorithm_digest(sigalg: u16) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_is_signature_algorithm_rsa_pss"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_is_signature_algorithm_rsa_pss"]
     pub fn SSL_is_signature_algorithm_rsa_pss(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_signing_algorithm_prefs"]
     pub fn SSL_CTX_set_signing_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -29471,7 +29471,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_signing_algorithm_prefs"]
     pub fn SSL_set_signing_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -29479,7 +29479,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_chain_and_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_chain_and_key"]
     pub fn SSL_CTX_set_chain_and_key(
         ctx: *mut SSL_CTX,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29489,7 +29489,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_chain_and_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_chain_and_key"]
     pub fn SSL_set_chain_and_key(
         ssl: *mut SSL,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29499,19 +29499,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get0_chain"]
     pub fn SSL_CTX_get0_chain(ctx: *const SSL_CTX) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_RSAPrivateKey"]
     pub fn SSL_CTX_use_RSAPrivateKey(ctx: *mut SSL_CTX, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_use_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_use_RSAPrivateKey"]
     pub fn SSL_use_RSAPrivateKey(ssl: *mut SSL, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_certificate_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_certificate_ASN1"]
     pub fn SSL_CTX_use_certificate_ASN1(
         ctx: *mut SSL_CTX,
         der_len: usize,
@@ -29519,7 +29519,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_use_certificate_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_use_certificate_ASN1"]
     pub fn SSL_use_certificate_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29527,7 +29527,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_PrivateKey_ASN1"]
     pub fn SSL_CTX_use_PrivateKey_ASN1(
         pk: ::std::os::raw::c_int,
         ctx: *mut SSL_CTX,
@@ -29536,7 +29536,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_use_PrivateKey_ASN1"]
     pub fn SSL_use_PrivateKey_ASN1(
         type_: ::std::os::raw::c_int,
         ssl: *mut SSL,
@@ -29545,7 +29545,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_RSAPrivateKey_ASN1"]
     pub fn SSL_CTX_use_RSAPrivateKey_ASN1(
         ctx: *mut SSL_CTX,
         der: *const u8,
@@ -29553,7 +29553,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_use_RSAPrivateKey_ASN1"]
     pub fn SSL_use_RSAPrivateKey_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29561,7 +29561,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_RSAPrivateKey_file"]
     pub fn SSL_CTX_use_RSAPrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29569,7 +29569,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_use_RSAPrivateKey_file"]
     pub fn SSL_use_RSAPrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29577,7 +29577,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_certificate_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_certificate_file"]
     pub fn SSL_CTX_use_certificate_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29585,7 +29585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_use_certificate_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_use_certificate_file"]
     pub fn SSL_use_certificate_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29593,7 +29593,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_PrivateKey_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_PrivateKey_file"]
     pub fn SSL_CTX_use_PrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29601,7 +29601,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_use_PrivateKey_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_use_PrivateKey_file"]
     pub fn SSL_use_PrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29609,29 +29609,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_certificate_chain_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_certificate_chain_file"]
     pub fn SSL_CTX_use_certificate_chain_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_default_passwd_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_default_passwd_cb"]
     pub fn SSL_CTX_set_default_passwd_cb(ctx: *mut SSL_CTX, cb: pem_password_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_default_passwd_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_default_passwd_cb"]
     pub fn SSL_CTX_get_default_passwd_cb(ctx: *const SSL_CTX) -> pem_password_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_default_passwd_cb_userdata"]
     pub fn SSL_CTX_set_default_passwd_cb_userdata(
         ctx: *mut SSL_CTX,
         data: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_default_passwd_cb_userdata"]
     pub fn SSL_CTX_get_default_passwd_cb_userdata(
         ctx: *const SSL_CTX,
     ) -> *mut ::std::os::raw::c_void;
@@ -29720,18 +29720,18 @@ fn bindgen_test_layout_ssl_private_key_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_private_key_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_private_key_method"]
     pub fn SSL_set_private_key_method(ssl: *mut SSL, key_method: *const SSL_PRIVATE_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_private_key_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_private_key_method"]
     pub fn SSL_CTX_set_private_key_method(
         ctx: *mut SSL_CTX,
         key_method: *const SSL_PRIVATE_KEY_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_can_release_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_can_release_private_key"]
     pub fn SSL_can_release_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -29756,149 +29756,149 @@ pub type sk_SSL_CIPHER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_cipher_by_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_cipher_by_value"]
     pub fn SSL_get_cipher_by_value(value: u16) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_id"]
     pub fn SSL_CIPHER_get_id(cipher: *const SSL_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_protocol_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_protocol_id"]
     pub fn SSL_CIPHER_get_protocol_id(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_is_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_is_aead"]
     pub fn SSL_CIPHER_is_aead(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_is_block_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_is_block_cipher"]
     pub fn SSL_CIPHER_is_block_cipher(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_cipher_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_cipher_nid"]
     pub fn SSL_CIPHER_get_cipher_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_digest_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_digest_nid"]
     pub fn SSL_CIPHER_get_digest_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_kx_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_kx_nid"]
     pub fn SSL_CIPHER_get_kx_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_auth_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_auth_nid"]
     pub fn SSL_CIPHER_get_auth_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_prf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_prf_nid"]
     pub fn SSL_CIPHER_get_prf_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_min_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_min_version"]
     pub fn SSL_CIPHER_get_min_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_max_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_max_version"]
     pub fn SSL_CIPHER_get_max_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_standard_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_standard_name"]
     pub fn SSL_CIPHER_standard_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_name"]
     pub fn SSL_CIPHER_get_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_kx_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_kx_name"]
     pub fn SSL_CIPHER_get_kx_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_bits"]
     pub fn SSL_CIPHER_get_bits(
         cipher: *const SSL_CIPHER,
         out_alg_bits: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_strict_cipher_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_strict_cipher_list"]
     pub fn SSL_CTX_set_strict_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_cipher_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_cipher_list"]
     pub fn SSL_CTX_set_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_strict_cipher_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_strict_cipher_list"]
     pub fn SSL_set_strict_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_ciphersuites"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_ciphersuites"]
     pub fn SSL_CTX_set_ciphersuites(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_cipher_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_cipher_list"]
     pub fn SSL_set_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_ciphers"]
     pub fn SSL_CTX_get_ciphers(ctx: *const SSL_CTX) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_cipher_in_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_cipher_in_group"]
     pub fn SSL_CTX_cipher_in_group(ctx: *const SSL_CTX, i: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_ciphers"]
     pub fn SSL_get_ciphers(ssl: *const SSL) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_is_init_finished"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_is_init_finished"]
     pub fn SSL_is_init_finished(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_in_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_in_init"]
     pub fn SSL_in_init(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_in_false_start"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_in_false_start"]
     pub fn SSL_in_false_start(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_peer_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_peer_certificate"]
     pub fn SSL_get_peer_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_peer_cert_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_peer_cert_chain"]
     pub fn SSL_get_peer_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_peer_full_cert_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_peer_full_cert_chain"]
     pub fn SSL_get_peer_full_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_peer_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_peer_certificates"]
     pub fn SSL_get0_peer_certificates(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_signed_cert_timestamp_list"]
     pub fn SSL_get0_signed_cert_timestamp_list(
         ssl: *const SSL,
         out: *mut *const u8,
@@ -29906,11 +29906,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_ocsp_response"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_ocsp_response"]
     pub fn SSL_get0_ocsp_response(ssl: *const SSL, out: *mut *const u8, out_len: *mut usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_tls_unique"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_tls_unique"]
     pub fn SSL_get_tls_unique(
         ssl: *const SSL,
         out: *mut u8,
@@ -29919,23 +29919,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_extms_support"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_extms_support"]
     pub fn SSL_get_extms_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_current_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_current_cipher"]
     pub fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_session_reused"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_session_reused"]
     pub fn SSL_session_reused(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_secure_renegotiation_support"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_secure_renegotiation_support"]
     pub fn SSL_get_secure_renegotiation_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_export_keying_material"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_export_keying_material"]
     pub fn SSL_export_keying_material(
         ssl: *mut SSL,
         out: *mut u8,
@@ -29948,7 +29948,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_SSL_SESSION"]
     pub fn PEM_read_bio_SSL_SESSION(
         bp: *mut BIO,
         x: *mut *mut SSL_SESSION,
@@ -29957,7 +29957,7 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_SSL_SESSION"]
     pub fn PEM_read_SSL_SESSION(
         fp: *mut FILE,
         x: *mut *mut SSL_SESSION,
@@ -29966,27 +29966,27 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_SSL_SESSION"]
     pub fn PEM_write_bio_SSL_SESSION(bp: *mut BIO, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_SSL_SESSION"]
     pub fn PEM_write_SSL_SESSION(fp: *mut FILE, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_new"]
     pub fn SSL_SESSION_new(ctx: *const SSL_CTX) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_up_ref"]
     pub fn SSL_SESSION_up_ref(session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_free"]
     pub fn SSL_SESSION_free(session: *mut SSL_SESSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_to_bytes"]
     pub fn SSL_SESSION_to_bytes(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -29994,7 +29994,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_to_bytes_for_ticket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_to_bytes_for_ticket"]
     pub fn SSL_SESSION_to_bytes_for_ticket(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -30002,7 +30002,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_from_bytes"]
     pub fn SSL_SESSION_from_bytes(
         in_: *const u8,
         in_len: usize,
@@ -30010,29 +30010,29 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get_version"]
     pub fn SSL_SESSION_get_version(session: *const SSL_SESSION) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get_protocol_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get_protocol_version"]
     pub fn SSL_SESSION_get_protocol_version(session: *const SSL_SESSION) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_set_protocol_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_set_protocol_version"]
     pub fn SSL_SESSION_set_protocol_version(
         session: *mut SSL_SESSION,
         version: u16,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get_id"]
     pub fn SSL_SESSION_get_id(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_set1_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_set1_id"]
     pub fn SSL_SESSION_set1_id(
         session: *mut SSL_SESSION,
         sid: *const u8,
@@ -30040,25 +30040,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get_time"]
     pub fn SSL_SESSION_get_time(session: *const SSL_SESSION) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get_timeout"]
     pub fn SSL_SESSION_get_timeout(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get0_peer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get0_peer"]
     pub fn SSL_SESSION_get0_peer(session: *const SSL_SESSION) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get0_peer_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get0_peer_certificates"]
     pub fn SSL_SESSION_get0_peer_certificates(
         session: *const SSL_SESSION,
     ) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get0_signed_cert_timestamp_list"]
     pub fn SSL_SESSION_get0_signed_cert_timestamp_list(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -30066,7 +30066,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get0_ocsp_response"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get0_ocsp_response"]
     pub fn SSL_SESSION_get0_ocsp_response(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -30074,7 +30074,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get_master_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get_master_key"]
     pub fn SSL_SESSION_get_master_key(
         session: *const SSL_SESSION,
         out: *mut u8,
@@ -30082,22 +30082,22 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_set_time"]
     pub fn SSL_SESSION_set_time(session: *mut SSL_SESSION, time: u64) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_set_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_set_timeout"]
     pub fn SSL_SESSION_set_timeout(session: *mut SSL_SESSION, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get0_id_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get0_id_context"]
     pub fn SSL_SESSION_get0_id_context(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_set1_id_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_set1_id_context"]
     pub fn SSL_SESSION_set1_id_context(
         session: *mut SSL_SESSION,
         sid_ctx: *const u8,
@@ -30105,19 +30105,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_should_be_single_use"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_should_be_single_use"]
     pub fn SSL_SESSION_should_be_single_use(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_is_resumable"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_is_resumable"]
     pub fn SSL_SESSION_is_resumable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_has_ticket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_has_ticket"]
     pub fn SSL_SESSION_has_ticket(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get0_ticket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get0_ticket"]
     pub fn SSL_SESSION_get0_ticket(
         session: *const SSL_SESSION,
         out_ticket: *mut *const u8,
@@ -30125,7 +30125,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_set_ticket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_set_ticket"]
     pub fn SSL_SESSION_set_ticket(
         session: *mut SSL_SESSION,
         ticket: *const u8,
@@ -30133,19 +30133,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get_ticket_lifetime_hint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get_ticket_lifetime_hint"]
     pub fn SSL_SESSION_get_ticket_lifetime_hint(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get0_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get0_cipher"]
     pub fn SSL_SESSION_get0_cipher(session: *const SSL_SESSION) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_has_peer_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_has_peer_sha256"]
     pub fn SSL_SESSION_has_peer_sha256(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get0_peer_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get0_peer_sha256"]
     pub fn SSL_SESSION_get0_peer_sha256(
         session: *const SSL_SESSION,
         out_ptr: *mut *const u8,
@@ -30153,34 +30153,34 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_session_cache_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_session_cache_mode"]
     pub fn SSL_CTX_set_session_cache_mode(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_session_cache_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_session_cache_mode"]
     pub fn SSL_CTX_get_session_cache_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_session"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_session"]
     pub fn SSL_set_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_timeout"]
     pub fn SSL_CTX_set_timeout(ctx: *mut SSL_CTX, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_session_psk_dhe_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_session_psk_dhe_timeout"]
     pub fn SSL_CTX_set_session_psk_dhe_timeout(ctx: *mut SSL_CTX, timeout: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_timeout"]
     pub fn SSL_CTX_get_timeout(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_session_id_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_session_id_context"]
     pub fn SSL_CTX_set_session_id_context(
         ctx: *mut SSL_CTX,
         sid_ctx: *const u8,
@@ -30188,7 +30188,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_session_id_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_session_id_context"]
     pub fn SSL_set_session_id_context(
         ssl: *mut SSL,
         sid_ctx: *const u8,
@@ -30196,44 +30196,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_session_id_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_session_id_context"]
     pub fn SSL_get0_session_id_context(ssl: *const SSL, out_len: *mut usize) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_set_cache_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_set_cache_size"]
     pub fn SSL_CTX_sess_set_cache_size(
         ctx: *mut SSL_CTX,
         size: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_get_cache_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_get_cache_size"]
     pub fn SSL_CTX_sess_get_cache_size(ctx: *const SSL_CTX) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_number"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_number"]
     pub fn SSL_CTX_sess_number(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_add_session"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_add_session"]
     pub fn SSL_CTX_add_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_remove_session"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_remove_session"]
     pub fn SSL_CTX_remove_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_flush_sessions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_flush_sessions"]
     pub fn SSL_CTX_flush_sessions(ctx: *mut SSL_CTX, time: u64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_set_new_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_set_new_cb"]
     pub fn SSL_CTX_sess_set_new_cb(
         ctx: *mut SSL_CTX,
         new_session_cb: ::std::option::Option<
@@ -30242,7 +30242,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_get_new_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_get_new_cb"]
     pub fn SSL_CTX_sess_get_new_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30250,7 +30250,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_set_remove_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_set_remove_cb"]
     pub fn SSL_CTX_sess_set_remove_cb(
         ctx: *mut SSL_CTX,
         remove_session_cb: ::std::option::Option<
@@ -30259,13 +30259,13 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_get_remove_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_get_remove_cb"]
     pub fn SSL_CTX_sess_get_remove_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<unsafe extern "C" fn(ctx: *mut SSL_CTX, arg1: *mut SSL_SESSION)>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_set_get_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_set_get_cb"]
     pub fn SSL_CTX_sess_set_get_cb(
         ctx: *mut SSL_CTX,
         get_session_cb: ::std::option::Option<
@@ -30279,7 +30279,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_get_get_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_get_get_cb"]
     pub fn SSL_CTX_sess_get_get_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30292,11 +30292,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_magic_pending_session_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_magic_pending_session_ptr"]
     pub fn SSL_magic_pending_session_ptr() -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_tlsext_ticket_keys"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_tlsext_ticket_keys"]
     pub fn SSL_CTX_get_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         out: *mut ::std::os::raw::c_void,
@@ -30304,7 +30304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_ticket_keys"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_ticket_keys"]
     pub fn SSL_CTX_set_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         in_: *const ::std::os::raw::c_void,
@@ -30312,7 +30312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_ticket_key_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_ticket_key_cb"]
     pub fn SSL_CTX_set_tlsext_ticket_key_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30404,14 +30404,14 @@ fn bindgen_test_layout_ssl_ticket_aead_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_ticket_aead_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_ticket_aead_method"]
     pub fn SSL_CTX_set_ticket_aead_method(
         ctx: *mut SSL_CTX,
         aead_method: *const SSL_TICKET_AEAD_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_process_tls13_new_session_ticket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_process_tls13_new_session_ticket"]
     pub fn SSL_process_tls13_new_session_ticket(
         ssl: *mut SSL,
         buf: *const u8,
@@ -30419,15 +30419,15 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_num_tickets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_num_tickets"]
     pub fn SSL_CTX_set_num_tickets(ctx: *mut SSL_CTX, num_tickets: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_num_tickets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_num_tickets"]
     pub fn SSL_CTX_get_num_tickets(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_curves"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_curves"]
     pub fn SSL_CTX_set1_curves(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_int,
@@ -30435,7 +30435,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_curves"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_curves"]
     pub fn SSL_set1_curves(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_int,
@@ -30443,29 +30443,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_curves_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_curves_list"]
     pub fn SSL_CTX_set1_curves_list(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_curves_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_curves_list"]
     pub fn SSL_set1_curves_list(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_curve_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_curve_id"]
     pub fn SSL_get_curve_id(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_curve_name"]
     pub fn SSL_get_curve_name(curve_id: u16) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_to_bytes"]
     pub fn SSL_to_bytes(
         in_: *const SSL,
         out_data: *mut *mut u8,
@@ -30473,11 +30473,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_from_bytes"]
     pub fn SSL_from_bytes(in_: *const u8, in_len: usize, ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_groups"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_groups"]
     pub fn SSL_CTX_set1_groups(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_int,
@@ -30485,7 +30485,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_groups"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_groups"]
     pub fn SSL_set1_groups(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_int,
@@ -30493,21 +30493,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_groups_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_groups_list"]
     pub fn SSL_CTX_set1_groups_list(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_groups_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_groups_list"]
     pub fn SSL_set1_groups_list(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_verify"]
     pub fn SSL_CTX_set_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30520,7 +30520,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_verify"]
     pub fn SSL_set_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30537,7 +30537,7 @@ pub const ssl_verify_result_t_ssl_verify_invalid: ssl_verify_result_t = 1;
 pub const ssl_verify_result_t_ssl_verify_retry: ssl_verify_result_t = 2;
 pub type ssl_verify_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_custom_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_custom_verify"]
     pub fn SSL_CTX_set_custom_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30547,7 +30547,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_custom_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_custom_verify"]
     pub fn SSL_set_custom_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30557,15 +30557,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_verify_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_verify_mode"]
     pub fn SSL_CTX_get_verify_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_verify_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_verify_mode"]
     pub fn SSL_get_verify_mode(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_verify_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_verify_callback"]
     pub fn SSL_CTX_get_verify_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -30576,7 +30576,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_verify_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_verify_callback"]
     pub fn SSL_get_verify_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -30587,83 +30587,83 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_host"]
     pub fn SSL_set1_host(
         ssl: *mut SSL,
         hostname: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_verify_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_verify_depth"]
     pub fn SSL_CTX_set_verify_depth(ctx: *mut SSL_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_verify_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_verify_depth"]
     pub fn SSL_set_verify_depth(ssl: *mut SSL, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_verify_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_verify_depth"]
     pub fn SSL_CTX_get_verify_depth(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_verify_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_verify_depth"]
     pub fn SSL_get_verify_depth(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_param"]
     pub fn SSL_CTX_set1_param(
         ctx: *mut SSL_CTX,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_param"]
     pub fn SSL_set1_param(ssl: *mut SSL, param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get0_param"]
     pub fn SSL_CTX_get0_param(ctx: *mut SSL_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_param"]
     pub fn SSL_get0_param(ssl: *mut SSL) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_purpose"]
     pub fn SSL_CTX_set_purpose(
         ctx: *mut SSL_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_purpose"]
     pub fn SSL_set_purpose(ssl: *mut SSL, purpose: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_trust"]
     pub fn SSL_CTX_set_trust(
         ctx: *mut SSL_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_trust"]
     pub fn SSL_set_trust(ssl: *mut SSL, trust: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_cert_store"]
     pub fn SSL_CTX_set_cert_store(ctx: *mut SSL_CTX, store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_cert_store"]
     pub fn SSL_CTX_get_cert_store(ctx: *const SSL_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_default_verify_paths"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_default_verify_paths"]
     pub fn SSL_CTX_set_default_verify_paths(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_load_verify_locations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_load_verify_locations"]
     pub fn SSL_CTX_load_verify_locations(
         ctx: *mut SSL_CTX,
         ca_file: *const ::std::os::raw::c_char,
@@ -30671,19 +30671,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_verify_result"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_verify_result"]
     pub fn SSL_get_verify_result(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_alert_from_verify_result"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_alert_from_verify_result"]
     pub fn SSL_alert_from_verify_result(result: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_ex_data_X509_STORE_CTX_idx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_ex_data_X509_STORE_CTX_idx"]
     pub fn SSL_get_ex_data_X509_STORE_CTX_idx() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_cert_verify_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_cert_verify_callback"]
     pub fn SSL_CTX_set_cert_verify_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30696,51 +30696,51 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_enable_signed_cert_timestamps"]
     pub fn SSL_enable_signed_cert_timestamps(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_enable_signed_cert_timestamps"]
     pub fn SSL_CTX_enable_signed_cert_timestamps(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_enable_ocsp_stapling"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_enable_ocsp_stapling"]
     pub fn SSL_enable_ocsp_stapling(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_enable_ocsp_stapling"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_enable_ocsp_stapling"]
     pub fn SSL_CTX_enable_ocsp_stapling(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set0_verify_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set0_verify_cert_store"]
     pub fn SSL_CTX_set0_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_verify_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_verify_cert_store"]
     pub fn SSL_CTX_set1_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set0_verify_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set0_verify_cert_store"]
     pub fn SSL_set0_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_verify_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_verify_cert_store"]
     pub fn SSL_set1_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_verify_algorithm_prefs"]
     pub fn SSL_CTX_set_verify_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -30748,7 +30748,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_verify_algorithm_prefs"]
     pub fn SSL_set_verify_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -30756,87 +30756,87 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_hostflags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_hostflags"]
     pub fn SSL_set_hostflags(ssl: *mut SSL, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_client_CA_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_client_CA_list"]
     pub fn SSL_set_client_CA_list(ssl: *mut SSL, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_client_CA_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_client_CA_list"]
     pub fn SSL_CTX_set_client_CA_list(ctx: *mut SSL_CTX, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set0_client_CAs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set0_client_CAs"]
     pub fn SSL_set0_client_CAs(ssl: *mut SSL, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set0_client_CAs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set0_client_CAs"]
     pub fn SSL_CTX_set0_client_CAs(ctx: *mut SSL_CTX, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_client_CA_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_client_CA_list"]
     pub fn SSL_get_client_CA_list(ssl: *const SSL) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_server_requested_CAs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_server_requested_CAs"]
     pub fn SSL_get0_server_requested_CAs(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_client_CA_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_client_CA_list"]
     pub fn SSL_CTX_get_client_CA_list(ctx: *const SSL_CTX) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_add_client_CA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_add_client_CA"]
     pub fn SSL_add_client_CA(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_add_client_CA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_add_client_CA"]
     pub fn SSL_CTX_add_client_CA(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_load_client_CA_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_load_client_CA_file"]
     pub fn SSL_load_client_CA_file(file: *const ::std::os::raw::c_char) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_dup_CA_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_dup_CA_list"]
     pub fn SSL_dup_CA_list(list: *mut stack_st_X509_NAME) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_add_file_cert_subjects_to_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_add_file_cert_subjects_to_stack"]
     pub fn SSL_add_file_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_add_bio_cert_subjects_to_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_add_bio_cert_subjects_to_stack"]
     pub fn SSL_add_bio_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_tlsext_host_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_tlsext_host_name"]
     pub fn SSL_set_tlsext_host_name(
         ssl: *mut SSL,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_servername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_servername"]
     pub fn SSL_get_servername(
         ssl: *const SSL,
         type_: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_servername_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_servername_type"]
     pub fn SSL_get_servername_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_servername_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_servername_callback"]
     pub fn SSL_CTX_set_tlsext_servername_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30849,18 +30849,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_servername_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_servername_arg"]
     pub fn SSL_CTX_set_tlsext_servername_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_SSL_CTX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_SSL_CTX"]
     pub fn SSL_set_SSL_CTX(ssl: *mut SSL, ctx: *mut SSL_CTX) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_alpn_protos"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_alpn_protos"]
     pub fn SSL_CTX_set_alpn_protos(
         ctx: *mut SSL_CTX,
         protos: *const u8,
@@ -30868,7 +30868,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_alpn_protos"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_alpn_protos"]
     pub fn SSL_set_alpn_protos(
         ssl: *mut SSL,
         protos: *const u8,
@@ -30876,7 +30876,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_alpn_select_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_alpn_select_cb"]
     pub fn SSL_CTX_set_alpn_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30893,7 +30893,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_alpn_selected"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_alpn_selected"]
     pub fn SSL_get0_alpn_selected(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30901,11 +30901,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_allow_unknown_alpn_protos"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_allow_unknown_alpn_protos"]
     pub fn SSL_CTX_set_allow_unknown_alpn_protos(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_add_application_settings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_add_application_settings"]
     pub fn SSL_add_application_settings(
         ssl: *mut SSL,
         proto: *const u8,
@@ -30915,7 +30915,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_peer_application_settings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_peer_application_settings"]
     pub fn SSL_get0_peer_application_settings(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30923,7 +30923,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_has_application_settings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_has_application_settings"]
     pub fn SSL_has_application_settings(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub type ssl_cert_compression_func_t = ::std::option::Option<
@@ -30944,7 +30944,7 @@ pub type ssl_cert_decompression_func_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_add_cert_compression_alg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_add_cert_compression_alg"]
     pub fn SSL_CTX_add_cert_compression_alg(
         ctx: *mut SSL_CTX,
         alg_id: u16,
@@ -30953,7 +30953,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_next_protos_advertised_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_next_protos_advertised_cb"]
     pub fn SSL_CTX_set_next_protos_advertised_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30968,7 +30968,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_next_proto_select_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_next_proto_select_cb"]
     pub fn SSL_CTX_set_next_proto_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30985,7 +30985,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_next_proto_negotiated"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_next_proto_negotiated"]
     pub fn SSL_get0_next_proto_negotiated(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30993,7 +30993,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_select_next_proto"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_select_next_proto"]
     pub fn SSL_select_next_proto(
         out: *mut *mut u8,
         out_len: *mut u8,
@@ -31004,29 +31004,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tls_channel_id_enabled"]
     pub fn SSL_CTX_set_tls_channel_id_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_tls_channel_id_enabled"]
     pub fn SSL_set_tls_channel_id_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_tls_channel_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_tls_channel_id"]
     pub fn SSL_CTX_set1_tls_channel_id(
         ctx: *mut SSL_CTX,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_tls_channel_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_tls_channel_id"]
     pub fn SSL_set1_tls_channel_id(
         ssl: *mut SSL,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_tls_channel_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_tls_channel_id"]
     pub fn SSL_get_tls_channel_id(ssl: *mut SSL, out: *mut u8, max_out: usize) -> usize;
 }
 #[repr(C)]
@@ -31103,29 +31103,29 @@ pub type sk_SRTP_PROTECTION_PROFILE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_srtp_profiles"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_srtp_profiles"]
     pub fn SSL_CTX_set_srtp_profiles(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_srtp_profiles"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_srtp_profiles"]
     pub fn SSL_set_srtp_profiles(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_srtp_profiles"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_srtp_profiles"]
     pub fn SSL_get_srtp_profiles(ssl: *const SSL) -> *const stack_st_SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_selected_srtp_profile"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_selected_srtp_profile"]
     pub fn SSL_get_selected_srtp_profile(ssl: *mut SSL) -> *const SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_psk_client_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_psk_client_callback"]
     pub fn SSL_CTX_set_psk_client_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31141,7 +31141,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_psk_client_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_psk_client_callback"]
     pub fn SSL_set_psk_client_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31157,7 +31157,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_psk_server_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_psk_server_callback"]
     pub fn SSL_CTX_set_psk_server_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31171,7 +31171,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_psk_server_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_psk_server_callback"]
     pub fn SSL_set_psk_server_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31185,29 +31185,29 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_psk_identity_hint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_psk_identity_hint"]
     pub fn SSL_CTX_use_psk_identity_hint(
         ctx: *mut SSL_CTX,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_use_psk_identity_hint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_use_psk_identity_hint"]
     pub fn SSL_use_psk_identity_hint(
         ssl: *mut SSL,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_psk_identity_hint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_psk_identity_hint"]
     pub fn SSL_get_psk_identity_hint(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_psk_identity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_psk_identity"]
     pub fn SSL_get_psk_identity(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_delegated_credential"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_delegated_credential"]
     pub fn SSL_set1_delegated_credential(
         ssl: *mut SSL,
         dc: *mut CRYPTO_BUFFER,
@@ -31216,7 +31216,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_delegated_credential_used"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_delegated_credential_used"]
     pub fn SSL_delegated_credential_used(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub const ssl_encryption_level_t_ssl_encryption_initial: ssl_encryption_level_t = 0;
@@ -31329,22 +31329,22 @@ fn bindgen_test_layout_ssl_quic_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_quic_max_handshake_flight_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_quic_max_handshake_flight_len"]
     pub fn SSL_quic_max_handshake_flight_len(
         ssl: *const SSL,
         level: ssl_encryption_level_t,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_quic_read_level"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_quic_read_level"]
     pub fn SSL_quic_read_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_quic_write_level"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_quic_write_level"]
     pub fn SSL_quic_write_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_provide_quic_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_provide_quic_data"]
     pub fn SSL_provide_quic_data(
         ssl: *mut SSL,
         level: ssl_encryption_level_t,
@@ -31353,25 +31353,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_process_quic_post_handshake"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_process_quic_post_handshake"]
     pub fn SSL_process_quic_post_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_quic_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_quic_method"]
     pub fn SSL_CTX_set_quic_method(
         ctx: *mut SSL_CTX,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_quic_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_quic_method"]
     pub fn SSL_set_quic_method(
         ssl: *mut SSL,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_quic_transport_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_quic_transport_params"]
     pub fn SSL_set_quic_transport_params(
         ssl: *mut SSL,
         params: *const u8,
@@ -31379,7 +31379,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_peer_quic_transport_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_peer_quic_transport_params"]
     pub fn SSL_get_peer_quic_transport_params(
         ssl: *const SSL,
         out_params: *mut *const u8,
@@ -31387,11 +31387,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_quic_use_legacy_codepoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_quic_use_legacy_codepoint"]
     pub fn SSL_set_quic_use_legacy_codepoint(ssl: *mut SSL, use_legacy: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_quic_early_data_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_quic_early_data_context"]
     pub fn SSL_set_quic_early_data_context(
         ssl: *mut SSL,
         context: *const u8,
@@ -31399,35 +31399,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_early_data_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_early_data_enabled"]
     pub fn SSL_CTX_set_early_data_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_early_data_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_early_data_enabled"]
     pub fn SSL_set_early_data_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_in_early_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_in_early_data"]
     pub fn SSL_in_early_data(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_early_data_capable"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_early_data_capable"]
     pub fn SSL_SESSION_early_data_capable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_copy_without_early_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_copy_without_early_data"]
     pub fn SSL_SESSION_copy_without_early_data(session: *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_early_data_accepted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_early_data_accepted"]
     pub fn SSL_early_data_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_reset_early_data_reject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_reset_early_data_reject"]
     pub fn SSL_reset_early_data_reject(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_ticket_age_skew"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_ticket_age_skew"]
     pub fn SSL_get_ticket_age_skew(ssl: *const SSL) -> i32;
 }
 pub const ssl_early_data_reason_t_ssl_early_data_unknown: ssl_early_data_reason_t = 0;
@@ -31449,21 +31449,21 @@ pub const ssl_early_data_reason_t_ssl_early_data_alps_mismatch: ssl_early_data_r
 pub const ssl_early_data_reason_t_ssl_early_data_reason_max_value: ssl_early_data_reason_t = 14;
 pub type ssl_early_data_reason_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_early_data_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_early_data_reason"]
     pub fn SSL_get_early_data_reason(ssl: *const SSL) -> ssl_early_data_reason_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_early_data_reason_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_early_data_reason_string"]
     pub fn SSL_early_data_reason_string(
         reason: ssl_early_data_reason_t,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_enable_ech_grease"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_enable_ech_grease"]
     pub fn SSL_set_enable_ech_grease(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_ech_config_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_ech_config_list"]
     pub fn SSL_set1_ech_config_list(
         ssl: *mut SSL,
         ech_config_list: *const u8,
@@ -31471,7 +31471,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_ech_name_override"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_ech_name_override"]
     pub fn SSL_get0_ech_name_override(
         ssl: *const SSL,
         out_name: *mut *const ::std::os::raw::c_char,
@@ -31479,7 +31479,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_ech_retry_configs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_ech_retry_configs"]
     pub fn SSL_get0_ech_retry_configs(
         ssl: *const SSL,
         out_retry_configs: *mut *const u8,
@@ -31487,7 +31487,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_marshal_ech_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_marshal_ech_config"]
     pub fn SSL_marshal_ech_config(
         out: *mut *mut u8,
         out_len: *mut usize,
@@ -31498,19 +31498,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_ECH_KEYS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_ECH_KEYS_new"]
     pub fn SSL_ECH_KEYS_new() -> *mut SSL_ECH_KEYS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_ECH_KEYS_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_ECH_KEYS_up_ref"]
     pub fn SSL_ECH_KEYS_up_ref(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_ECH_KEYS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_ECH_KEYS_free"]
     pub fn SSL_ECH_KEYS_free(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_ECH_KEYS_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_ECH_KEYS_add"]
     pub fn SSL_ECH_KEYS_add(
         keys: *mut SSL_ECH_KEYS,
         is_retry_config: ::std::os::raw::c_int,
@@ -31520,12 +31520,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_ECH_KEYS_has_duplicate_config_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_ECH_KEYS_has_duplicate_config_id"]
     pub fn SSL_ECH_KEYS_has_duplicate_config_id(keys: *const SSL_ECH_KEYS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_ECH_KEYS_marshal_retry_configs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_ECH_KEYS_marshal_retry_configs"]
     pub fn SSL_ECH_KEYS_marshal_retry_configs(
         keys: *const SSL_ECH_KEYS,
         out: *mut *mut u8,
@@ -31533,34 +31533,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_ech_keys"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_ech_keys"]
     pub fn SSL_CTX_set1_ech_keys(
         ctx: *mut SSL_CTX,
         keys: *mut SSL_ECH_KEYS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_ech_accepted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_ech_accepted"]
     pub fn SSL_ech_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_alert_type_string_long"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_alert_type_string_long"]
     pub fn SSL_alert_type_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_alert_desc_string_long"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_alert_desc_string_long"]
     pub fn SSL_alert_desc_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_send_fatal_alert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_send_fatal_alert"]
     pub fn SSL_send_fatal_alert(ssl: *mut SSL, alert: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_ex_data"]
     pub fn SSL_set_ex_data(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -31568,14 +31568,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_ex_data"]
     pub fn SSL_get_ex_data(
         ssl: *const SSL,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_ex_new_index"]
     pub fn SSL_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31585,7 +31585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_set_ex_data"]
     pub fn SSL_SESSION_set_ex_data(
         session: *mut SSL_SESSION,
         idx: ::std::os::raw::c_int,
@@ -31593,14 +31593,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get_ex_data"]
     pub fn SSL_SESSION_get_ex_data(
         session: *const SSL_SESSION,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get_ex_new_index"]
     pub fn SSL_SESSION_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31610,7 +31610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_ex_data"]
     pub fn SSL_CTX_set_ex_data(
         ctx: *mut SSL_CTX,
         idx: ::std::os::raw::c_int,
@@ -31618,14 +31618,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_ex_data"]
     pub fn SSL_CTX_get_ex_data(
         ctx: *const SSL_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_ex_new_index"]
     pub fn SSL_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31635,7 +31635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_ivs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_ivs"]
     pub fn SSL_get_ivs(
         ssl: *const SSL,
         out_read_iv: *mut *const u8,
@@ -31644,11 +31644,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_key_block_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_key_block_len"]
     pub fn SSL_get_key_block_len(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_generate_key_block"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_generate_key_block"]
     pub fn SSL_generate_key_block(
         ssl: *const SSL,
         out: *mut u8,
@@ -31656,26 +31656,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_read_sequence"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_read_sequence"]
     pub fn SSL_get_read_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_write_sequence"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_write_sequence"]
     pub fn SSL_get_write_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_record_protocol_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_record_protocol_version"]
     pub fn SSL_CTX_set_record_protocol_version(
         ctx: *mut SSL_CTX,
         version: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_serialize_capabilities"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_serialize_capabilities"]
     pub fn SSL_serialize_capabilities(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_request_handshake_hints"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_request_handshake_hints"]
     pub fn SSL_request_handshake_hints(
         ssl: *mut SSL,
         client_hello: *const u8,
@@ -31685,11 +31685,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_serialize_handshake_hints"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_serialize_handshake_hints"]
     pub fn SSL_serialize_handshake_hints(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_handshake_hints"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_handshake_hints"]
     pub fn SSL_set_handshake_hints(
         ssl: *mut SSL,
         hints: *const u8,
@@ -31697,7 +31697,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_msg_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_msg_callback"]
     pub fn SSL_CTX_set_msg_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31714,11 +31714,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_msg_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_msg_callback_arg"]
     pub fn SSL_CTX_set_msg_callback_arg(ctx: *mut SSL_CTX, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_msg_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_msg_callback"]
     pub fn SSL_set_msg_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31735,11 +31735,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_msg_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_msg_callback_arg"]
     pub fn SSL_set_msg_callback_arg(ssl: *mut SSL, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_keylog_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_keylog_callback"]
     pub fn SSL_CTX_set_keylog_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31748,7 +31748,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_keylog_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_keylog_callback"]
     pub fn SSL_CTX_get_keylog_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -31756,14 +31756,14 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_current_time_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_current_time_cb"]
     pub fn SSL_CTX_set_current_time_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<unsafe extern "C" fn(ssl: *const SSL, out_clock: *mut timeval)>,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_shed_handshake_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_shed_handshake_config"]
     pub fn SSL_set_shed_handshake_config(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_never: ssl_renegotiate_mode_t = 0;
@@ -31773,46 +31773,46 @@ pub const ssl_renegotiate_mode_t_ssl_renegotiate_ignore: ssl_renegotiate_mode_t 
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_explicit: ssl_renegotiate_mode_t = 4;
 pub type ssl_renegotiate_mode_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_renegotiate_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_renegotiate_mode"]
     pub fn SSL_set_renegotiate_mode(ssl: *mut SSL, mode: ssl_renegotiate_mode_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_renegotiate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_renegotiate"]
     pub fn SSL_renegotiate(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_renegotiate_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_renegotiate_pending"]
     pub fn SSL_renegotiate_pending(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_total_renegotiations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_total_renegotiations"]
     pub fn SSL_total_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_max_cert_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_max_cert_list"]
     pub fn SSL_CTX_get_max_cert_list(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_max_cert_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_max_cert_list"]
     pub fn SSL_CTX_set_max_cert_list(ctx: *mut SSL_CTX, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_max_cert_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_max_cert_list"]
     pub fn SSL_get_max_cert_list(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_max_cert_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_max_cert_list"]
     pub fn SSL_set_max_cert_list(ssl: *mut SSL, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_max_send_fragment"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_max_send_fragment"]
     pub fn SSL_CTX_set_max_send_fragment(
         ctx: *mut SSL_CTX,
         max_send_fragment: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_max_send_fragment"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_max_send_fragment"]
     pub fn SSL_set_max_send_fragment(
         ssl: *mut SSL,
         max_send_fragment: usize,
@@ -32006,7 +32006,7 @@ pub const ssl_select_cert_result_t_ssl_select_cert_retry: ssl_select_cert_result
 pub const ssl_select_cert_result_t_ssl_select_cert_error: ssl_select_cert_result_t = -1;
 pub type ssl_select_cert_result_t = ::std::os::raw::c_int;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_early_callback_ctx_extension_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_early_callback_ctx_extension_get"]
     pub fn SSL_early_callback_ctx_extension_get(
         client_hello: *const SSL_CLIENT_HELLO,
         extension_type: u16,
@@ -32015,7 +32015,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_select_certificate_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_select_certificate_cb"]
     pub fn SSL_CTX_set_select_certificate_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32024,7 +32024,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_dos_protection_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_dos_protection_cb"]
     pub fn SSL_CTX_set_dos_protection_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32033,19 +32033,19 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_reverify_on_resume"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_reverify_on_resume"]
     pub fn SSL_CTX_set_reverify_on_resume(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_enforce_rsa_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_enforce_rsa_key_usage"]
     pub fn SSL_set_enforce_rsa_key_usage(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_was_key_usage_invalid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_was_key_usage_invalid"]
     pub fn SSL_was_key_usage_invalid(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_info_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_info_callback"]
     pub fn SSL_CTX_set_info_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32058,7 +32058,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_info_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_info_callback"]
     pub fn SSL_CTX_get_info_callback(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -32070,7 +32070,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_info_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_info_callback"]
     pub fn SSL_set_info_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32083,7 +32083,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_info_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_info_callback"]
     pub fn SSL_get_info_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -32095,77 +32095,77 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_state_string_long"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_state_string_long"]
     pub fn SSL_state_string_long(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_shutdown"]
     pub fn SSL_get_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_peer_signature_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_peer_signature_algorithm"]
     pub fn SSL_get_peer_signature_algorithm(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_client_random"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_client_random"]
     pub fn SSL_get_client_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_server_random"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_server_random"]
     pub fn SSL_get_server_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_pending_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_pending_cipher"]
     pub fn SSL_get_pending_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_set_retain_only_sha256_of_client_certs(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_CTX_set_retain_only_sha256_of_client_certs(
         ctx: *mut SSL_CTX,
         enable: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_grease_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_grease_enabled"]
     pub fn SSL_CTX_set_grease_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_permute_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_permute_extensions"]
     pub fn SSL_CTX_set_permute_extensions(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_permute_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_permute_extensions"]
     pub fn SSL_set_permute_extensions(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_max_seal_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_max_seal_overhead"]
     pub fn SSL_max_seal_overhead(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_false_start_allowed_without_alpn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_false_start_allowed_without_alpn"]
     pub fn SSL_CTX_set_false_start_allowed_without_alpn(
         ctx: *mut SSL_CTX,
         allowed: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_used_hello_retry_request"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_used_hello_retry_request"]
     pub fn SSL_used_hello_retry_request(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_jdk11_workaround"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_jdk11_workaround"]
     pub fn SSL_set_jdk11_workaround(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_library_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_library_init"]
     pub fn SSL_library_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_description"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_description"]
     pub fn SSL_CIPHER_description(
         cipher: *const SSL_CIPHER,
         buf: *mut ::std::os::raw::c_char,
@@ -32173,11 +32173,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_version"]
     pub fn SSL_CIPHER_get_version(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_rfc_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_rfc_name"]
     pub fn SSL_CIPHER_get_rfc_name(cipher: *const SSL_CIPHER) -> *mut ::std::os::raw::c_char;
 }
 pub type COMP_METHOD = ::std::os::raw::c_void;
@@ -32188,126 +32188,126 @@ pub struct stack_st_SSL_COMP {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_COMP_get_compression_methods"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_COMP_get_compression_methods"]
     pub fn SSL_COMP_get_compression_methods() -> *mut stack_st_SSL_COMP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_COMP_add_compression_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_COMP_add_compression_method"]
     pub fn SSL_COMP_add_compression_method(
         id: ::std::os::raw::c_int,
         cm: *mut COMP_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_COMP_get_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_COMP_get_name"]
     pub fn SSL_COMP_get_name(comp: *const COMP_METHOD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_COMP_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_COMP_get0_name"]
     pub fn SSL_COMP_get0_name(comp: *const SSL_COMP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_COMP_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_COMP_get_id"]
     pub fn SSL_COMP_get_id(comp: *const SSL_COMP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_COMP_free_compression_methods"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_COMP_free_compression_methods"]
     pub fn SSL_COMP_free_compression_methods();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSLv23_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSLv23_method"]
     pub fn SSLv23_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLSv1_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLSv1_method"]
     pub fn TLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLSv1_1_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLSv1_1_method"]
     pub fn TLSv1_1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLSv1_2_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLSv1_2_method"]
     pub fn TLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLSv1_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLSv1_method"]
     pub fn DTLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLSv1_2_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLSv1_2_method"]
     pub fn DTLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLS_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLS_server_method"]
     pub fn TLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLS_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLS_client_method"]
     pub fn TLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSLv23_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSLv23_server_method"]
     pub fn SSLv23_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSLv23_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSLv23_client_method"]
     pub fn SSLv23_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLSv1_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLSv1_server_method"]
     pub fn TLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLSv1_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLSv1_client_method"]
     pub fn TLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLSv1_1_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLSv1_1_server_method"]
     pub fn TLSv1_1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLSv1_1_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLSv1_1_client_method"]
     pub fn TLSv1_1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLSv1_2_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLSv1_2_server_method"]
     pub fn TLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLSv1_2_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLSv1_2_client_method"]
     pub fn TLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLS_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLS_server_method"]
     pub fn DTLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLS_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLS_client_method"]
     pub fn DTLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLSv1_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLSv1_server_method"]
     pub fn DTLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLSv1_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLSv1_client_method"]
     pub fn DTLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLSv1_2_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLSv1_2_server_method"]
     pub fn DTLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLSv1_2_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLSv1_2_client_method"]
     pub fn DTLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_clear"]
     pub fn SSL_clear(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tmp_rsa_callback"]
     pub fn SSL_CTX_set_tmp_rsa_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32320,7 +32320,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_tmp_rsa_callback"]
     pub fn SSL_set_tmp_rsa_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32333,98 +32333,98 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_connect"]
     pub fn SSL_CTX_sess_connect(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_connect_good"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_connect_good"]
     pub fn SSL_CTX_sess_connect_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_connect_renegotiate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_connect_renegotiate"]
     pub fn SSL_CTX_sess_connect_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_accept"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_accept"]
     pub fn SSL_CTX_sess_accept(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_accept_renegotiate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_accept_renegotiate"]
     pub fn SSL_CTX_sess_accept_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_accept_good"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_accept_good"]
     pub fn SSL_CTX_sess_accept_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_hits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_hits"]
     pub fn SSL_CTX_sess_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_cb_hits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_cb_hits"]
     pub fn SSL_CTX_sess_cb_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_misses"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_misses"]
     pub fn SSL_CTX_sess_misses(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_timeouts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_timeouts"]
     pub fn SSL_CTX_sess_timeouts(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_cache_full"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_cache_full"]
     pub fn SSL_CTX_sess_cache_full(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_cutthrough_complete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_cutthrough_complete"]
     pub fn SSL_cutthrough_complete(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_num_renegotiations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_num_renegotiations"]
     pub fn SSL_num_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_need_tmp_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_need_tmp_RSA"]
     pub fn SSL_CTX_need_tmp_RSA(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_need_tmp_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_need_tmp_RSA"]
     pub fn SSL_need_tmp_RSA(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tmp_rsa"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tmp_rsa"]
     pub fn SSL_CTX_set_tmp_rsa(ctx: *mut SSL_CTX, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_tmp_rsa"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_tmp_rsa"]
     pub fn SSL_set_tmp_rsa(ssl: *mut SSL, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_read_ahead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_read_ahead"]
     pub fn SSL_CTX_get_read_ahead(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_read_ahead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_read_ahead"]
     pub fn SSL_CTX_set_read_ahead(
         ctx: *mut SSL_CTX,
         yes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_read_ahead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_read_ahead"]
     pub fn SSL_get_read_ahead(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_read_ahead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_read_ahead"]
     pub fn SSL_set_read_ahead(ssl: *mut SSL, yes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_state"]
     pub fn SSL_set_state(ssl: *mut SSL, state: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_shared_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_shared_ciphers"]
     pub fn SSL_get_shared_ciphers(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_char,
@@ -32432,7 +32432,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_shared_sigalgs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_shared_sigalgs"]
     pub fn SSL_get_shared_sigalgs(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -32444,11 +32444,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_SSL_SESSION"]
     pub fn i2d_SSL_SESSION(in_: *mut SSL_SESSION, pp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_SSL_SESSION"]
     pub fn d2i_SSL_SESSION(
         a: *mut *mut SSL_SESSION,
         pp: *mut *const u8,
@@ -32456,61 +32456,61 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_SSL_SESSION_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_SSL_SESSION_bio"]
     pub fn i2d_SSL_SESSION_bio(bio: *mut BIO, session: *const SSL_SESSION)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_SSL_SESSION_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_SSL_SESSION_bio"]
     pub fn d2i_SSL_SESSION_bio(bio: *mut BIO, out: *mut *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_load_SSL_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_load_SSL_strings"]
     pub fn ERR_load_SSL_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_load_error_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_load_error_strings"]
     pub fn SSL_load_error_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_use_srtp"]
     pub fn SSL_CTX_set_tlsext_use_srtp(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_tlsext_use_srtp"]
     pub fn SSL_set_tlsext_use_srtp(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_current_compression"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_current_compression"]
     pub fn SSL_get_current_compression(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_current_expansion"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_current_expansion"]
     pub fn SSL_get_current_expansion(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_server_tmp_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_server_tmp_key"]
     pub fn SSL_get_server_tmp_key(
         ssl: *mut SSL,
         out_key: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tmp_dh"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tmp_dh"]
     pub fn SSL_CTX_set_tmp_dh(ctx: *mut SSL_CTX, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_tmp_dh"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_tmp_dh"]
     pub fn SSL_set_tmp_dh(ssl: *mut SSL, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tmp_dh_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tmp_dh_callback"]
     pub fn SSL_CTX_set_tmp_dh_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32523,7 +32523,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_tmp_dh_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_tmp_dh_callback"]
     pub fn SSL_set_tmp_dh_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32536,7 +32536,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_sigalgs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_sigalgs"]
     pub fn SSL_CTX_set1_sigalgs(
         ctx: *mut SSL_CTX,
         values: *const ::std::os::raw::c_int,
@@ -32544,7 +32544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_sigalgs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_sigalgs"]
     pub fn SSL_set1_sigalgs(
         ssl: *mut SSL,
         values: *const ::std::os::raw::c_int,
@@ -32552,25 +32552,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_sigalgs_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_sigalgs_list"]
     pub fn SSL_CTX_set1_sigalgs_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_sigalgs_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_sigalgs_list"]
     pub fn SSL_set1_sigalgs_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_security_level"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_security_level"]
     pub fn SSL_CTX_get_security_level(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_security_level"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_security_level"]
     pub fn SSL_CTX_set_security_level(ctx: *const SSL_CTX, level: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -32650,26 +32650,26 @@ pub type sk_SSL_COMP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_cache_hit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_cache_hit"]
     pub fn SSL_cache_hit(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_default_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_default_timeout"]
     pub fn SSL_get_default_timeout(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_version"]
     pub fn SSL_get_version(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_cipher_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_cipher_list"]
     pub fn SSL_get_cipher_list(
         ssl: *const SSL,
         n: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_client_cert_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_client_cert_cb"]
     pub fn SSL_CTX_set_client_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32682,11 +32682,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_want"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_want"]
     pub fn SSL_want(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_finished"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_finished"]
     pub fn SSL_get_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32694,7 +32694,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_peer_finished"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_peer_finished"]
     pub fn SSL_get_peer_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32702,15 +32702,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_alert_type_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_alert_type_string"]
     pub fn SSL_alert_type_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_alert_desc_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_alert_desc_string"]
     pub fn SSL_alert_desc_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_state_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_state_string"]
     pub fn SSL_state_string(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 #[repr(C)]
@@ -32720,42 +32720,42 @@ pub struct ssl_conf_ctx_st {
 }
 pub type SSL_CONF_CTX = ssl_conf_ctx_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_state"]
     pub fn SSL_state(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_shutdown"]
     pub fn SSL_set_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tmp_ecdh"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tmp_ecdh"]
     pub fn SSL_CTX_set_tmp_ecdh(ctx: *mut SSL_CTX, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_tmp_ecdh"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_tmp_ecdh"]
     pub fn SSL_set_tmp_ecdh(ssl: *mut SSL, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_add_dir_cert_subjects_to_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_add_dir_cert_subjects_to_stack"]
     pub fn SSL_add_dir_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         dir: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_enable_tls_channel_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_enable_tls_channel_id"]
     pub fn SSL_CTX_enable_tls_channel_id(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_enable_tls_channel_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_enable_tls_channel_id"]
     pub fn SSL_enable_tls_channel_id(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_f_ssl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_f_ssl"]
     pub fn BIO_f_ssl() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_ssl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_ssl"]
     pub fn BIO_set_ssl(
         bio: *mut BIO,
         ssl: *mut SSL,
@@ -32763,33 +32763,33 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_session"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_session"]
     pub fn SSL_get_session(ssl: *const SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get1_session"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get1_session"]
     pub fn SSL_get1_session(ssl: *mut SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_init_ssl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_init_ssl"]
     pub fn OPENSSL_init_ssl(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_tlsext_status_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_tlsext_status_type"]
     pub fn SSL_set_tlsext_status_type(
         ssl: *mut SSL,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_tlsext_status_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_tlsext_status_type"]
     pub fn SSL_get_tlsext_status_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_tlsext_status_ocsp_resp"]
     pub fn SSL_set_tlsext_status_ocsp_resp(
         ssl: *mut SSL,
         resp: *mut u8,
@@ -32797,11 +32797,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_tlsext_status_ocsp_resp"]
     pub fn SSL_get_tlsext_status_ocsp_resp(ssl: *const SSL, out: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_status_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_status_cb"]
     pub fn SSL_CTX_set_tlsext_status_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -32813,18 +32813,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_status_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_status_arg"]
     pub fn SSL_CTX_set_tlsext_status_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_value"]
     pub fn SSL_CIPHER_get_value(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,

--- a/aws-lc-fips-sys/src/aarch64_unknown_linux_gnu_crypto.rs
+++ b/aws-lc-fips-sys/src/aarch64_unknown_linux_gnu_crypto.rs
@@ -4536,38 +4536,38 @@ pub type X509_STORE = x509_store_st;
 pub type X509_TRUST = x509_trust_st;
 pub type OPENSSL_BLOCK = *mut ::std::os::raw::c_void;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4576,18 +4576,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4596,18 +4596,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4616,7 +4616,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -4624,11 +4624,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -4639,30 +4639,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -4701,30 +4701,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -4734,15 +4734,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -4806,7 +4806,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4814,7 +4814,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4822,15 +4822,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4842,7 +4842,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4851,7 +4851,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4862,7 +4862,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4873,7 +4873,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4885,7 +4885,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4895,7 +4895,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4905,7 +4905,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4916,7 +4916,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5137,27 +5137,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5165,29 +5165,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5195,7 +5195,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5327,27 +5327,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -5355,11 +5355,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -5367,22 +5367,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -5391,7 +5391,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -5400,35 +5400,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -5438,7 +5438,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -5498,7 +5498,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -5604,19 +5604,19 @@ impl Default for crypto_mutex_st {
 pub type CRYPTO_MUTEX = crypto_mutex_st;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5629,7 +5629,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5643,7 +5643,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5654,29 +5654,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -5732,7 +5732,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5743,7 +5743,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5756,7 +5756,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5768,7 +5768,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -5777,7 +5777,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5788,7 +5788,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -5815,23 +5815,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -5839,7 +5839,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -5847,7 +5847,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5855,7 +5855,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5863,15 +5863,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5880,7 +5880,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5888,7 +5888,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5897,67 +5897,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -5983,7 +5983,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5991,68 +5991,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6060,7 +6060,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6068,7 +6068,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6077,11 +6077,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -6090,15 +6090,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -6106,11 +6106,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -6118,22 +6118,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -6141,30 +6141,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -6172,89 +6172,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -6263,34 +6263,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -6299,13 +6299,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -6314,13 +6314,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -6333,7 +6333,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -6346,7 +6346,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -6359,7 +6359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6371,7 +6371,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -6385,7 +6385,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6398,7 +6398,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -6411,7 +6411,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6423,23 +6423,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -6449,7 +6449,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -6457,37 +6457,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -6499,7 +6499,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6869,193 +6869,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7064,15 +7064,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7082,11 +7082,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -7094,47 +7094,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7142,11 +7142,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7154,43 +7154,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -7199,7 +7199,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7209,7 +7209,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7218,7 +7218,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7228,7 +7228,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7237,7 +7237,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7247,7 +7247,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7256,7 +7256,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7266,7 +7266,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7275,7 +7275,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7284,7 +7284,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7292,7 +7292,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7301,7 +7301,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7310,7 +7310,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7319,11 +7319,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -7331,7 +7331,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -7391,15 +7391,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -7413,7 +7413,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -7421,11 +7421,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7440,7 +7440,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -7450,7 +7450,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -7461,7 +7461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7471,7 +7471,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7480,7 +7480,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7489,7 +7489,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7498,7 +7498,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7508,7 +7508,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7518,23 +7518,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7543,7 +7543,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7552,7 +7552,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7562,7 +7562,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7571,7 +7571,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7581,7 +7581,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7592,7 +7592,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7603,15 +7603,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -7622,7 +7622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -7635,11 +7635,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -7647,7 +7647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -7655,7 +7655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -7803,15 +7803,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -7835,15 +7835,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7852,7 +7852,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -7860,14 +7860,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -7875,7 +7875,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -7883,7 +7883,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -7891,7 +7891,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -7899,14 +7899,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -7914,7 +7914,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7922,22 +7922,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8013,54 +8013,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8068,7 +8068,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8076,79 +8076,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -8156,7 +8156,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -8164,7 +8164,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -8172,7 +8172,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -8180,7 +8180,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -8188,7 +8188,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -8196,7 +8196,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -8204,7 +8204,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -8212,7 +8212,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -8220,117 +8220,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -8338,14 +8338,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8355,7 +8355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8367,7 +8367,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -8377,7 +8377,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -8387,15 +8387,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8403,26 +8403,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8430,23 +8430,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8454,14 +8454,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8469,25 +8469,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -8495,7 +8495,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -8503,14 +8503,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -8539,19 +8539,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -8559,11 +8559,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -8571,54 +8571,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -8626,59 +8626,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -8686,23 +8686,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, t: time_t) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         t: time_t,
@@ -8711,26 +8711,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -8738,29 +8738,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
@@ -8769,22 +8769,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -8792,15 +8792,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -8809,11 +8809,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, t: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         t: time_t,
@@ -8822,41 +8822,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -8864,11 +8864,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8893,7 +8893,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -8903,11 +8903,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8915,11 +8915,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8927,7 +8927,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9261,15 +9261,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -9277,19 +9277,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9297,7 +9297,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9305,12 +9305,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9318,14 +9318,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9333,33 +9333,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -9367,7 +9367,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -9375,19 +9375,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -9395,7 +9395,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -9403,7 +9403,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -9413,7 +9413,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -9423,11 +9423,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -9435,33 +9435,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9469,34 +9469,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -10106,7 +10106,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10131,19 +10131,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -10153,19 +10153,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10175,7 +10175,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10183,11 +10183,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10197,7 +10197,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10205,7 +10205,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -10415,11 +10415,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -10427,11 +10427,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -10486,19 +10486,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10507,7 +10507,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10568,23 +10568,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -10592,82 +10592,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10675,7 +10675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10683,11 +10683,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10695,7 +10695,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10704,7 +10704,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10715,22 +10715,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10739,7 +10739,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10748,7 +10748,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -10757,7 +10757,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -10766,33 +10766,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10800,7 +10800,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10808,7 +10808,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -11115,23 +11115,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11139,40 +11139,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -11180,15 +11180,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11196,55 +11196,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -11252,11 +11252,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -11264,7 +11264,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -11272,11 +11272,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -11284,11 +11284,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -11299,114 +11299,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11417,7 +11417,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11427,7 +11427,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11437,7 +11437,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11447,7 +11447,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11455,7 +11455,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11465,7 +11465,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11473,7 +11473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11483,7 +11483,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11491,47 +11491,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -11540,45 +11540,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -11591,23 +11591,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11617,7 +11617,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11626,7 +11626,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11635,7 +11635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11643,7 +11643,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11651,7 +11651,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11659,7 +11659,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11668,118 +11668,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -12016,7 +12016,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -12026,19 +12026,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12048,15 +12048,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -12151,15 +12151,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -12167,7 +12167,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -12175,14 +12175,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -12190,7 +12190,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -12198,23 +12198,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12222,15 +12222,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12317,11 +12317,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12329,19 +12329,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12349,19 +12349,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -12459,11 +12459,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12471,19 +12471,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12491,15 +12491,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12597,11 +12597,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12609,34 +12609,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -12644,34 +12644,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -12679,7 +12679,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12688,7 +12688,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12697,7 +12697,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12705,7 +12705,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12713,21 +12713,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12735,7 +12735,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12743,7 +12743,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -12751,7 +12751,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -12760,7 +12760,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -12768,11 +12768,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -12799,51 +12799,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -12853,70 +12853,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -12924,15 +12924,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -12941,7 +12941,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -12950,7 +12950,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -12961,7 +12961,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -12971,11 +12971,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -12986,7 +12986,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13059,15 +13059,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13076,7 +13076,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13087,7 +13087,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13098,7 +13098,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13111,7 +13111,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13123,7 +13123,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_decrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13132,7 +13132,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_encrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13141,43 +13141,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13185,7 +13185,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13193,7 +13193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13202,7 +13202,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13211,40 +13211,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13253,11 +13253,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13265,7 +13265,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13276,19 +13276,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13296,19 +13296,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13323,7 +13323,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13331,14 +13331,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13346,114 +13346,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13461,11 +13461,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13473,7 +13473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13481,7 +13481,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13489,7 +13489,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13500,75 +13500,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13576,19 +13576,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -13680,15 +13680,15 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -13696,11 +13696,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -13708,15 +13708,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_METHOD_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_METHOD_unref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -13762,43 +13762,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -13806,7 +13806,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -13815,7 +13815,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -13823,7 +13823,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -13832,7 +13832,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -13844,11 +13844,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13902,28 +13902,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -13932,7 +13932,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13942,7 +13942,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13953,7 +13953,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13964,7 +13964,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13975,47 +13975,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14025,7 +14025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14033,14 +14033,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14048,11 +14048,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14060,11 +14060,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14072,11 +14072,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14084,7 +14084,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14240,19 +14240,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14260,19 +14260,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14280,7 +14280,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14290,53 +14290,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14344,7 +14344,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14353,7 +14353,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14363,7 +14363,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14373,7 +14373,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14383,7 +14383,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14393,7 +14393,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14404,7 +14404,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14414,7 +14414,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14424,7 +14424,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14434,7 +14434,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14444,7 +14444,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14453,7 +14453,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14461,7 +14461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14472,7 +14472,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14481,7 +14481,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14490,7 +14490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14498,11 +14498,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14512,15 +14512,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -14574,92 +14574,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -14667,7 +14667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -14676,15 +14676,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -14692,11 +14692,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -14704,22 +14704,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14729,7 +14729,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14737,7 +14737,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14859,11 +14859,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14871,11 +14871,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14883,11 +14883,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14895,14 +14895,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -14919,7 +14919,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -14928,7 +14928,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14939,7 +14939,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14950,7 +14950,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15004,23 +15004,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15028,7 +15028,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15036,7 +15036,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15044,7 +15044,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15053,19 +15053,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15073,11 +15073,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15087,7 +15087,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15095,83 +15095,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15309,11 +15309,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15322,11 +15322,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15337,11 +15337,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15356,7 +15356,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15371,7 +15371,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15389,7 +15389,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15404,66 +15404,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15474,7 +15474,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15482,7 +15482,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15491,7 +15491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15499,102 +15499,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -15602,40 +15602,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15644,7 +15644,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15653,7 +15653,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15661,7 +15661,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15669,7 +15669,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15679,7 +15679,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15687,7 +15687,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15695,7 +15695,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15705,7 +15705,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15715,7 +15715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15723,7 +15723,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15731,7 +15731,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15741,7 +15741,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15749,11 +15749,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15761,7 +15761,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -15770,7 +15770,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15778,11 +15778,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15790,7 +15790,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15799,7 +15799,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15808,7 +15808,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15817,7 +15817,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15826,7 +15826,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15839,7 +15839,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15851,7 +15851,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15866,31 +15866,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -15900,11 +15900,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -15914,11 +15914,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15928,11 +15928,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15942,11 +15942,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15956,18 +15956,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -15975,18 +15975,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -15996,7 +15996,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16006,102 +16006,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16109,28 +16109,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16138,7 +16138,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16146,7 +16146,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16156,31 +16156,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16194,7 +16194,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16208,15 +16208,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16225,7 +16225,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16233,7 +16233,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16242,22 +16242,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16265,40 +16265,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16306,11 +16306,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16318,11 +16318,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16330,11 +16330,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16342,14 +16342,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -16523,7 +16523,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16537,7 +16537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16549,7 +16549,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -16561,11 +16561,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16573,15 +16573,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -16668,7 +16668,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -16680,27 +16680,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16710,7 +16710,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -16718,7 +16718,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16726,23 +16726,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16751,7 +16751,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -16927,82 +16927,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17011,18 +17011,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17031,7 +17031,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17040,23 +17040,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17072,7 +17072,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17090,7 +17090,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17103,7 +17103,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17116,7 +17116,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17129,7 +17129,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17139,19 +17139,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17410,7 +17410,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17418,7 +17418,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17427,7 +17427,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17436,22 +17436,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17459,15 +17459,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17554,66 +17554,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -17622,7 +17622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -17630,7 +17630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -17638,7 +17638,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -17719,7 +17719,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -17738,7 +17738,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -17746,47 +17746,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18080,51 +18080,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18150,15 +18150,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18166,18 +18166,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18185,79 +18185,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18266,11 +18266,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18279,7 +18279,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18288,12 +18288,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18302,7 +18302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18311,7 +18311,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18319,7 +18319,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18331,7 +18331,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18343,7 +18343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -18353,7 +18353,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -18363,7 +18363,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18374,7 +18374,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18388,7 +18388,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18400,7 +18400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18411,7 +18411,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -18424,7 +18424,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18436,7 +18436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -18446,7 +18446,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -18456,31 +18456,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18491,7 +18491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18502,7 +18502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -18515,7 +18515,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -18526,19 +18526,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18546,19 +18546,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18566,7 +18566,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -18576,7 +18576,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -18584,26 +18584,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -18612,7 +18612,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18620,11 +18620,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18632,11 +18632,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18646,7 +18646,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18656,7 +18656,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -18667,7 +18667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -18675,7 +18675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -19176,27 +19176,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19204,51 +19204,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19261,15 +19261,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19277,7 +19277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19285,7 +19285,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19293,15 +19293,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19309,68 +19309,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19378,7 +19378,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19386,25 +19386,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19412,14 +19412,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -19427,7 +19427,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -19435,7 +19435,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -19443,14 +19443,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -19472,23 +19472,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19496,23 +19496,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -19521,19 +19521,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19541,7 +19541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -19549,7 +19549,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -19557,11 +19557,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19569,55 +19569,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -19625,7 +19625,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -19633,25 +19633,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -19659,19 +19659,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -19679,23 +19679,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19703,33 +19703,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -19737,22 +19737,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -19802,19 +19802,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -19822,15 +19822,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -19838,15 +19838,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19854,7 +19854,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19862,21 +19862,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -19885,7 +19885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19897,7 +19897,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19909,7 +19909,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -19921,19 +19921,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -19941,33 +19941,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -19976,11 +19976,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -19990,7 +19990,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20000,7 +20000,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20010,19 +20010,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20030,18 +20030,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20050,7 +20050,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20059,33 +20059,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20109,11 +20109,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20121,18 +20121,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20140,7 +20140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20148,7 +20148,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20156,21 +20156,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -20199,23 +20199,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -20223,11 +20223,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -20236,7 +20236,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -20245,15 +20245,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -20261,7 +20261,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -20269,7 +20269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20278,7 +20278,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20287,7 +20287,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -20296,7 +20296,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -20305,7 +20305,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -20314,259 +20314,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -20574,11 +20574,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20588,7 +20588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -20596,14 +20596,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20613,7 +20613,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -20621,42 +20621,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20665,7 +20665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -21238,11 +21238,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -21250,7 +21250,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -21258,54 +21258,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21313,23 +21313,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -21337,7 +21337,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -21346,44 +21346,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21391,34 +21391,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21426,26 +21426,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21453,18 +21453,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21472,38 +21472,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21511,25 +21511,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21537,7 +21537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21545,23 +21545,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21569,26 +21569,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21596,26 +21596,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -21623,7 +21623,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -21633,7 +21633,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -21643,7 +21643,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -21653,7 +21653,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21665,7 +21665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21676,15 +21676,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -21692,18 +21692,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21711,7 +21711,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21719,28 +21719,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21750,7 +21750,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21760,7 +21760,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -21770,37 +21770,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -21810,66 +21810,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -21878,19 +21878,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -21899,7 +21899,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -21907,7 +21907,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -21916,7 +21916,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -21925,15 +21925,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -21942,11 +21942,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -21955,7 +21955,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -21965,7 +21965,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21974,7 +21974,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21984,11 +21984,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21996,7 +21996,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -22004,7 +22004,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -22012,21 +22012,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -22034,7 +22034,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22043,7 +22043,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22053,11 +22053,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22065,7 +22065,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22073,28 +22073,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22104,7 +22104,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22114,7 +22114,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22124,7 +22124,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22134,7 +22134,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22144,7 +22144,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22154,14 +22154,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -22170,7 +22170,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -22179,34 +22179,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22214,26 +22214,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -22244,7 +22244,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -22254,11 +22254,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -22266,19 +22266,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -22295,19 +22295,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22394,15 +22394,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22410,14 +22410,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -22536,18 +22536,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22555,7 +22555,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22563,202 +22563,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -22766,15 +22766,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -22783,50 +22783,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -22835,7 +22835,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -22845,7 +22845,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22853,7 +22853,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22861,7 +22861,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22869,19 +22869,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -22890,11 +22890,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -22902,81 +22902,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -22985,11 +22985,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -22997,7 +22997,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23009,105 +23009,105 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23115,7 +23115,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23123,20 +23123,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -23144,7 +23144,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -23152,42 +23152,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -23199,14 +23199,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -23216,7 +23216,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23226,7 +23226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -23236,7 +23236,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -23248,7 +23248,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23259,7 +23259,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23273,7 +23273,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -23282,7 +23282,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23292,7 +23292,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -23302,7 +23302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23313,7 +23313,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23327,7 +23327,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -23336,7 +23336,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -23345,11 +23345,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_proc_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_dek_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -23358,7 +23358,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23367,7 +23367,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23376,15 +23376,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23393,7 +23393,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23402,15 +23402,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -23419,7 +23419,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -23428,23 +23428,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -23453,7 +23453,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -23462,15 +23462,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -23479,7 +23479,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -23488,15 +23488,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -23505,7 +23505,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -23514,15 +23514,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23531,7 +23531,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23540,21 +23540,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23563,7 +23563,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23572,7 +23572,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -23584,7 +23584,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -23596,7 +23596,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23605,7 +23605,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23614,15 +23614,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23631,7 +23631,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23640,15 +23640,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23657,7 +23657,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23666,7 +23666,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -23678,7 +23678,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -23690,7 +23690,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23699,7 +23699,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23708,15 +23708,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23725,7 +23725,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23734,15 +23734,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23751,7 +23751,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23760,7 +23760,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -23772,7 +23772,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -23784,7 +23784,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23793,7 +23793,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23802,15 +23802,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -23819,7 +23819,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -23828,15 +23828,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23845,7 +23845,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23854,7 +23854,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23866,7 +23866,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23878,7 +23878,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23887,7 +23887,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23896,15 +23896,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23916,7 +23916,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -23928,7 +23928,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23940,7 +23940,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23952,7 +23952,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23961,7 +23961,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23973,7 +23973,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23985,7 +23985,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23997,7 +23997,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24006,7 +24006,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24018,7 +24018,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -24031,7 +24031,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -24045,7 +24045,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -24053,7 +24053,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -24061,7 +24061,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -24070,11 +24070,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -24082,27 +24082,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24112,7 +24112,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24120,7 +24120,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -24135,74 +24135,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24303,19 +24303,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24380,11 +24380,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -24471,11 +24471,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -24483,42 +24483,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -24593,15 +24593,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24614,7 +24614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24629,18 +24629,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24649,14 +24649,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24665,7 +24665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24676,7 +24676,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24685,7 +24685,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24697,7 +24697,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -24709,18 +24709,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24728,14 +24728,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24743,7 +24743,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24757,7 +24757,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24772,7 +24772,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24785,7 +24785,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24800,7 +24800,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -26508,15 +26508,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26524,26 +26524,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26551,14 +26551,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -26790,15 +26790,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26806,26 +26806,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26833,26 +26833,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26860,29 +26860,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -26890,19 +26890,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26910,18 +26910,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -26929,7 +26929,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -26937,15 +26937,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26953,26 +26953,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26980,22 +26980,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -27003,14 +27003,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -27018,7 +27018,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -27026,14 +27026,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27041,15 +27041,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27057,33 +27057,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27091,26 +27091,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27118,26 +27118,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27145,26 +27145,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27172,26 +27172,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27199,26 +27199,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27226,26 +27226,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27253,26 +27253,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27280,26 +27280,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27307,38 +27307,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27346,26 +27346,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27373,70 +27373,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27447,7 +27447,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27455,7 +27455,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27465,7 +27465,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -27563,7 +27563,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -27574,11 +27574,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27587,7 +27587,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27596,7 +27596,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -27605,7 +27605,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27614,7 +27614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27623,7 +27623,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27632,7 +27632,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27641,67 +27641,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27710,14 +27710,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -27725,7 +27725,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27735,7 +27735,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -27744,7 +27744,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -27753,7 +27753,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -27762,7 +27762,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -27772,11 +27772,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -27784,70 +27784,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_akid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -27865,43 +27865,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27911,7 +27911,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27920,7 +27920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -27929,7 +27929,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -27937,15 +27937,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,

--- a/aws-lc-fips-sys/src/aarch64_unknown_linux_gnu_crypto_ssl.rs
+++ b/aws-lc-fips-sys/src/aarch64_unknown_linux_gnu_crypto_ssl.rs
@@ -5528,38 +5528,38 @@ pub type X509_STORE = x509_store_st;
 pub type X509_TRUST = x509_trust_st;
 pub type OPENSSL_BLOCK = *mut ::std::os::raw::c_void;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5568,18 +5568,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5588,18 +5588,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5608,7 +5608,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -5616,11 +5616,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -5631,30 +5631,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -5693,30 +5693,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -5726,15 +5726,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -5798,7 +5798,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5806,7 +5806,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5814,15 +5814,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5834,7 +5834,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5843,7 +5843,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5854,7 +5854,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5865,7 +5865,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5877,7 +5877,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5887,7 +5887,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5897,7 +5897,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5908,7 +5908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -6129,27 +6129,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -6157,29 +6157,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -6187,7 +6187,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -6319,27 +6319,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -6347,11 +6347,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6359,22 +6359,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6383,7 +6383,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -6392,35 +6392,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6430,7 +6430,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6490,7 +6490,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6596,19 +6596,19 @@ impl Default for crypto_mutex_st {
 pub type CRYPTO_MUTEX = crypto_mutex_st;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6621,7 +6621,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6635,7 +6635,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6646,29 +6646,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6724,7 +6724,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6735,7 +6735,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6748,7 +6748,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6760,7 +6760,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6769,7 +6769,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6780,7 +6780,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6807,23 +6807,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6831,7 +6831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6839,7 +6839,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6847,7 +6847,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6855,15 +6855,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6872,7 +6872,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6880,7 +6880,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6889,67 +6889,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6975,7 +6975,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6983,68 +6983,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -7052,7 +7052,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -7060,7 +7060,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -7069,11 +7069,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -7082,15 +7082,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -7098,11 +7098,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -7110,22 +7110,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -7133,30 +7133,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -7164,89 +7164,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -7255,34 +7255,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -7291,13 +7291,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -7306,13 +7306,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7325,7 +7325,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7338,7 +7338,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7351,7 +7351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7363,7 +7363,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7377,7 +7377,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7390,7 +7390,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7403,7 +7403,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7415,23 +7415,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7441,7 +7441,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7449,37 +7449,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7491,7 +7491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7861,193 +7861,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8056,15 +8056,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -8074,11 +8074,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -8086,47 +8086,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8134,11 +8134,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8146,43 +8146,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -8191,7 +8191,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8201,7 +8201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8210,7 +8210,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8220,7 +8220,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8229,7 +8229,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8239,7 +8239,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8248,7 +8248,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8258,7 +8258,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8267,7 +8267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8276,7 +8276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8284,7 +8284,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8293,7 +8293,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8302,7 +8302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8311,11 +8311,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8323,7 +8323,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8383,15 +8383,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8405,7 +8405,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8413,11 +8413,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8432,7 +8432,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8442,7 +8442,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8453,7 +8453,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8463,7 +8463,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8472,7 +8472,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8481,7 +8481,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8490,7 +8490,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8500,7 +8500,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8510,23 +8510,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8535,7 +8535,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8544,7 +8544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8554,7 +8554,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8563,7 +8563,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8573,7 +8573,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8584,7 +8584,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8595,15 +8595,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8614,7 +8614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8627,11 +8627,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8639,7 +8639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8647,7 +8647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -8795,15 +8795,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8827,15 +8827,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8844,7 +8844,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8852,14 +8852,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8867,7 +8867,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8875,7 +8875,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8883,7 +8883,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8891,14 +8891,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8906,7 +8906,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8914,22 +8914,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9005,54 +9005,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -9060,7 +9060,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -9068,79 +9068,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -9148,7 +9148,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -9156,7 +9156,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -9164,7 +9164,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -9172,7 +9172,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -9180,7 +9180,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -9188,7 +9188,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -9196,7 +9196,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -9204,7 +9204,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -9212,117 +9212,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9330,14 +9330,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9347,7 +9347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9359,7 +9359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9369,7 +9369,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9379,15 +9379,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9395,26 +9395,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9422,23 +9422,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9446,14 +9446,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9461,25 +9461,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9487,7 +9487,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9495,14 +9495,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9531,19 +9531,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9551,11 +9551,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9563,54 +9563,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9618,59 +9618,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9678,23 +9678,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, t: time_t) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         t: time_t,
@@ -9703,26 +9703,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9730,29 +9730,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
@@ -9761,22 +9761,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9784,15 +9784,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9801,11 +9801,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, t: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         t: time_t,
@@ -9814,41 +9814,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9856,11 +9856,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9885,7 +9885,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9895,11 +9895,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9907,11 +9907,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9919,7 +9919,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10253,15 +10253,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10269,19 +10269,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10289,7 +10289,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10297,12 +10297,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10310,14 +10310,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10325,33 +10325,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10359,7 +10359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10367,19 +10367,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10387,7 +10387,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10395,7 +10395,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10405,7 +10405,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10415,11 +10415,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10427,33 +10427,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10461,34 +10461,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -11098,7 +11098,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -11123,19 +11123,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -11145,19 +11145,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11167,7 +11167,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11175,11 +11175,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11189,7 +11189,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11197,7 +11197,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11407,11 +11407,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11419,11 +11419,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11478,19 +11478,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11499,7 +11499,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11560,23 +11560,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11584,82 +11584,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11667,7 +11667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11675,11 +11675,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11687,7 +11687,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11696,7 +11696,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11707,22 +11707,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11731,7 +11731,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11740,7 +11740,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11749,7 +11749,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11758,33 +11758,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11792,7 +11792,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11800,7 +11800,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -12107,23 +12107,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12131,40 +12131,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -12172,15 +12172,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12188,55 +12188,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -12244,11 +12244,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -12256,7 +12256,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12264,11 +12264,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12276,11 +12276,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12291,114 +12291,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12409,7 +12409,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12419,7 +12419,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12429,7 +12429,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12439,7 +12439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12447,7 +12447,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12457,7 +12457,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12465,7 +12465,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12475,7 +12475,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12483,47 +12483,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12532,45 +12532,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12583,23 +12583,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12609,7 +12609,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12618,7 +12618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12627,7 +12627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12635,7 +12635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12643,7 +12643,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12651,7 +12651,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12660,118 +12660,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -13008,7 +13008,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -13018,19 +13018,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -13040,15 +13040,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -13143,15 +13143,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -13159,7 +13159,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -13167,14 +13167,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -13182,7 +13182,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -13190,23 +13190,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13214,15 +13214,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13309,11 +13309,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13321,19 +13321,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13341,19 +13341,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -13451,11 +13451,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13463,19 +13463,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13483,15 +13483,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13589,11 +13589,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13601,34 +13601,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -13636,34 +13636,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13671,7 +13671,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13680,7 +13680,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13689,7 +13689,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13697,7 +13697,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13705,21 +13705,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13727,7 +13727,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13735,7 +13735,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -13743,7 +13743,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -13752,7 +13752,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -13760,11 +13760,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -13791,51 +13791,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -13845,70 +13845,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13916,15 +13916,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13933,7 +13933,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13942,7 +13942,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13953,7 +13953,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13963,11 +13963,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13978,7 +13978,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -14051,15 +14051,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -14068,7 +14068,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14079,7 +14079,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -14090,7 +14090,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14103,7 +14103,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14115,7 +14115,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_decrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -14124,7 +14124,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_encrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -14133,43 +14133,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -14177,7 +14177,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -14185,7 +14185,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -14194,7 +14194,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -14203,40 +14203,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -14245,11 +14245,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14257,7 +14257,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -14268,19 +14268,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -14288,19 +14288,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -14315,7 +14315,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -14323,14 +14323,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14338,114 +14338,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -14453,11 +14453,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -14465,7 +14465,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14473,7 +14473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14481,7 +14481,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -14492,75 +14492,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -14568,19 +14568,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14672,15 +14672,15 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -14688,11 +14688,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -14700,15 +14700,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_METHOD_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_METHOD_unref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -14754,43 +14754,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14798,7 +14798,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14807,7 +14807,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14815,7 +14815,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14824,7 +14824,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14836,11 +14836,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14894,28 +14894,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14924,7 +14924,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14934,7 +14934,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14945,7 +14945,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14956,7 +14956,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14967,47 +14967,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15017,7 +15017,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -15025,14 +15025,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -15040,11 +15040,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15052,11 +15052,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15064,11 +15064,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15076,7 +15076,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15232,19 +15232,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -15252,19 +15252,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -15272,7 +15272,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -15282,53 +15282,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15336,7 +15336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -15345,7 +15345,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15355,7 +15355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15365,7 +15365,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15375,7 +15375,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15385,7 +15385,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15396,7 +15396,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -15406,7 +15406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15416,7 +15416,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15426,7 +15426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15436,7 +15436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15445,7 +15445,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -15453,7 +15453,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15464,7 +15464,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -15473,7 +15473,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -15482,7 +15482,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -15490,11 +15490,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15504,15 +15504,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -15566,92 +15566,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -15659,7 +15659,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15668,15 +15668,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15684,11 +15684,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15696,22 +15696,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15721,7 +15721,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15729,7 +15729,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15851,11 +15851,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15863,11 +15863,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15875,11 +15875,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15887,14 +15887,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15911,7 +15911,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15920,7 +15920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15931,7 +15931,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15942,7 +15942,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15996,23 +15996,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -16020,7 +16020,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -16028,7 +16028,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -16036,7 +16036,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -16045,19 +16045,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -16065,11 +16065,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -16079,7 +16079,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -16087,83 +16087,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -16301,11 +16301,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -16314,11 +16314,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16329,11 +16329,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16348,7 +16348,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16363,7 +16363,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16381,7 +16381,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16396,66 +16396,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16466,7 +16466,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -16474,7 +16474,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -16483,7 +16483,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -16491,102 +16491,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16594,40 +16594,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16636,7 +16636,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16645,7 +16645,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16653,7 +16653,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16661,7 +16661,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16671,7 +16671,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16679,7 +16679,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16687,7 +16687,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16697,7 +16697,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16707,7 +16707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16715,7 +16715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16723,7 +16723,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16733,7 +16733,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16741,11 +16741,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16753,7 +16753,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16762,7 +16762,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16770,11 +16770,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16782,7 +16782,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16791,7 +16791,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16800,7 +16800,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16809,7 +16809,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16818,7 +16818,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16831,7 +16831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16843,7 +16843,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16858,31 +16858,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16892,11 +16892,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16906,11 +16906,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16920,11 +16920,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16934,11 +16934,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16948,18 +16948,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16967,18 +16967,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16988,7 +16988,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16998,102 +16998,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -17101,28 +17101,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -17130,7 +17130,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -17138,7 +17138,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -17148,31 +17148,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -17186,7 +17186,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -17200,15 +17200,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -17217,7 +17217,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -17225,7 +17225,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -17234,22 +17234,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -17257,40 +17257,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -17298,11 +17298,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -17310,11 +17310,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -17322,11 +17322,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -17334,14 +17334,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -17515,7 +17515,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -17529,7 +17529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -17541,7 +17541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -17553,11 +17553,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17565,15 +17565,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17660,7 +17660,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17672,27 +17672,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17702,7 +17702,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17710,7 +17710,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17718,23 +17718,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17743,7 +17743,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17919,82 +17919,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -18003,18 +18003,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -18023,7 +18023,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -18032,23 +18032,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -18064,7 +18064,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -18082,7 +18082,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -18095,7 +18095,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -18108,7 +18108,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -18121,7 +18121,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -18131,19 +18131,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -18402,7 +18402,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -18410,7 +18410,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -18419,7 +18419,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -18428,22 +18428,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18451,15 +18451,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18546,66 +18546,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -18614,7 +18614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -18622,7 +18622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -18630,7 +18630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -18711,7 +18711,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -18730,7 +18730,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18738,47 +18738,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -19072,51 +19072,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19142,15 +19142,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -19158,18 +19158,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -19177,79 +19177,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -19258,11 +19258,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -19271,7 +19271,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -19280,12 +19280,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -19294,7 +19294,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19303,7 +19303,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19311,7 +19311,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19323,7 +19323,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19335,7 +19335,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19345,7 +19345,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19355,7 +19355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19366,7 +19366,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19380,7 +19380,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19392,7 +19392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19403,7 +19403,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19416,7 +19416,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19428,7 +19428,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19438,7 +19438,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19448,31 +19448,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19483,7 +19483,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19494,7 +19494,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19507,7 +19507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19518,19 +19518,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19538,19 +19538,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19558,7 +19558,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19568,7 +19568,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19576,26 +19576,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19604,7 +19604,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19612,11 +19612,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19624,11 +19624,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19638,7 +19638,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19648,7 +19648,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19659,7 +19659,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19667,7 +19667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -20168,27 +20168,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -20196,51 +20196,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -20253,15 +20253,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -20269,7 +20269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -20277,7 +20277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -20285,15 +20285,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -20301,68 +20301,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -20370,7 +20370,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -20378,25 +20378,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -20404,14 +20404,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -20419,7 +20419,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -20427,7 +20427,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -20435,14 +20435,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -20464,23 +20464,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -20488,23 +20488,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -20513,19 +20513,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20533,7 +20533,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20541,7 +20541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20549,11 +20549,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20561,55 +20561,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20617,7 +20617,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20625,25 +20625,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20651,19 +20651,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20671,23 +20671,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20695,33 +20695,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20729,22 +20729,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20794,19 +20794,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20814,15 +20814,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20830,15 +20830,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20846,7 +20846,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20854,21 +20854,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20877,7 +20877,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20889,7 +20889,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20901,7 +20901,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20913,19 +20913,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20933,33 +20933,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20968,11 +20968,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20982,7 +20982,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20992,7 +20992,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -21002,19 +21002,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -21022,18 +21022,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -21042,7 +21042,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -21051,33 +21051,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -21101,11 +21101,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -21113,18 +21113,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -21132,7 +21132,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -21140,7 +21140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -21148,21 +21148,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21191,23 +21191,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21215,11 +21215,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21228,7 +21228,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21237,15 +21237,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -21253,7 +21253,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -21261,7 +21261,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -21270,7 +21270,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -21279,7 +21279,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -21288,7 +21288,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -21297,7 +21297,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -21306,259 +21306,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -21566,11 +21566,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21580,7 +21580,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -21588,14 +21588,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21605,7 +21605,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -21613,42 +21613,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -21657,7 +21657,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -22230,11 +22230,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22242,7 +22242,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22250,54 +22250,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -22305,23 +22305,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22329,7 +22329,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22338,44 +22338,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22383,34 +22383,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22418,26 +22418,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22445,18 +22445,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -22464,38 +22464,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22503,25 +22503,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22529,7 +22529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22537,23 +22537,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22561,26 +22561,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22588,26 +22588,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22615,7 +22615,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22625,7 +22625,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22635,7 +22635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22645,7 +22645,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22657,7 +22657,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22668,15 +22668,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -22684,18 +22684,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22703,7 +22703,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22711,28 +22711,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22742,7 +22742,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22752,7 +22752,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -22762,37 +22762,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -22802,66 +22802,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -22870,19 +22870,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22891,7 +22891,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22899,7 +22899,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22908,7 +22908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22917,15 +22917,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22934,11 +22934,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -22947,7 +22947,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -22957,7 +22957,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22966,7 +22966,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22976,11 +22976,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22988,7 +22988,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -22996,7 +22996,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -23004,21 +23004,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -23026,7 +23026,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -23035,7 +23035,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -23045,11 +23045,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23057,7 +23057,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23065,28 +23065,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23096,7 +23096,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23106,7 +23106,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -23116,7 +23116,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23126,7 +23126,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23136,7 +23136,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -23146,14 +23146,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -23162,7 +23162,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -23171,34 +23171,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23206,26 +23206,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -23236,7 +23236,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -23246,11 +23246,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -23258,19 +23258,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -23287,19 +23287,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23386,15 +23386,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23402,14 +23402,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -23528,18 +23528,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23547,7 +23547,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23555,202 +23555,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23758,15 +23758,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -23775,50 +23775,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23827,7 +23827,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23837,7 +23837,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23845,7 +23845,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23853,7 +23853,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23861,19 +23861,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -23882,11 +23882,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23894,81 +23894,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -23977,11 +23977,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23989,7 +23989,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -24001,105 +24001,105 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -24107,7 +24107,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -24115,20 +24115,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -24136,7 +24136,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -24144,42 +24144,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -24191,14 +24191,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -24208,7 +24208,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -24218,7 +24218,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -24228,7 +24228,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -24240,7 +24240,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24251,7 +24251,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24265,7 +24265,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -24274,7 +24274,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -24284,7 +24284,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -24294,7 +24294,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24305,7 +24305,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24319,7 +24319,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -24328,7 +24328,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -24337,11 +24337,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_proc_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_dek_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -24350,7 +24350,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24359,7 +24359,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24368,15 +24368,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24385,7 +24385,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24394,15 +24394,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -24411,7 +24411,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -24420,23 +24420,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -24445,7 +24445,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -24454,15 +24454,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -24471,7 +24471,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -24480,15 +24480,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -24497,7 +24497,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -24506,15 +24506,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24523,7 +24523,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24532,21 +24532,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24555,7 +24555,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24564,7 +24564,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -24576,7 +24576,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -24588,7 +24588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24597,7 +24597,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24606,15 +24606,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24623,7 +24623,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24632,15 +24632,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24649,7 +24649,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24658,7 +24658,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -24670,7 +24670,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -24682,7 +24682,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24691,7 +24691,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24700,15 +24700,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24717,7 +24717,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24726,15 +24726,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24743,7 +24743,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24752,7 +24752,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -24764,7 +24764,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -24776,7 +24776,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24785,7 +24785,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24794,15 +24794,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -24811,7 +24811,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -24820,15 +24820,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24837,7 +24837,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24846,7 +24846,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24858,7 +24858,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24870,7 +24870,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24879,7 +24879,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24888,15 +24888,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24908,7 +24908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -24920,7 +24920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24932,7 +24932,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24944,7 +24944,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24953,7 +24953,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24965,7 +24965,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24977,7 +24977,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24989,7 +24989,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24998,7 +24998,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -25010,7 +25010,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -25023,7 +25023,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -25037,7 +25037,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -25045,7 +25045,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -25053,7 +25053,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -25062,11 +25062,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -25074,27 +25074,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -25104,7 +25104,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -25112,7 +25112,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -25127,74 +25127,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25295,19 +25295,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25372,11 +25372,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -25463,11 +25463,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -25475,42 +25475,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -25585,15 +25585,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25606,7 +25606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25621,18 +25621,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25641,14 +25641,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25657,7 +25657,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25668,7 +25668,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25677,7 +25677,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25689,7 +25689,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -25701,18 +25701,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25720,14 +25720,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25735,7 +25735,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25749,7 +25749,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25764,7 +25764,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25777,7 +25777,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25792,7 +25792,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -27500,15 +27500,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27516,26 +27516,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27543,14 +27543,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -27782,15 +27782,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27798,26 +27798,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27825,26 +27825,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27852,29 +27852,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -27882,19 +27882,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27902,18 +27902,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -27921,7 +27921,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27929,15 +27929,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27945,26 +27945,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27972,22 +27972,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -27995,14 +27995,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -28010,7 +28010,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -28018,14 +28018,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -28033,15 +28033,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28049,33 +28049,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28083,26 +28083,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28110,26 +28110,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28137,26 +28137,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28164,26 +28164,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28191,26 +28191,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28218,26 +28218,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28245,26 +28245,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28272,26 +28272,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28299,38 +28299,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28338,26 +28338,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28365,70 +28365,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28439,7 +28439,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -28447,7 +28447,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28457,7 +28457,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -28555,7 +28555,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -28566,11 +28566,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28579,7 +28579,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28588,7 +28588,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -28597,7 +28597,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28606,7 +28606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28615,7 +28615,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28624,7 +28624,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28633,67 +28633,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28702,14 +28702,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -28717,7 +28717,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28727,7 +28727,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -28736,7 +28736,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -28745,7 +28745,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -28754,7 +28754,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -28764,11 +28764,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -28776,70 +28776,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_akid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -28857,43 +28857,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28903,7 +28903,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28912,7 +28912,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -28921,7 +28921,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -28929,11 +28929,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -28999,119 +28999,119 @@ impl static_assertion_at_line_255_error_is_max_overheads_are_inconsistent {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLS_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLS_method"]
     pub fn TLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLS_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLS_method"]
     pub fn DTLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLS_with_buffers_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLS_with_buffers_method"]
     pub fn TLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLS_with_buffers_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLS_with_buffers_method"]
     pub fn DTLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_new"]
     pub fn SSL_CTX_new(method: *const SSL_METHOD) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_up_ref"]
     pub fn SSL_CTX_up_ref(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_free"]
     pub fn SSL_CTX_free(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_new"]
     pub fn SSL_new(ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_free"]
     pub fn SSL_free(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_SSL_CTX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_SSL_CTX"]
     pub fn SSL_get_SSL_CTX(ssl: *const SSL) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_connect_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_connect_state"]
     pub fn SSL_set_connect_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_accept_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_accept_state"]
     pub fn SSL_set_accept_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_is_server"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_is_server"]
     pub fn SSL_is_server(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_is_dtls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_is_dtls"]
     pub fn SSL_is_dtls(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_bio"]
     pub fn SSL_set_bio(ssl: *mut SSL, rbio: *mut BIO, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set0_rbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set0_rbio"]
     pub fn SSL_set0_rbio(ssl: *mut SSL, rbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set0_wbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set0_wbio"]
     pub fn SSL_set0_wbio(ssl: *mut SSL, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_rbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_rbio"]
     pub fn SSL_get_rbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_wbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_wbio"]
     pub fn SSL_get_wbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_fd"]
     pub fn SSL_get_fd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_rfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_rfd"]
     pub fn SSL_get_rfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_wfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_wfd"]
     pub fn SSL_get_wfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_fd"]
     pub fn SSL_set_fd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_rfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_rfd"]
     pub fn SSL_set_rfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_wfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_wfd"]
     pub fn SSL_set_wfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_do_handshake"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_do_handshake"]
     pub fn SSL_do_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_connect"]
     pub fn SSL_connect(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_accept"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_accept"]
     pub fn SSL_accept(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_read"]
     pub fn SSL_read(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -29119,7 +29119,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_peek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_peek"]
     pub fn SSL_peek(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -29127,15 +29127,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_pending"]
     pub fn SSL_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_has_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_has_pending"]
     pub fn SSL_has_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_write"]
     pub fn SSL_write(
         ssl: *mut SSL,
         buf: *const ::std::os::raw::c_void,
@@ -29143,220 +29143,220 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_key_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_key_update"]
     pub fn SSL_key_update(
         ssl: *mut SSL,
         request_type: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_shutdown"]
     pub fn SSL_shutdown(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_quiet_shutdown"]
     pub fn SSL_CTX_set_quiet_shutdown(ctx: *mut SSL_CTX, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_quiet_shutdown"]
     pub fn SSL_CTX_get_quiet_shutdown(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_quiet_shutdown"]
     pub fn SSL_set_quiet_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_quiet_shutdown"]
     pub fn SSL_get_quiet_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_error"]
     pub fn SSL_get_error(ssl: *const SSL, ret_code: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_error_description"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_error_description"]
     pub fn SSL_error_description(err: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_mtu"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_mtu"]
     pub fn SSL_set_mtu(ssl: *mut SSL, mtu: ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_set_initial_timeout_duration"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_set_initial_timeout_duration"]
     pub fn DTLSv1_set_initial_timeout_duration(ssl: *mut SSL, duration_ms: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_get_timeout"]
     pub fn DTLSv1_get_timeout(ssl: *const SSL, out: *mut timeval) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_handle_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_handle_timeout"]
     pub fn DTLSv1_handle_timeout(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_min_proto_version"]
     pub fn SSL_CTX_set_min_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_max_proto_version"]
     pub fn SSL_CTX_set_max_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_min_proto_version"]
     pub fn SSL_CTX_get_min_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_max_proto_version"]
     pub fn SSL_CTX_get_max_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_min_proto_version"]
     pub fn SSL_set_min_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_max_proto_version"]
     pub fn SSL_set_max_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_min_proto_version"]
     pub fn SSL_get_min_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_max_proto_version"]
     pub fn SSL_get_max_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_version"]
     pub fn SSL_version(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_options"]
     pub fn SSL_CTX_set_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_clear_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_clear_options"]
     pub fn SSL_CTX_clear_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_options"]
     pub fn SSL_CTX_get_options(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_options"]
     pub fn SSL_set_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_clear_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_clear_options"]
     pub fn SSL_clear_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_options"]
     pub fn SSL_get_options(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_mode"]
     pub fn SSL_CTX_set_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_clear_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_clear_mode"]
     pub fn SSL_CTX_clear_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_mode"]
     pub fn SSL_CTX_get_mode(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_mode"]
     pub fn SSL_set_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_clear_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_clear_mode"]
     pub fn SSL_clear_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_mode"]
     pub fn SSL_get_mode(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set0_buffer_pool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set0_buffer_pool"]
     pub fn SSL_CTX_set0_buffer_pool(ctx: *mut SSL_CTX, pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_certificate"]
     pub fn SSL_CTX_use_certificate(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_certificate"]
     pub fn SSL_use_certificate(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_PrivateKey"]
     pub fn SSL_CTX_use_PrivateKey(ctx: *mut SSL_CTX, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_PrivateKey"]
     pub fn SSL_use_PrivateKey(ssl: *mut SSL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set0_chain"]
     pub fn SSL_CTX_set0_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_chain"]
     pub fn SSL_CTX_set1_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set0_chain"]
     pub fn SSL_set0_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_chain"]
     pub fn SSL_set1_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add0_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add0_chain_cert"]
     pub fn SSL_CTX_add0_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add1_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add1_chain_cert"]
     pub fn SSL_CTX_add1_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add0_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add0_chain_cert"]
     pub fn SSL_add0_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add_extra_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add_extra_chain_cert"]
     pub fn SSL_CTX_add_extra_chain_cert(
         ctx: *mut SSL_CTX,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add1_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add1_chain_cert"]
     pub fn SSL_add1_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_clear_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_clear_chain_certs"]
     pub fn SSL_CTX_clear_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_clear_extra_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_clear_extra_chain_certs"]
     pub fn SSL_CTX_clear_extra_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_clear_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_clear_chain_certs"]
     pub fn SSL_clear_chain_certs(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_cert_cb"]
     pub fn SSL_CTX_set_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -29369,7 +29369,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_cert_cb"]
     pub fn SSL_set_cert_cb(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -29382,71 +29382,71 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_certificate_types"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_certificate_types"]
     pub fn SSL_get0_certificate_types(ssl: *const SSL, out_types: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_peer_verify_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_peer_verify_algorithms"]
     pub fn SSL_get0_peer_verify_algorithms(ssl: *const SSL, out_sigalgs: *mut *const u16) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_peer_delegation_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_peer_delegation_algorithms"]
     pub fn SSL_get0_peer_delegation_algorithms(
         ssl: *const SSL,
         out_sigalgs: *mut *const u16,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_certs_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_certs_clear"]
     pub fn SSL_certs_clear(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_check_private_key"]
     pub fn SSL_CTX_check_private_key(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_check_private_key"]
     pub fn SSL_check_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get0_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get0_certificate"]
     pub fn SSL_CTX_get0_certificate(ctx: *const SSL_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_certificate"]
     pub fn SSL_get_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get0_privatekey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get0_privatekey"]
     pub fn SSL_CTX_get0_privatekey(ctx: *const SSL_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_privatekey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_privatekey"]
     pub fn SSL_get_privatekey(ssl: *const SSL) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get0_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get0_chain_certs"]
     pub fn SSL_CTX_get0_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_extra_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_extra_chain_certs"]
     pub fn SSL_CTX_get_extra_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_chain_certs"]
     pub fn SSL_get0_chain_certs(
         ssl: *const SSL,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_signed_cert_timestamp_list"]
     pub fn SSL_CTX_set_signed_cert_timestamp_list(
         ctx: *mut SSL_CTX,
         list: *const u8,
@@ -29454,7 +29454,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_signed_cert_timestamp_list"]
     pub fn SSL_set_signed_cert_timestamp_list(
         ctx: *mut SSL,
         list: *const u8,
@@ -29462,7 +29462,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_ocsp_response"]
     pub fn SSL_CTX_set_ocsp_response(
         ctx: *mut SSL_CTX,
         response: *const u8,
@@ -29470,7 +29470,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_ocsp_response"]
     pub fn SSL_set_ocsp_response(
         ssl: *mut SSL,
         response: *const u8,
@@ -29478,26 +29478,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_signature_algorithm_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_signature_algorithm_name"]
     pub fn SSL_get_signature_algorithm_name(
         sigalg: u16,
         include_curve: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_signature_algorithm_key_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_signature_algorithm_key_type"]
     pub fn SSL_get_signature_algorithm_key_type(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_signature_algorithm_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_signature_algorithm_digest"]
     pub fn SSL_get_signature_algorithm_digest(sigalg: u16) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_is_signature_algorithm_rsa_pss"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_is_signature_algorithm_rsa_pss"]
     pub fn SSL_is_signature_algorithm_rsa_pss(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_signing_algorithm_prefs"]
     pub fn SSL_CTX_set_signing_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -29505,7 +29505,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_signing_algorithm_prefs"]
     pub fn SSL_set_signing_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -29513,7 +29513,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_chain_and_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_chain_and_key"]
     pub fn SSL_CTX_set_chain_and_key(
         ctx: *mut SSL_CTX,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29523,7 +29523,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_chain_and_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_chain_and_key"]
     pub fn SSL_set_chain_and_key(
         ssl: *mut SSL,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29533,19 +29533,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get0_chain"]
     pub fn SSL_CTX_get0_chain(ctx: *const SSL_CTX) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_RSAPrivateKey"]
     pub fn SSL_CTX_use_RSAPrivateKey(ctx: *mut SSL_CTX, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_RSAPrivateKey"]
     pub fn SSL_use_RSAPrivateKey(ssl: *mut SSL, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_certificate_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_certificate_ASN1"]
     pub fn SSL_CTX_use_certificate_ASN1(
         ctx: *mut SSL_CTX,
         der_len: usize,
@@ -29553,7 +29553,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_certificate_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_certificate_ASN1"]
     pub fn SSL_use_certificate_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29561,7 +29561,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_PrivateKey_ASN1"]
     pub fn SSL_CTX_use_PrivateKey_ASN1(
         pk: ::std::os::raw::c_int,
         ctx: *mut SSL_CTX,
@@ -29570,7 +29570,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_PrivateKey_ASN1"]
     pub fn SSL_use_PrivateKey_ASN1(
         type_: ::std::os::raw::c_int,
         ssl: *mut SSL,
@@ -29579,7 +29579,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_RSAPrivateKey_ASN1"]
     pub fn SSL_CTX_use_RSAPrivateKey_ASN1(
         ctx: *mut SSL_CTX,
         der: *const u8,
@@ -29587,7 +29587,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_RSAPrivateKey_ASN1"]
     pub fn SSL_use_RSAPrivateKey_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29595,7 +29595,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_RSAPrivateKey_file"]
     pub fn SSL_CTX_use_RSAPrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29603,7 +29603,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_RSAPrivateKey_file"]
     pub fn SSL_use_RSAPrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29611,7 +29611,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_certificate_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_certificate_file"]
     pub fn SSL_CTX_use_certificate_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29619,7 +29619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_certificate_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_certificate_file"]
     pub fn SSL_use_certificate_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29627,7 +29627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_PrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_PrivateKey_file"]
     pub fn SSL_CTX_use_PrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29635,7 +29635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_PrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_PrivateKey_file"]
     pub fn SSL_use_PrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29643,29 +29643,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_certificate_chain_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_certificate_chain_file"]
     pub fn SSL_CTX_use_certificate_chain_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_default_passwd_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_default_passwd_cb"]
     pub fn SSL_CTX_set_default_passwd_cb(ctx: *mut SSL_CTX, cb: pem_password_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_default_passwd_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_default_passwd_cb"]
     pub fn SSL_CTX_get_default_passwd_cb(ctx: *const SSL_CTX) -> pem_password_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_default_passwd_cb_userdata"]
     pub fn SSL_CTX_set_default_passwd_cb_userdata(
         ctx: *mut SSL_CTX,
         data: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_default_passwd_cb_userdata"]
     pub fn SSL_CTX_get_default_passwd_cb_userdata(
         ctx: *const SSL_CTX,
     ) -> *mut ::std::os::raw::c_void;
@@ -29754,18 +29754,18 @@ fn bindgen_test_layout_ssl_private_key_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_private_key_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_private_key_method"]
     pub fn SSL_set_private_key_method(ssl: *mut SSL, key_method: *const SSL_PRIVATE_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_private_key_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_private_key_method"]
     pub fn SSL_CTX_set_private_key_method(
         ctx: *mut SSL_CTX,
         key_method: *const SSL_PRIVATE_KEY_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_can_release_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_can_release_private_key"]
     pub fn SSL_can_release_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -29790,149 +29790,149 @@ pub type sk_SSL_CIPHER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_cipher_by_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_cipher_by_value"]
     pub fn SSL_get_cipher_by_value(value: u16) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_id"]
     pub fn SSL_CIPHER_get_id(cipher: *const SSL_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_protocol_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_protocol_id"]
     pub fn SSL_CIPHER_get_protocol_id(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_is_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_is_aead"]
     pub fn SSL_CIPHER_is_aead(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_is_block_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_is_block_cipher"]
     pub fn SSL_CIPHER_is_block_cipher(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_cipher_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_cipher_nid"]
     pub fn SSL_CIPHER_get_cipher_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_digest_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_digest_nid"]
     pub fn SSL_CIPHER_get_digest_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_kx_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_kx_nid"]
     pub fn SSL_CIPHER_get_kx_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_auth_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_auth_nid"]
     pub fn SSL_CIPHER_get_auth_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_prf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_prf_nid"]
     pub fn SSL_CIPHER_get_prf_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_min_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_min_version"]
     pub fn SSL_CIPHER_get_min_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_max_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_max_version"]
     pub fn SSL_CIPHER_get_max_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_standard_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_standard_name"]
     pub fn SSL_CIPHER_standard_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_name"]
     pub fn SSL_CIPHER_get_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_kx_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_kx_name"]
     pub fn SSL_CIPHER_get_kx_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_bits"]
     pub fn SSL_CIPHER_get_bits(
         cipher: *const SSL_CIPHER,
         out_alg_bits: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_strict_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_strict_cipher_list"]
     pub fn SSL_CTX_set_strict_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_cipher_list"]
     pub fn SSL_CTX_set_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_strict_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_strict_cipher_list"]
     pub fn SSL_set_strict_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_ciphersuites"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_ciphersuites"]
     pub fn SSL_CTX_set_ciphersuites(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_cipher_list"]
     pub fn SSL_set_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_ciphers"]
     pub fn SSL_CTX_get_ciphers(ctx: *const SSL_CTX) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_cipher_in_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_cipher_in_group"]
     pub fn SSL_CTX_cipher_in_group(ctx: *const SSL_CTX, i: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ciphers"]
     pub fn SSL_get_ciphers(ssl: *const SSL) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_is_init_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_is_init_finished"]
     pub fn SSL_is_init_finished(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_in_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_in_init"]
     pub fn SSL_in_init(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_in_false_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_in_false_start"]
     pub fn SSL_in_false_start(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_certificate"]
     pub fn SSL_get_peer_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_cert_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_cert_chain"]
     pub fn SSL_get_peer_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_full_cert_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_full_cert_chain"]
     pub fn SSL_get_peer_full_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_peer_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_peer_certificates"]
     pub fn SSL_get0_peer_certificates(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_signed_cert_timestamp_list"]
     pub fn SSL_get0_signed_cert_timestamp_list(
         ssl: *const SSL,
         out: *mut *const u8,
@@ -29940,11 +29940,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_ocsp_response"]
     pub fn SSL_get0_ocsp_response(ssl: *const SSL, out: *mut *const u8, out_len: *mut usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_tls_unique"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_tls_unique"]
     pub fn SSL_get_tls_unique(
         ssl: *const SSL,
         out: *mut u8,
@@ -29953,23 +29953,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_extms_support"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_extms_support"]
     pub fn SSL_get_extms_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_current_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_current_cipher"]
     pub fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_session_reused"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_session_reused"]
     pub fn SSL_session_reused(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_secure_renegotiation_support"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_secure_renegotiation_support"]
     pub fn SSL_get_secure_renegotiation_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_export_keying_material"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_export_keying_material"]
     pub fn SSL_export_keying_material(
         ssl: *mut SSL,
         out: *mut u8,
@@ -29982,7 +29982,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_SSL_SESSION"]
     pub fn PEM_read_bio_SSL_SESSION(
         bp: *mut BIO,
         x: *mut *mut SSL_SESSION,
@@ -29991,7 +29991,7 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_SSL_SESSION"]
     pub fn PEM_read_SSL_SESSION(
         fp: *mut FILE,
         x: *mut *mut SSL_SESSION,
@@ -30000,27 +30000,27 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_SSL_SESSION"]
     pub fn PEM_write_bio_SSL_SESSION(bp: *mut BIO, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_SSL_SESSION"]
     pub fn PEM_write_SSL_SESSION(fp: *mut FILE, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_new"]
     pub fn SSL_SESSION_new(ctx: *const SSL_CTX) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_up_ref"]
     pub fn SSL_SESSION_up_ref(session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_free"]
     pub fn SSL_SESSION_free(session: *mut SSL_SESSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_to_bytes"]
     pub fn SSL_SESSION_to_bytes(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -30028,7 +30028,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_to_bytes_for_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_to_bytes_for_ticket"]
     pub fn SSL_SESSION_to_bytes_for_ticket(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -30036,7 +30036,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_from_bytes"]
     pub fn SSL_SESSION_from_bytes(
         in_: *const u8,
         in_len: usize,
@@ -30044,29 +30044,29 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_version"]
     pub fn SSL_SESSION_get_version(session: *const SSL_SESSION) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_protocol_version"]
     pub fn SSL_SESSION_get_protocol_version(session: *const SSL_SESSION) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set_protocol_version"]
     pub fn SSL_SESSION_set_protocol_version(
         session: *mut SSL_SESSION,
         version: u16,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_id"]
     pub fn SSL_SESSION_get_id(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set1_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set1_id"]
     pub fn SSL_SESSION_set1_id(
         session: *mut SSL_SESSION,
         sid: *const u8,
@@ -30074,25 +30074,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_time"]
     pub fn SSL_SESSION_get_time(session: *const SSL_SESSION) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_timeout"]
     pub fn SSL_SESSION_get_timeout(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_peer"]
     pub fn SSL_SESSION_get0_peer(session: *const SSL_SESSION) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_peer_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_peer_certificates"]
     pub fn SSL_SESSION_get0_peer_certificates(
         session: *const SSL_SESSION,
     ) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_signed_cert_timestamp_list"]
     pub fn SSL_SESSION_get0_signed_cert_timestamp_list(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -30100,7 +30100,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_ocsp_response"]
     pub fn SSL_SESSION_get0_ocsp_response(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -30108,7 +30108,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_master_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_master_key"]
     pub fn SSL_SESSION_get_master_key(
         session: *const SSL_SESSION,
         out: *mut u8,
@@ -30116,22 +30116,22 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set_time"]
     pub fn SSL_SESSION_set_time(session: *mut SSL_SESSION, time: u64) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set_timeout"]
     pub fn SSL_SESSION_set_timeout(session: *mut SSL_SESSION, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_id_context"]
     pub fn SSL_SESSION_get0_id_context(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set1_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set1_id_context"]
     pub fn SSL_SESSION_set1_id_context(
         session: *mut SSL_SESSION,
         sid_ctx: *const u8,
@@ -30139,19 +30139,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_should_be_single_use"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_should_be_single_use"]
     pub fn SSL_SESSION_should_be_single_use(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_is_resumable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_is_resumable"]
     pub fn SSL_SESSION_is_resumable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_has_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_has_ticket"]
     pub fn SSL_SESSION_has_ticket(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_ticket"]
     pub fn SSL_SESSION_get0_ticket(
         session: *const SSL_SESSION,
         out_ticket: *mut *const u8,
@@ -30159,7 +30159,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set_ticket"]
     pub fn SSL_SESSION_set_ticket(
         session: *mut SSL_SESSION,
         ticket: *const u8,
@@ -30167,19 +30167,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_ticket_lifetime_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_ticket_lifetime_hint"]
     pub fn SSL_SESSION_get_ticket_lifetime_hint(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_cipher"]
     pub fn SSL_SESSION_get0_cipher(session: *const SSL_SESSION) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_has_peer_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_has_peer_sha256"]
     pub fn SSL_SESSION_has_peer_sha256(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_peer_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_peer_sha256"]
     pub fn SSL_SESSION_get0_peer_sha256(
         session: *const SSL_SESSION,
         out_ptr: *mut *const u8,
@@ -30187,34 +30187,34 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_session_cache_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_session_cache_mode"]
     pub fn SSL_CTX_set_session_cache_mode(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_session_cache_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_session_cache_mode"]
     pub fn SSL_CTX_get_session_cache_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_session"]
     pub fn SSL_set_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_timeout"]
     pub fn SSL_CTX_set_timeout(ctx: *mut SSL_CTX, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_session_psk_dhe_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_session_psk_dhe_timeout"]
     pub fn SSL_CTX_set_session_psk_dhe_timeout(ctx: *mut SSL_CTX, timeout: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_timeout"]
     pub fn SSL_CTX_get_timeout(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_session_id_context"]
     pub fn SSL_CTX_set_session_id_context(
         ctx: *mut SSL_CTX,
         sid_ctx: *const u8,
@@ -30222,7 +30222,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_session_id_context"]
     pub fn SSL_set_session_id_context(
         ssl: *mut SSL,
         sid_ctx: *const u8,
@@ -30230,44 +30230,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_session_id_context"]
     pub fn SSL_get0_session_id_context(ssl: *const SSL, out_len: *mut usize) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_set_cache_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_set_cache_size"]
     pub fn SSL_CTX_sess_set_cache_size(
         ctx: *mut SSL_CTX,
         size: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_get_cache_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_get_cache_size"]
     pub fn SSL_CTX_sess_get_cache_size(ctx: *const SSL_CTX) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_number"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_number"]
     pub fn SSL_CTX_sess_number(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add_session"]
     pub fn SSL_CTX_add_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_remove_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_remove_session"]
     pub fn SSL_CTX_remove_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_flush_sessions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_flush_sessions"]
     pub fn SSL_CTX_flush_sessions(ctx: *mut SSL_CTX, time: u64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_set_new_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_set_new_cb"]
     pub fn SSL_CTX_sess_set_new_cb(
         ctx: *mut SSL_CTX,
         new_session_cb: ::std::option::Option<
@@ -30276,7 +30276,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_get_new_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_get_new_cb"]
     pub fn SSL_CTX_sess_get_new_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30284,7 +30284,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_set_remove_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_set_remove_cb"]
     pub fn SSL_CTX_sess_set_remove_cb(
         ctx: *mut SSL_CTX,
         remove_session_cb: ::std::option::Option<
@@ -30293,13 +30293,13 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_get_remove_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_get_remove_cb"]
     pub fn SSL_CTX_sess_get_remove_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<unsafe extern "C" fn(ctx: *mut SSL_CTX, arg1: *mut SSL_SESSION)>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_set_get_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_set_get_cb"]
     pub fn SSL_CTX_sess_set_get_cb(
         ctx: *mut SSL_CTX,
         get_session_cb: ::std::option::Option<
@@ -30313,7 +30313,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_get_get_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_get_get_cb"]
     pub fn SSL_CTX_sess_get_get_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30326,11 +30326,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_magic_pending_session_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_magic_pending_session_ptr"]
     pub fn SSL_magic_pending_session_ptr() -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_tlsext_ticket_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_tlsext_ticket_keys"]
     pub fn SSL_CTX_get_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         out: *mut ::std::os::raw::c_void,
@@ -30338,7 +30338,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_ticket_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_ticket_keys"]
     pub fn SSL_CTX_set_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         in_: *const ::std::os::raw::c_void,
@@ -30346,7 +30346,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_ticket_key_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_ticket_key_cb"]
     pub fn SSL_CTX_set_tlsext_ticket_key_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30438,14 +30438,14 @@ fn bindgen_test_layout_ssl_ticket_aead_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_ticket_aead_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_ticket_aead_method"]
     pub fn SSL_CTX_set_ticket_aead_method(
         ctx: *mut SSL_CTX,
         aead_method: *const SSL_TICKET_AEAD_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_process_tls13_new_session_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_process_tls13_new_session_ticket"]
     pub fn SSL_process_tls13_new_session_ticket(
         ssl: *mut SSL,
         buf: *const u8,
@@ -30453,15 +30453,15 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_num_tickets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_num_tickets"]
     pub fn SSL_CTX_set_num_tickets(ctx: *mut SSL_CTX, num_tickets: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_num_tickets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_num_tickets"]
     pub fn SSL_CTX_get_num_tickets(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_curves"]
     pub fn SSL_CTX_set1_curves(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_int,
@@ -30469,7 +30469,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_curves"]
     pub fn SSL_set1_curves(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_int,
@@ -30477,29 +30477,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_curves_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_curves_list"]
     pub fn SSL_CTX_set1_curves_list(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_curves_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_curves_list"]
     pub fn SSL_set1_curves_list(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_curve_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_curve_id"]
     pub fn SSL_get_curve_id(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_curve_name"]
     pub fn SSL_get_curve_name(curve_id: u16) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_to_bytes"]
     pub fn SSL_to_bytes(
         in_: *const SSL,
         out_data: *mut *mut u8,
@@ -30507,11 +30507,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_from_bytes"]
     pub fn SSL_from_bytes(in_: *const u8, in_len: usize, ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_groups"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_groups"]
     pub fn SSL_CTX_set1_groups(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_int,
@@ -30519,7 +30519,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_groups"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_groups"]
     pub fn SSL_set1_groups(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_int,
@@ -30527,21 +30527,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_groups_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_groups_list"]
     pub fn SSL_CTX_set1_groups_list(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_groups_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_groups_list"]
     pub fn SSL_set1_groups_list(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_verify"]
     pub fn SSL_CTX_set_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30554,7 +30554,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_verify"]
     pub fn SSL_set_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30571,7 +30571,7 @@ pub const ssl_verify_result_t_ssl_verify_invalid: ssl_verify_result_t = 1;
 pub const ssl_verify_result_t_ssl_verify_retry: ssl_verify_result_t = 2;
 pub type ssl_verify_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_custom_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_custom_verify"]
     pub fn SSL_CTX_set_custom_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30581,7 +30581,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_custom_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_custom_verify"]
     pub fn SSL_set_custom_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30591,15 +30591,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_verify_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_verify_mode"]
     pub fn SSL_CTX_get_verify_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_verify_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_verify_mode"]
     pub fn SSL_get_verify_mode(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_verify_callback"]
     pub fn SSL_CTX_get_verify_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -30610,7 +30610,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_verify_callback"]
     pub fn SSL_get_verify_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -30621,83 +30621,83 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_host"]
     pub fn SSL_set1_host(
         ssl: *mut SSL,
         hostname: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_verify_depth"]
     pub fn SSL_CTX_set_verify_depth(ctx: *mut SSL_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_verify_depth"]
     pub fn SSL_set_verify_depth(ssl: *mut SSL, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_verify_depth"]
     pub fn SSL_CTX_get_verify_depth(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_verify_depth"]
     pub fn SSL_get_verify_depth(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_param"]
     pub fn SSL_CTX_set1_param(
         ctx: *mut SSL_CTX,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_param"]
     pub fn SSL_set1_param(ssl: *mut SSL, param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get0_param"]
     pub fn SSL_CTX_get0_param(ctx: *mut SSL_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_param"]
     pub fn SSL_get0_param(ssl: *mut SSL) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_purpose"]
     pub fn SSL_CTX_set_purpose(
         ctx: *mut SSL_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_purpose"]
     pub fn SSL_set_purpose(ssl: *mut SSL, purpose: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_trust"]
     pub fn SSL_CTX_set_trust(
         ctx: *mut SSL_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_trust"]
     pub fn SSL_set_trust(ssl: *mut SSL, trust: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_cert_store"]
     pub fn SSL_CTX_set_cert_store(ctx: *mut SSL_CTX, store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_cert_store"]
     pub fn SSL_CTX_get_cert_store(ctx: *const SSL_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_default_verify_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_default_verify_paths"]
     pub fn SSL_CTX_set_default_verify_paths(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_load_verify_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_load_verify_locations"]
     pub fn SSL_CTX_load_verify_locations(
         ctx: *mut SSL_CTX,
         ca_file: *const ::std::os::raw::c_char,
@@ -30705,19 +30705,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_verify_result"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_verify_result"]
     pub fn SSL_get_verify_result(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_alert_from_verify_result"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_alert_from_verify_result"]
     pub fn SSL_alert_from_verify_result(result: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ex_data_X509_STORE_CTX_idx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ex_data_X509_STORE_CTX_idx"]
     pub fn SSL_get_ex_data_X509_STORE_CTX_idx() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_cert_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_cert_verify_callback"]
     pub fn SSL_CTX_set_cert_verify_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30730,51 +30730,51 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_enable_signed_cert_timestamps"]
     pub fn SSL_enable_signed_cert_timestamps(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_enable_signed_cert_timestamps"]
     pub fn SSL_CTX_enable_signed_cert_timestamps(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_enable_ocsp_stapling"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_enable_ocsp_stapling"]
     pub fn SSL_enable_ocsp_stapling(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_enable_ocsp_stapling"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_enable_ocsp_stapling"]
     pub fn SSL_CTX_enable_ocsp_stapling(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set0_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set0_verify_cert_store"]
     pub fn SSL_CTX_set0_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_verify_cert_store"]
     pub fn SSL_CTX_set1_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set0_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set0_verify_cert_store"]
     pub fn SSL_set0_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_verify_cert_store"]
     pub fn SSL_set1_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_verify_algorithm_prefs"]
     pub fn SSL_CTX_set_verify_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -30782,7 +30782,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_verify_algorithm_prefs"]
     pub fn SSL_set_verify_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -30790,87 +30790,87 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_hostflags"]
     pub fn SSL_set_hostflags(ssl: *mut SSL, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_client_CA_list"]
     pub fn SSL_set_client_CA_list(ssl: *mut SSL, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_client_CA_list"]
     pub fn SSL_CTX_set_client_CA_list(ctx: *mut SSL_CTX, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set0_client_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set0_client_CAs"]
     pub fn SSL_set0_client_CAs(ssl: *mut SSL, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set0_client_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set0_client_CAs"]
     pub fn SSL_CTX_set0_client_CAs(ctx: *mut SSL_CTX, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_client_CA_list"]
     pub fn SSL_get_client_CA_list(ssl: *const SSL) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_server_requested_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_server_requested_CAs"]
     pub fn SSL_get0_server_requested_CAs(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_client_CA_list"]
     pub fn SSL_CTX_get_client_CA_list(ctx: *const SSL_CTX) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add_client_CA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add_client_CA"]
     pub fn SSL_add_client_CA(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add_client_CA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add_client_CA"]
     pub fn SSL_CTX_add_client_CA(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_load_client_CA_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_load_client_CA_file"]
     pub fn SSL_load_client_CA_file(file: *const ::std::os::raw::c_char) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_dup_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_dup_CA_list"]
     pub fn SSL_dup_CA_list(list: *mut stack_st_X509_NAME) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add_file_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add_file_cert_subjects_to_stack"]
     pub fn SSL_add_file_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add_bio_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add_bio_cert_subjects_to_stack"]
     pub fn SSL_add_bio_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tlsext_host_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tlsext_host_name"]
     pub fn SSL_set_tlsext_host_name(
         ssl: *mut SSL,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_servername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_servername"]
     pub fn SSL_get_servername(
         ssl: *const SSL,
         type_: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_servername_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_servername_type"]
     pub fn SSL_get_servername_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_servername_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_servername_callback"]
     pub fn SSL_CTX_set_tlsext_servername_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30883,18 +30883,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_servername_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_servername_arg"]
     pub fn SSL_CTX_set_tlsext_servername_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_SSL_CTX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_SSL_CTX"]
     pub fn SSL_set_SSL_CTX(ssl: *mut SSL, ctx: *mut SSL_CTX) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_alpn_protos"]
     pub fn SSL_CTX_set_alpn_protos(
         ctx: *mut SSL_CTX,
         protos: *const u8,
@@ -30902,7 +30902,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_alpn_protos"]
     pub fn SSL_set_alpn_protos(
         ssl: *mut SSL,
         protos: *const u8,
@@ -30910,7 +30910,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_alpn_select_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_alpn_select_cb"]
     pub fn SSL_CTX_set_alpn_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30927,7 +30927,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_alpn_selected"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_alpn_selected"]
     pub fn SSL_get0_alpn_selected(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30935,11 +30935,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_allow_unknown_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_allow_unknown_alpn_protos"]
     pub fn SSL_CTX_set_allow_unknown_alpn_protos(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add_application_settings"]
     pub fn SSL_add_application_settings(
         ssl: *mut SSL,
         proto: *const u8,
@@ -30949,7 +30949,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_peer_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_peer_application_settings"]
     pub fn SSL_get0_peer_application_settings(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30957,7 +30957,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_has_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_has_application_settings"]
     pub fn SSL_has_application_settings(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub type ssl_cert_compression_func_t = ::std::option::Option<
@@ -30978,7 +30978,7 @@ pub type ssl_cert_decompression_func_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add_cert_compression_alg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add_cert_compression_alg"]
     pub fn SSL_CTX_add_cert_compression_alg(
         ctx: *mut SSL_CTX,
         alg_id: u16,
@@ -30987,7 +30987,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_next_protos_advertised_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_next_protos_advertised_cb"]
     pub fn SSL_CTX_set_next_protos_advertised_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31002,7 +31002,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_next_proto_select_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_next_proto_select_cb"]
     pub fn SSL_CTX_set_next_proto_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31019,7 +31019,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_next_proto_negotiated"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_next_proto_negotiated"]
     pub fn SSL_get0_next_proto_negotiated(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -31027,7 +31027,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_select_next_proto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_select_next_proto"]
     pub fn SSL_select_next_proto(
         out: *mut *mut u8,
         out_len: *mut u8,
@@ -31038,29 +31038,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tls_channel_id_enabled"]
     pub fn SSL_CTX_set_tls_channel_id_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tls_channel_id_enabled"]
     pub fn SSL_set_tls_channel_id_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_tls_channel_id"]
     pub fn SSL_CTX_set1_tls_channel_id(
         ctx: *mut SSL_CTX,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_tls_channel_id"]
     pub fn SSL_set1_tls_channel_id(
         ssl: *mut SSL,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_tls_channel_id"]
     pub fn SSL_get_tls_channel_id(ssl: *mut SSL, out: *mut u8, max_out: usize) -> usize;
 }
 #[repr(C)]
@@ -31137,29 +31137,29 @@ pub type sk_SRTP_PROTECTION_PROFILE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_srtp_profiles"]
     pub fn SSL_CTX_set_srtp_profiles(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_srtp_profiles"]
     pub fn SSL_set_srtp_profiles(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_srtp_profiles"]
     pub fn SSL_get_srtp_profiles(ssl: *const SSL) -> *const stack_st_SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_selected_srtp_profile"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_selected_srtp_profile"]
     pub fn SSL_get_selected_srtp_profile(ssl: *mut SSL) -> *const SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_psk_client_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_psk_client_callback"]
     pub fn SSL_CTX_set_psk_client_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31175,7 +31175,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_psk_client_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_psk_client_callback"]
     pub fn SSL_set_psk_client_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31191,7 +31191,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_psk_server_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_psk_server_callback"]
     pub fn SSL_CTX_set_psk_server_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31205,7 +31205,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_psk_server_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_psk_server_callback"]
     pub fn SSL_set_psk_server_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31219,29 +31219,29 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_psk_identity_hint"]
     pub fn SSL_CTX_use_psk_identity_hint(
         ctx: *mut SSL_CTX,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_psk_identity_hint"]
     pub fn SSL_use_psk_identity_hint(
         ssl: *mut SSL,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_psk_identity_hint"]
     pub fn SSL_get_psk_identity_hint(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_psk_identity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_psk_identity"]
     pub fn SSL_get_psk_identity(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_delegated_credential"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_delegated_credential"]
     pub fn SSL_set1_delegated_credential(
         ssl: *mut SSL,
         dc: *mut CRYPTO_BUFFER,
@@ -31250,7 +31250,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_delegated_credential_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_delegated_credential_used"]
     pub fn SSL_delegated_credential_used(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub const ssl_encryption_level_t_ssl_encryption_initial: ssl_encryption_level_t = 0;
@@ -31363,22 +31363,22 @@ fn bindgen_test_layout_ssl_quic_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_quic_max_handshake_flight_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_quic_max_handshake_flight_len"]
     pub fn SSL_quic_max_handshake_flight_len(
         ssl: *const SSL,
         level: ssl_encryption_level_t,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_quic_read_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_quic_read_level"]
     pub fn SSL_quic_read_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_quic_write_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_quic_write_level"]
     pub fn SSL_quic_write_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_provide_quic_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_provide_quic_data"]
     pub fn SSL_provide_quic_data(
         ssl: *mut SSL,
         level: ssl_encryption_level_t,
@@ -31387,25 +31387,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_process_quic_post_handshake"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_process_quic_post_handshake"]
     pub fn SSL_process_quic_post_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_quic_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_quic_method"]
     pub fn SSL_CTX_set_quic_method(
         ctx: *mut SSL_CTX,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_quic_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_quic_method"]
     pub fn SSL_set_quic_method(
         ssl: *mut SSL,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_quic_transport_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_quic_transport_params"]
     pub fn SSL_set_quic_transport_params(
         ssl: *mut SSL,
         params: *const u8,
@@ -31413,7 +31413,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_quic_transport_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_quic_transport_params"]
     pub fn SSL_get_peer_quic_transport_params(
         ssl: *const SSL,
         out_params: *mut *const u8,
@@ -31421,11 +31421,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_quic_use_legacy_codepoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_quic_use_legacy_codepoint"]
     pub fn SSL_set_quic_use_legacy_codepoint(ssl: *mut SSL, use_legacy: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_quic_early_data_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_quic_early_data_context"]
     pub fn SSL_set_quic_early_data_context(
         ssl: *mut SSL,
         context: *const u8,
@@ -31433,35 +31433,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_early_data_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_early_data_enabled"]
     pub fn SSL_CTX_set_early_data_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_early_data_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_early_data_enabled"]
     pub fn SSL_set_early_data_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_in_early_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_in_early_data"]
     pub fn SSL_in_early_data(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_early_data_capable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_early_data_capable"]
     pub fn SSL_SESSION_early_data_capable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_copy_without_early_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_copy_without_early_data"]
     pub fn SSL_SESSION_copy_without_early_data(session: *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_early_data_accepted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_early_data_accepted"]
     pub fn SSL_early_data_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_reset_early_data_reject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_reset_early_data_reject"]
     pub fn SSL_reset_early_data_reject(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ticket_age_skew"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ticket_age_skew"]
     pub fn SSL_get_ticket_age_skew(ssl: *const SSL) -> i32;
 }
 pub const ssl_early_data_reason_t_ssl_early_data_unknown: ssl_early_data_reason_t = 0;
@@ -31483,21 +31483,21 @@ pub const ssl_early_data_reason_t_ssl_early_data_alps_mismatch: ssl_early_data_r
 pub const ssl_early_data_reason_t_ssl_early_data_reason_max_value: ssl_early_data_reason_t = 14;
 pub type ssl_early_data_reason_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_early_data_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_early_data_reason"]
     pub fn SSL_get_early_data_reason(ssl: *const SSL) -> ssl_early_data_reason_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_early_data_reason_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_early_data_reason_string"]
     pub fn SSL_early_data_reason_string(
         reason: ssl_early_data_reason_t,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_enable_ech_grease"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_enable_ech_grease"]
     pub fn SSL_set_enable_ech_grease(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_ech_config_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_ech_config_list"]
     pub fn SSL_set1_ech_config_list(
         ssl: *mut SSL,
         ech_config_list: *const u8,
@@ -31505,7 +31505,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_ech_name_override"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_ech_name_override"]
     pub fn SSL_get0_ech_name_override(
         ssl: *const SSL,
         out_name: *mut *const ::std::os::raw::c_char,
@@ -31513,7 +31513,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_ech_retry_configs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_ech_retry_configs"]
     pub fn SSL_get0_ech_retry_configs(
         ssl: *const SSL,
         out_retry_configs: *mut *const u8,
@@ -31521,7 +31521,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_marshal_ech_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_marshal_ech_config"]
     pub fn SSL_marshal_ech_config(
         out: *mut *mut u8,
         out_len: *mut usize,
@@ -31532,19 +31532,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_new"]
     pub fn SSL_ECH_KEYS_new() -> *mut SSL_ECH_KEYS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_up_ref"]
     pub fn SSL_ECH_KEYS_up_ref(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_free"]
     pub fn SSL_ECH_KEYS_free(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_add"]
     pub fn SSL_ECH_KEYS_add(
         keys: *mut SSL_ECH_KEYS,
         is_retry_config: ::std::os::raw::c_int,
@@ -31554,12 +31554,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_has_duplicate_config_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_has_duplicate_config_id"]
     pub fn SSL_ECH_KEYS_has_duplicate_config_id(keys: *const SSL_ECH_KEYS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_marshal_retry_configs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_marshal_retry_configs"]
     pub fn SSL_ECH_KEYS_marshal_retry_configs(
         keys: *const SSL_ECH_KEYS,
         out: *mut *mut u8,
@@ -31567,34 +31567,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_ech_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_ech_keys"]
     pub fn SSL_CTX_set1_ech_keys(
         ctx: *mut SSL_CTX,
         keys: *mut SSL_ECH_KEYS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ech_accepted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ech_accepted"]
     pub fn SSL_ech_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_alert_type_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_alert_type_string_long"]
     pub fn SSL_alert_type_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_alert_desc_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_alert_desc_string_long"]
     pub fn SSL_alert_desc_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_send_fatal_alert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_send_fatal_alert"]
     pub fn SSL_send_fatal_alert(ssl: *mut SSL, alert: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_ex_data"]
     pub fn SSL_set_ex_data(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -31602,14 +31602,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ex_data"]
     pub fn SSL_get_ex_data(
         ssl: *const SSL,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ex_new_index"]
     pub fn SSL_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31619,7 +31619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set_ex_data"]
     pub fn SSL_SESSION_set_ex_data(
         session: *mut SSL_SESSION,
         idx: ::std::os::raw::c_int,
@@ -31627,14 +31627,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_ex_data"]
     pub fn SSL_SESSION_get_ex_data(
         session: *const SSL_SESSION,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_ex_new_index"]
     pub fn SSL_SESSION_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31644,7 +31644,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_ex_data"]
     pub fn SSL_CTX_set_ex_data(
         ctx: *mut SSL_CTX,
         idx: ::std::os::raw::c_int,
@@ -31652,14 +31652,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_ex_data"]
     pub fn SSL_CTX_get_ex_data(
         ctx: *const SSL_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_ex_new_index"]
     pub fn SSL_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31669,7 +31669,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ivs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ivs"]
     pub fn SSL_get_ivs(
         ssl: *const SSL,
         out_read_iv: *mut *const u8,
@@ -31678,11 +31678,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_key_block_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_key_block_len"]
     pub fn SSL_get_key_block_len(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_generate_key_block"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_generate_key_block"]
     pub fn SSL_generate_key_block(
         ssl: *const SSL,
         out: *mut u8,
@@ -31690,26 +31690,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_read_sequence"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_read_sequence"]
     pub fn SSL_get_read_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_write_sequence"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_write_sequence"]
     pub fn SSL_get_write_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_record_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_record_protocol_version"]
     pub fn SSL_CTX_set_record_protocol_version(
         ctx: *mut SSL_CTX,
         version: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_serialize_capabilities"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_serialize_capabilities"]
     pub fn SSL_serialize_capabilities(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_request_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_request_handshake_hints"]
     pub fn SSL_request_handshake_hints(
         ssl: *mut SSL,
         client_hello: *const u8,
@@ -31719,11 +31719,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_serialize_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_serialize_handshake_hints"]
     pub fn SSL_serialize_handshake_hints(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_handshake_hints"]
     pub fn SSL_set_handshake_hints(
         ssl: *mut SSL,
         hints: *const u8,
@@ -31731,7 +31731,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_msg_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_msg_callback"]
     pub fn SSL_CTX_set_msg_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31748,11 +31748,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_msg_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_msg_callback_arg"]
     pub fn SSL_CTX_set_msg_callback_arg(ctx: *mut SSL_CTX, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_msg_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_msg_callback"]
     pub fn SSL_set_msg_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31769,11 +31769,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_msg_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_msg_callback_arg"]
     pub fn SSL_set_msg_callback_arg(ssl: *mut SSL, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_keylog_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_keylog_callback"]
     pub fn SSL_CTX_set_keylog_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31782,7 +31782,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_keylog_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_keylog_callback"]
     pub fn SSL_CTX_get_keylog_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -31790,14 +31790,14 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_current_time_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_current_time_cb"]
     pub fn SSL_CTX_set_current_time_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<unsafe extern "C" fn(ssl: *const SSL, out_clock: *mut timeval)>,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_shed_handshake_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_shed_handshake_config"]
     pub fn SSL_set_shed_handshake_config(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_never: ssl_renegotiate_mode_t = 0;
@@ -31807,46 +31807,46 @@ pub const ssl_renegotiate_mode_t_ssl_renegotiate_ignore: ssl_renegotiate_mode_t 
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_explicit: ssl_renegotiate_mode_t = 4;
 pub type ssl_renegotiate_mode_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_renegotiate_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_renegotiate_mode"]
     pub fn SSL_set_renegotiate_mode(ssl: *mut SSL, mode: ssl_renegotiate_mode_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_renegotiate"]
     pub fn SSL_renegotiate(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_renegotiate_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_renegotiate_pending"]
     pub fn SSL_renegotiate_pending(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_total_renegotiations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_total_renegotiations"]
     pub fn SSL_total_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_max_cert_list"]
     pub fn SSL_CTX_get_max_cert_list(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_max_cert_list"]
     pub fn SSL_CTX_set_max_cert_list(ctx: *mut SSL_CTX, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_max_cert_list"]
     pub fn SSL_get_max_cert_list(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_max_cert_list"]
     pub fn SSL_set_max_cert_list(ssl: *mut SSL, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_max_send_fragment"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_max_send_fragment"]
     pub fn SSL_CTX_set_max_send_fragment(
         ctx: *mut SSL_CTX,
         max_send_fragment: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_max_send_fragment"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_max_send_fragment"]
     pub fn SSL_set_max_send_fragment(
         ssl: *mut SSL,
         max_send_fragment: usize,
@@ -32040,7 +32040,7 @@ pub const ssl_select_cert_result_t_ssl_select_cert_retry: ssl_select_cert_result
 pub const ssl_select_cert_result_t_ssl_select_cert_error: ssl_select_cert_result_t = -1;
 pub type ssl_select_cert_result_t = ::std::os::raw::c_int;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_early_callback_ctx_extension_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_early_callback_ctx_extension_get"]
     pub fn SSL_early_callback_ctx_extension_get(
         client_hello: *const SSL_CLIENT_HELLO,
         extension_type: u16,
@@ -32049,7 +32049,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_select_certificate_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_select_certificate_cb"]
     pub fn SSL_CTX_set_select_certificate_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32058,7 +32058,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_dos_protection_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_dos_protection_cb"]
     pub fn SSL_CTX_set_dos_protection_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32067,19 +32067,19 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_reverify_on_resume"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_reverify_on_resume"]
     pub fn SSL_CTX_set_reverify_on_resume(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_enforce_rsa_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_enforce_rsa_key_usage"]
     pub fn SSL_set_enforce_rsa_key_usage(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_was_key_usage_invalid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_was_key_usage_invalid"]
     pub fn SSL_was_key_usage_invalid(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_info_callback"]
     pub fn SSL_CTX_set_info_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32092,7 +32092,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_info_callback"]
     pub fn SSL_CTX_get_info_callback(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -32104,7 +32104,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_info_callback"]
     pub fn SSL_set_info_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32117,7 +32117,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_info_callback"]
     pub fn SSL_get_info_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -32129,77 +32129,77 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_state_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_state_string_long"]
     pub fn SSL_state_string_long(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_shutdown"]
     pub fn SSL_get_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_signature_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_signature_algorithm"]
     pub fn SSL_get_peer_signature_algorithm(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_client_random"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_client_random"]
     pub fn SSL_get_client_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_server_random"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_server_random"]
     pub fn SSL_get_server_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_pending_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_pending_cipher"]
     pub fn SSL_get_pending_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_set_retain_only_sha256_of_client_certs(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_CTX_set_retain_only_sha256_of_client_certs(
         ctx: *mut SSL_CTX,
         enable: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_grease_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_grease_enabled"]
     pub fn SSL_CTX_set_grease_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_permute_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_permute_extensions"]
     pub fn SSL_CTX_set_permute_extensions(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_permute_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_permute_extensions"]
     pub fn SSL_set_permute_extensions(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_max_seal_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_max_seal_overhead"]
     pub fn SSL_max_seal_overhead(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_false_start_allowed_without_alpn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_false_start_allowed_without_alpn"]
     pub fn SSL_CTX_set_false_start_allowed_without_alpn(
         ctx: *mut SSL_CTX,
         allowed: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_used_hello_retry_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_used_hello_retry_request"]
     pub fn SSL_used_hello_retry_request(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_jdk11_workaround"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_jdk11_workaround"]
     pub fn SSL_set_jdk11_workaround(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_library_init"]
     pub fn SSL_library_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_description"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_description"]
     pub fn SSL_CIPHER_description(
         cipher: *const SSL_CIPHER,
         buf: *mut ::std::os::raw::c_char,
@@ -32207,11 +32207,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_version"]
     pub fn SSL_CIPHER_get_version(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_rfc_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_rfc_name"]
     pub fn SSL_CIPHER_get_rfc_name(cipher: *const SSL_CIPHER) -> *mut ::std::os::raw::c_char;
 }
 pub type COMP_METHOD = ::std::os::raw::c_void;
@@ -32222,126 +32222,126 @@ pub struct stack_st_SSL_COMP {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_get_compression_methods"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_get_compression_methods"]
     pub fn SSL_COMP_get_compression_methods() -> *mut stack_st_SSL_COMP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_add_compression_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_add_compression_method"]
     pub fn SSL_COMP_add_compression_method(
         id: ::std::os::raw::c_int,
         cm: *mut COMP_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_get_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_get_name"]
     pub fn SSL_COMP_get_name(comp: *const COMP_METHOD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_get0_name"]
     pub fn SSL_COMP_get0_name(comp: *const SSL_COMP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_get_id"]
     pub fn SSL_COMP_get_id(comp: *const SSL_COMP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_free_compression_methods"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_free_compression_methods"]
     pub fn SSL_COMP_free_compression_methods();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLv23_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLv23_method"]
     pub fn SSLv23_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_method"]
     pub fn TLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_1_method"]
     pub fn TLSv1_1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_2_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_2_method"]
     pub fn TLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_method"]
     pub fn DTLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_2_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_2_method"]
     pub fn DTLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLS_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLS_server_method"]
     pub fn TLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLS_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLS_client_method"]
     pub fn TLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLv23_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLv23_server_method"]
     pub fn SSLv23_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLv23_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLv23_client_method"]
     pub fn SSLv23_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_server_method"]
     pub fn TLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_client_method"]
     pub fn TLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_1_server_method"]
     pub fn TLSv1_1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_1_client_method"]
     pub fn TLSv1_1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_2_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_2_server_method"]
     pub fn TLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_2_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_2_client_method"]
     pub fn TLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLS_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLS_server_method"]
     pub fn DTLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLS_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLS_client_method"]
     pub fn DTLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_server_method"]
     pub fn DTLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_client_method"]
     pub fn DTLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_2_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_2_server_method"]
     pub fn DTLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_2_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_2_client_method"]
     pub fn DTLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_clear"]
     pub fn SSL_clear(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tmp_rsa_callback"]
     pub fn SSL_CTX_set_tmp_rsa_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32354,7 +32354,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tmp_rsa_callback"]
     pub fn SSL_set_tmp_rsa_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32367,98 +32367,98 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_connect"]
     pub fn SSL_CTX_sess_connect(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_connect_good"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_connect_good"]
     pub fn SSL_CTX_sess_connect_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_connect_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_connect_renegotiate"]
     pub fn SSL_CTX_sess_connect_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_accept"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_accept"]
     pub fn SSL_CTX_sess_accept(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_accept_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_accept_renegotiate"]
     pub fn SSL_CTX_sess_accept_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_accept_good"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_accept_good"]
     pub fn SSL_CTX_sess_accept_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_hits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_hits"]
     pub fn SSL_CTX_sess_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_cb_hits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_cb_hits"]
     pub fn SSL_CTX_sess_cb_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_misses"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_misses"]
     pub fn SSL_CTX_sess_misses(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_timeouts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_timeouts"]
     pub fn SSL_CTX_sess_timeouts(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_cache_full"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_cache_full"]
     pub fn SSL_CTX_sess_cache_full(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_cutthrough_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_cutthrough_complete"]
     pub fn SSL_cutthrough_complete(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_num_renegotiations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_num_renegotiations"]
     pub fn SSL_num_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_need_tmp_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_need_tmp_RSA"]
     pub fn SSL_CTX_need_tmp_RSA(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_need_tmp_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_need_tmp_RSA"]
     pub fn SSL_need_tmp_RSA(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tmp_rsa"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tmp_rsa"]
     pub fn SSL_CTX_set_tmp_rsa(ctx: *mut SSL_CTX, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tmp_rsa"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tmp_rsa"]
     pub fn SSL_set_tmp_rsa(ssl: *mut SSL, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_read_ahead"]
     pub fn SSL_CTX_get_read_ahead(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_read_ahead"]
     pub fn SSL_CTX_set_read_ahead(
         ctx: *mut SSL_CTX,
         yes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_read_ahead"]
     pub fn SSL_get_read_ahead(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_read_ahead"]
     pub fn SSL_set_read_ahead(ssl: *mut SSL, yes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_state"]
     pub fn SSL_set_state(ssl: *mut SSL, state: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_shared_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_shared_ciphers"]
     pub fn SSL_get_shared_ciphers(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_char,
@@ -32466,7 +32466,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_shared_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_shared_sigalgs"]
     pub fn SSL_get_shared_sigalgs(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -32478,11 +32478,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_SSL_SESSION"]
     pub fn i2d_SSL_SESSION(in_: *mut SSL_SESSION, pp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_SSL_SESSION"]
     pub fn d2i_SSL_SESSION(
         a: *mut *mut SSL_SESSION,
         pp: *mut *const u8,
@@ -32490,61 +32490,61 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_SSL_SESSION_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_SSL_SESSION_bio"]
     pub fn i2d_SSL_SESSION_bio(bio: *mut BIO, session: *const SSL_SESSION)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_SSL_SESSION_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_SSL_SESSION_bio"]
     pub fn d2i_SSL_SESSION_bio(bio: *mut BIO, out: *mut *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_SSL_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_SSL_strings"]
     pub fn ERR_load_SSL_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_load_error_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_load_error_strings"]
     pub fn SSL_load_error_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_use_srtp"]
     pub fn SSL_CTX_set_tlsext_use_srtp(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tlsext_use_srtp"]
     pub fn SSL_set_tlsext_use_srtp(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_current_compression"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_current_compression"]
     pub fn SSL_get_current_compression(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_current_expansion"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_current_expansion"]
     pub fn SSL_get_current_expansion(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_server_tmp_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_server_tmp_key"]
     pub fn SSL_get_server_tmp_key(
         ssl: *mut SSL,
         out_key: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tmp_dh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tmp_dh"]
     pub fn SSL_CTX_set_tmp_dh(ctx: *mut SSL_CTX, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tmp_dh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tmp_dh"]
     pub fn SSL_set_tmp_dh(ssl: *mut SSL, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tmp_dh_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tmp_dh_callback"]
     pub fn SSL_CTX_set_tmp_dh_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32557,7 +32557,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tmp_dh_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tmp_dh_callback"]
     pub fn SSL_set_tmp_dh_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32570,7 +32570,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_sigalgs"]
     pub fn SSL_CTX_set1_sigalgs(
         ctx: *mut SSL_CTX,
         values: *const ::std::os::raw::c_int,
@@ -32578,7 +32578,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_sigalgs"]
     pub fn SSL_set1_sigalgs(
         ssl: *mut SSL,
         values: *const ::std::os::raw::c_int,
@@ -32586,25 +32586,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_sigalgs_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_sigalgs_list"]
     pub fn SSL_CTX_set1_sigalgs_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_sigalgs_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_sigalgs_list"]
     pub fn SSL_set1_sigalgs_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_security_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_security_level"]
     pub fn SSL_CTX_get_security_level(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_security_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_security_level"]
     pub fn SSL_CTX_set_security_level(ctx: *const SSL_CTX, level: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -32684,26 +32684,26 @@ pub type sk_SSL_COMP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_cache_hit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_cache_hit"]
     pub fn SSL_cache_hit(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_default_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_default_timeout"]
     pub fn SSL_get_default_timeout(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_version"]
     pub fn SSL_get_version(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_cipher_list"]
     pub fn SSL_get_cipher_list(
         ssl: *const SSL,
         n: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_client_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_client_cert_cb"]
     pub fn SSL_CTX_set_client_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32716,11 +32716,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_want"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_want"]
     pub fn SSL_want(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_finished"]
     pub fn SSL_get_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32728,7 +32728,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_finished"]
     pub fn SSL_get_peer_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32736,15 +32736,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_alert_type_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_alert_type_string"]
     pub fn SSL_alert_type_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_alert_desc_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_alert_desc_string"]
     pub fn SSL_alert_desc_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_state_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_state_string"]
     pub fn SSL_state_string(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 #[repr(C)]
@@ -32754,42 +32754,42 @@ pub struct ssl_conf_ctx_st {
 }
 pub type SSL_CONF_CTX = ssl_conf_ctx_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_state"]
     pub fn SSL_state(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_shutdown"]
     pub fn SSL_set_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tmp_ecdh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tmp_ecdh"]
     pub fn SSL_CTX_set_tmp_ecdh(ctx: *mut SSL_CTX, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tmp_ecdh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tmp_ecdh"]
     pub fn SSL_set_tmp_ecdh(ssl: *mut SSL, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add_dir_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add_dir_cert_subjects_to_stack"]
     pub fn SSL_add_dir_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         dir: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_enable_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_enable_tls_channel_id"]
     pub fn SSL_CTX_enable_tls_channel_id(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_enable_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_enable_tls_channel_id"]
     pub fn SSL_enable_tls_channel_id(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_f_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_f_ssl"]
     pub fn BIO_f_ssl() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_ssl"]
     pub fn BIO_set_ssl(
         bio: *mut BIO,
         ssl: *mut SSL,
@@ -32797,33 +32797,33 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_session"]
     pub fn SSL_get_session(ssl: *const SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get1_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get1_session"]
     pub fn SSL_get1_session(ssl: *mut SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_init_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_init_ssl"]
     pub fn OPENSSL_init_ssl(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tlsext_status_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tlsext_status_type"]
     pub fn SSL_set_tlsext_status_type(
         ssl: *mut SSL,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_tlsext_status_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_tlsext_status_type"]
     pub fn SSL_get_tlsext_status_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tlsext_status_ocsp_resp"]
     pub fn SSL_set_tlsext_status_ocsp_resp(
         ssl: *mut SSL,
         resp: *mut u8,
@@ -32831,11 +32831,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_tlsext_status_ocsp_resp"]
     pub fn SSL_get_tlsext_status_ocsp_resp(ssl: *const SSL, out: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_status_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_status_cb"]
     pub fn SSL_CTX_set_tlsext_status_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -32847,18 +32847,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_status_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_status_arg"]
     pub fn SSL_CTX_set_tlsext_status_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_value"]
     pub fn SSL_CIPHER_get_value(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,

--- a/aws-lc-fips-sys/src/aarch64_unknown_linux_musl_crypto.rs
+++ b/aws-lc-fips-sys/src/aarch64_unknown_linux_musl_crypto.rs
@@ -4276,38 +4276,38 @@ pub type X509_STORE = x509_store_st;
 pub type X509_TRUST = x509_trust_st;
 pub type OPENSSL_BLOCK = *mut ::std::os::raw::c_void;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4316,18 +4316,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4336,18 +4336,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4356,7 +4356,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -4364,11 +4364,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -4379,30 +4379,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -4441,30 +4441,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -4474,15 +4474,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -4546,7 +4546,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4554,7 +4554,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4562,15 +4562,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4582,7 +4582,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4591,7 +4591,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4602,7 +4602,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4613,7 +4613,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4625,7 +4625,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4635,7 +4635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4645,7 +4645,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4656,7 +4656,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4877,27 +4877,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -4905,29 +4905,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -4935,7 +4935,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5067,27 +5067,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -5095,11 +5095,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -5107,22 +5107,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -5131,7 +5131,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -5140,35 +5140,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -5178,7 +5178,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -5238,7 +5238,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -5294,19 +5294,19 @@ impl Default for crypto_ex_data_st {
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5319,7 +5319,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5333,7 +5333,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5344,29 +5344,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -5422,7 +5422,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5433,7 +5433,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5446,7 +5446,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5458,7 +5458,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -5467,7 +5467,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5478,7 +5478,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -5505,23 +5505,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -5529,7 +5529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -5537,7 +5537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5545,7 +5545,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5553,15 +5553,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5570,7 +5570,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5578,7 +5578,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5587,67 +5587,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -5673,7 +5673,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5681,68 +5681,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -5750,7 +5750,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -5758,7 +5758,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -5767,11 +5767,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -5780,15 +5780,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -5796,11 +5796,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -5808,22 +5808,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -5831,30 +5831,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -5862,89 +5862,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -5953,34 +5953,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -5989,13 +5989,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -6004,13 +6004,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -6023,7 +6023,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -6036,7 +6036,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -6049,7 +6049,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6061,7 +6061,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -6075,7 +6075,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6088,7 +6088,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -6101,7 +6101,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6113,23 +6113,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -6139,7 +6139,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -6147,37 +6147,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -6189,7 +6189,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6559,193 +6559,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6754,15 +6754,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -6772,11 +6772,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -6784,47 +6784,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6832,11 +6832,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6844,43 +6844,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -6889,7 +6889,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6899,7 +6899,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6908,7 +6908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6918,7 +6918,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6927,7 +6927,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6937,7 +6937,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6946,7 +6946,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6956,7 +6956,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6965,7 +6965,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6974,7 +6974,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6982,7 +6982,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6991,7 +6991,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7000,7 +7000,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7009,11 +7009,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -7021,7 +7021,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -7081,15 +7081,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -7103,7 +7103,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -7111,11 +7111,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7130,7 +7130,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -7140,7 +7140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -7151,7 +7151,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7161,7 +7161,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7170,7 +7170,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7179,7 +7179,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7188,7 +7188,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7198,7 +7198,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7208,23 +7208,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7233,7 +7233,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7242,7 +7242,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7252,7 +7252,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7261,7 +7261,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7271,7 +7271,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7282,7 +7282,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7293,15 +7293,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -7312,7 +7312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -7325,11 +7325,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -7337,7 +7337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -7345,7 +7345,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -7493,15 +7493,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -7525,15 +7525,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7542,7 +7542,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -7550,14 +7550,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -7565,7 +7565,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -7573,7 +7573,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -7581,7 +7581,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -7589,14 +7589,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -7604,7 +7604,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7612,22 +7612,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -7703,54 +7703,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -7758,7 +7758,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -7766,79 +7766,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -7846,7 +7846,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -7854,7 +7854,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -7862,7 +7862,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -7870,7 +7870,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -7878,7 +7878,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -7886,7 +7886,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -7894,7 +7894,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -7902,7 +7902,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -7910,117 +7910,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -8028,14 +8028,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8045,7 +8045,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8057,7 +8057,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -8067,7 +8067,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -8077,15 +8077,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8093,26 +8093,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8120,23 +8120,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8144,14 +8144,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8159,25 +8159,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -8185,7 +8185,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -8193,14 +8193,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -8229,19 +8229,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -8249,11 +8249,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -8261,54 +8261,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -8316,59 +8316,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -8376,23 +8376,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, t: time_t) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         t: time_t,
@@ -8401,26 +8401,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -8428,29 +8428,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
@@ -8459,22 +8459,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -8482,15 +8482,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -8499,11 +8499,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, t: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         t: time_t,
@@ -8512,41 +8512,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -8554,11 +8554,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8583,7 +8583,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -8593,11 +8593,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8605,11 +8605,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8617,7 +8617,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8951,15 +8951,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -8967,19 +8967,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -8987,7 +8987,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -8995,12 +8995,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9008,14 +9008,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9023,33 +9023,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -9057,7 +9057,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -9065,19 +9065,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -9085,7 +9085,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -9093,7 +9093,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -9103,7 +9103,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -9113,11 +9113,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -9125,33 +9125,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9159,34 +9159,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -9796,7 +9796,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9821,19 +9821,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -9843,19 +9843,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -9865,7 +9865,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -9873,11 +9873,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -9887,7 +9887,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -9895,7 +9895,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -10105,11 +10105,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -10117,11 +10117,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -10176,19 +10176,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10197,7 +10197,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10258,23 +10258,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -10282,82 +10282,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10365,7 +10365,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10373,11 +10373,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10385,7 +10385,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10394,7 +10394,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10405,22 +10405,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10429,7 +10429,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10438,7 +10438,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -10447,7 +10447,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -10456,33 +10456,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10490,7 +10490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10498,7 +10498,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -10805,23 +10805,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -10829,40 +10829,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -10870,15 +10870,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -10886,55 +10886,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -10942,11 +10942,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -10954,7 +10954,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -10962,11 +10962,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -10974,11 +10974,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -10989,114 +10989,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11107,7 +11107,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11117,7 +11117,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11127,7 +11127,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11137,7 +11137,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11145,7 +11145,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11155,7 +11155,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11163,7 +11163,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11173,7 +11173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11181,47 +11181,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -11230,45 +11230,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -11281,23 +11281,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11307,7 +11307,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11316,7 +11316,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11325,7 +11325,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11333,7 +11333,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11341,7 +11341,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11349,7 +11349,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11358,118 +11358,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -11706,7 +11706,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -11716,19 +11716,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -11738,15 +11738,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -11841,15 +11841,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -11857,7 +11857,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -11865,14 +11865,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -11880,7 +11880,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -11888,23 +11888,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11912,15 +11912,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12007,11 +12007,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12019,19 +12019,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12039,19 +12039,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -12149,11 +12149,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12161,19 +12161,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12181,15 +12181,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12287,11 +12287,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12299,34 +12299,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -12334,34 +12334,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -12369,7 +12369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12378,7 +12378,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12387,7 +12387,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12395,7 +12395,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12403,21 +12403,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12425,7 +12425,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12433,7 +12433,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -12441,7 +12441,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -12450,7 +12450,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -12458,11 +12458,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -12489,51 +12489,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -12543,70 +12543,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -12614,15 +12614,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -12631,7 +12631,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -12640,7 +12640,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -12651,7 +12651,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -12661,11 +12661,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -12676,7 +12676,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -12749,15 +12749,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -12766,7 +12766,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -12777,7 +12777,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -12788,7 +12788,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -12801,7 +12801,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -12813,7 +12813,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_decrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -12822,7 +12822,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_encrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -12831,43 +12831,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -12875,7 +12875,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -12883,7 +12883,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -12892,7 +12892,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -12901,40 +12901,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -12943,11 +12943,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -12955,7 +12955,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -12966,19 +12966,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -12986,19 +12986,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13013,7 +13013,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13021,14 +13021,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13036,114 +13036,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13151,11 +13151,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13163,7 +13163,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13171,7 +13171,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13179,7 +13179,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13190,75 +13190,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13266,19 +13266,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -13370,15 +13370,15 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -13386,11 +13386,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -13398,15 +13398,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_METHOD_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_METHOD_unref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -13452,43 +13452,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -13496,7 +13496,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -13505,7 +13505,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -13513,7 +13513,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -13522,7 +13522,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -13534,11 +13534,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13592,28 +13592,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -13622,7 +13622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13632,7 +13632,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13643,7 +13643,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13654,7 +13654,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13665,47 +13665,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -13715,7 +13715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -13723,14 +13723,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -13738,11 +13738,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -13750,11 +13750,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -13762,11 +13762,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -13774,7 +13774,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13930,19 +13930,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -13950,19 +13950,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -13970,7 +13970,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -13980,53 +13980,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14034,7 +14034,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14043,7 +14043,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14053,7 +14053,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14063,7 +14063,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14073,7 +14073,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14083,7 +14083,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14094,7 +14094,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14104,7 +14104,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14114,7 +14114,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14124,7 +14124,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14134,7 +14134,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14143,7 +14143,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14151,7 +14151,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14162,7 +14162,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14171,7 +14171,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14180,7 +14180,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14188,11 +14188,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14202,15 +14202,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -14264,92 +14264,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -14357,7 +14357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -14366,15 +14366,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -14382,11 +14382,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -14394,22 +14394,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14419,7 +14419,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14427,7 +14427,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14549,11 +14549,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14561,11 +14561,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14573,11 +14573,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14585,14 +14585,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -14609,7 +14609,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -14618,7 +14618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14629,7 +14629,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14640,7 +14640,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -14694,23 +14694,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -14718,7 +14718,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -14726,7 +14726,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -14734,7 +14734,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14743,19 +14743,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -14763,11 +14763,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -14777,7 +14777,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -14785,83 +14785,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -14999,11 +14999,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15012,11 +15012,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15027,11 +15027,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15046,7 +15046,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15061,7 +15061,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15079,7 +15079,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15094,66 +15094,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15164,7 +15164,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15172,7 +15172,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15181,7 +15181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15189,102 +15189,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -15292,40 +15292,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15334,7 +15334,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15343,7 +15343,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15351,7 +15351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15359,7 +15359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15369,7 +15369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15377,7 +15377,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15385,7 +15385,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15395,7 +15395,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15405,7 +15405,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15413,7 +15413,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15421,7 +15421,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15431,7 +15431,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15439,11 +15439,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15451,7 +15451,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -15460,7 +15460,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15468,11 +15468,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15480,7 +15480,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15489,7 +15489,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15498,7 +15498,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15507,7 +15507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15516,7 +15516,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15529,7 +15529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15541,7 +15541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15556,31 +15556,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -15590,11 +15590,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -15604,11 +15604,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15618,11 +15618,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15632,11 +15632,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15646,18 +15646,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -15665,18 +15665,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -15686,7 +15686,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -15696,102 +15696,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -15799,28 +15799,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -15828,7 +15828,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -15836,7 +15836,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -15846,31 +15846,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -15884,7 +15884,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -15898,15 +15898,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -15915,7 +15915,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -15923,7 +15923,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -15932,22 +15932,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -15955,40 +15955,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -15996,11 +15996,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16008,11 +16008,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16020,11 +16020,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16032,14 +16032,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -16213,7 +16213,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16227,7 +16227,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16239,7 +16239,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -16251,11 +16251,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16263,15 +16263,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -16358,7 +16358,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -16370,27 +16370,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16400,7 +16400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -16408,7 +16408,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16416,23 +16416,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16441,7 +16441,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -16617,82 +16617,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -16701,18 +16701,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -16721,7 +16721,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -16730,23 +16730,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -16762,7 +16762,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -16780,7 +16780,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -16793,7 +16793,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -16806,7 +16806,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -16819,7 +16819,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -16829,19 +16829,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17100,7 +17100,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17108,7 +17108,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17117,7 +17117,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17126,22 +17126,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17149,15 +17149,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17244,66 +17244,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -17312,7 +17312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -17320,7 +17320,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -17328,7 +17328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -17409,7 +17409,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -17428,7 +17428,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -17436,47 +17436,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -17770,51 +17770,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -17840,15 +17840,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -17856,18 +17856,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -17875,79 +17875,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -17956,11 +17956,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -17969,7 +17969,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -17978,12 +17978,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -17992,7 +17992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18001,7 +18001,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18009,7 +18009,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18021,7 +18021,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18033,7 +18033,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -18043,7 +18043,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -18053,7 +18053,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18064,7 +18064,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18078,7 +18078,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18090,7 +18090,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18101,7 +18101,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -18114,7 +18114,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18126,7 +18126,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -18136,7 +18136,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -18146,31 +18146,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18181,7 +18181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18192,7 +18192,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -18205,7 +18205,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -18216,19 +18216,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18236,19 +18236,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18256,7 +18256,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -18266,7 +18266,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -18274,26 +18274,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -18302,7 +18302,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18310,11 +18310,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18322,11 +18322,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18336,7 +18336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18346,7 +18346,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -18357,7 +18357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -18365,7 +18365,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -18866,27 +18866,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -18894,51 +18894,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -18951,15 +18951,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -18967,7 +18967,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -18975,7 +18975,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -18983,15 +18983,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -18999,68 +18999,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19068,7 +19068,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19076,25 +19076,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19102,14 +19102,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -19117,7 +19117,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -19125,7 +19125,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -19133,14 +19133,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -19162,23 +19162,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19186,23 +19186,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -19211,19 +19211,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19231,7 +19231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -19239,7 +19239,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -19247,11 +19247,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19259,55 +19259,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -19315,7 +19315,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -19323,25 +19323,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -19349,19 +19349,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -19369,23 +19369,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19393,33 +19393,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -19427,22 +19427,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -19492,19 +19492,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -19512,15 +19512,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -19528,15 +19528,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19544,7 +19544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19552,21 +19552,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -19575,7 +19575,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19587,7 +19587,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19599,7 +19599,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -19611,19 +19611,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -19631,33 +19631,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -19666,11 +19666,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -19680,7 +19680,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -19690,7 +19690,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -19700,19 +19700,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -19720,18 +19720,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -19740,7 +19740,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -19749,33 +19749,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -19799,11 +19799,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -19811,18 +19811,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -19830,7 +19830,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -19838,7 +19838,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -19846,21 +19846,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -19889,23 +19889,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -19913,11 +19913,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -19926,7 +19926,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -19935,15 +19935,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -19951,7 +19951,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -19959,7 +19959,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -19968,7 +19968,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -19977,7 +19977,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -19986,7 +19986,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -19995,7 +19995,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -20004,259 +20004,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -20264,11 +20264,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20278,7 +20278,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -20286,14 +20286,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20303,7 +20303,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -20311,42 +20311,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20355,7 +20355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20928,11 +20928,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -20940,7 +20940,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -20948,54 +20948,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21003,23 +21003,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -21027,7 +21027,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -21036,44 +21036,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21081,34 +21081,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21116,26 +21116,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21143,18 +21143,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21162,38 +21162,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21201,25 +21201,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21227,7 +21227,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21235,23 +21235,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21259,26 +21259,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21286,26 +21286,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -21313,7 +21313,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -21323,7 +21323,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -21333,7 +21333,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -21343,7 +21343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21355,7 +21355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21366,15 +21366,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -21382,18 +21382,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21401,7 +21401,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21409,28 +21409,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21440,7 +21440,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21450,7 +21450,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -21460,37 +21460,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -21500,66 +21500,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -21568,19 +21568,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -21589,7 +21589,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -21597,7 +21597,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -21606,7 +21606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -21615,15 +21615,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -21632,11 +21632,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -21645,7 +21645,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -21655,7 +21655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21664,7 +21664,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21674,11 +21674,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21686,7 +21686,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -21694,7 +21694,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -21702,21 +21702,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -21724,7 +21724,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21733,7 +21733,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21743,11 +21743,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21755,7 +21755,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21763,28 +21763,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21794,7 +21794,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21804,7 +21804,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -21814,7 +21814,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21824,7 +21824,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21834,7 +21834,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -21844,14 +21844,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -21860,7 +21860,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -21869,34 +21869,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21904,26 +21904,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -21934,7 +21934,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -21944,11 +21944,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -21956,19 +21956,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -21985,19 +21985,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22084,15 +22084,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22100,14 +22100,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -22226,18 +22226,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22245,7 +22245,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22253,202 +22253,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -22456,15 +22456,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -22473,50 +22473,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -22525,7 +22525,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -22535,7 +22535,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22543,7 +22543,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22551,7 +22551,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22559,19 +22559,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -22580,11 +22580,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -22592,81 +22592,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -22675,11 +22675,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -22687,7 +22687,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -22699,105 +22699,105 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -22805,7 +22805,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -22813,20 +22813,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -22834,7 +22834,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -22842,42 +22842,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -22889,14 +22889,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -22906,7 +22906,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -22916,7 +22916,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -22926,7 +22926,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -22938,7 +22938,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -22949,7 +22949,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -22963,7 +22963,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -22972,7 +22972,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -22982,7 +22982,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -22992,7 +22992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23003,7 +23003,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23017,7 +23017,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -23026,7 +23026,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -23035,11 +23035,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_proc_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_dek_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -23048,7 +23048,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23057,7 +23057,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23066,15 +23066,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23083,7 +23083,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23092,15 +23092,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -23109,7 +23109,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -23118,23 +23118,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -23143,7 +23143,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -23152,15 +23152,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -23169,7 +23169,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -23178,15 +23178,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -23195,7 +23195,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -23204,15 +23204,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23221,7 +23221,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23230,21 +23230,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23253,7 +23253,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23262,7 +23262,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -23274,7 +23274,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -23286,7 +23286,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23295,7 +23295,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23304,15 +23304,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23321,7 +23321,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23330,15 +23330,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23347,7 +23347,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23356,7 +23356,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -23368,7 +23368,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -23380,7 +23380,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23389,7 +23389,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23398,15 +23398,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23415,7 +23415,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23424,15 +23424,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23441,7 +23441,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23450,7 +23450,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -23462,7 +23462,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -23474,7 +23474,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23483,7 +23483,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23492,15 +23492,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -23509,7 +23509,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -23518,15 +23518,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23535,7 +23535,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23544,7 +23544,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23556,7 +23556,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23568,7 +23568,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23577,7 +23577,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23586,15 +23586,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23606,7 +23606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -23618,7 +23618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23630,7 +23630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23642,7 +23642,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23651,7 +23651,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23663,7 +23663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23675,7 +23675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23687,7 +23687,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23696,7 +23696,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23708,7 +23708,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -23721,7 +23721,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -23735,7 +23735,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -23743,7 +23743,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -23751,7 +23751,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -23760,11 +23760,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -23772,27 +23772,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -23802,7 +23802,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -23810,7 +23810,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -23825,74 +23825,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23993,19 +23993,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24070,11 +24070,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -24161,11 +24161,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -24173,42 +24173,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -24283,15 +24283,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24304,7 +24304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24319,18 +24319,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24339,14 +24339,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24355,7 +24355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24366,7 +24366,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24375,7 +24375,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24387,7 +24387,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -24399,18 +24399,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24418,14 +24418,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24433,7 +24433,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24447,7 +24447,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24462,7 +24462,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24475,7 +24475,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24490,7 +24490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -26198,15 +26198,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26214,26 +26214,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26241,14 +26241,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -26480,15 +26480,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26496,26 +26496,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26523,26 +26523,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26550,29 +26550,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -26580,19 +26580,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26600,18 +26600,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -26619,7 +26619,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -26627,15 +26627,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26643,26 +26643,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26670,22 +26670,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -26693,14 +26693,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -26708,7 +26708,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -26716,14 +26716,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -26731,15 +26731,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26747,33 +26747,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26781,26 +26781,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26808,26 +26808,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26835,26 +26835,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26862,26 +26862,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26889,26 +26889,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26916,26 +26916,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26943,26 +26943,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26970,26 +26970,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26997,38 +26997,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27036,26 +27036,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27063,70 +27063,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27137,7 +27137,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27145,7 +27145,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27155,7 +27155,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -27253,7 +27253,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -27264,11 +27264,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27277,7 +27277,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27286,7 +27286,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -27295,7 +27295,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27304,7 +27304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27313,7 +27313,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27322,7 +27322,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27331,67 +27331,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27400,14 +27400,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -27415,7 +27415,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27425,7 +27425,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -27434,7 +27434,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -27443,7 +27443,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -27452,7 +27452,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -27462,11 +27462,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -27474,70 +27474,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_akid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -27555,43 +27555,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27601,7 +27601,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27610,7 +27610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -27619,7 +27619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -27627,15 +27627,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,

--- a/aws-lc-fips-sys/src/aarch64_unknown_linux_musl_crypto_ssl.rs
+++ b/aws-lc-fips-sys/src/aarch64_unknown_linux_musl_crypto_ssl.rs
@@ -5268,38 +5268,38 @@ pub type X509_STORE = x509_store_st;
 pub type X509_TRUST = x509_trust_st;
 pub type OPENSSL_BLOCK = *mut ::std::os::raw::c_void;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5308,18 +5308,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5328,18 +5328,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5348,7 +5348,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -5356,11 +5356,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -5371,30 +5371,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -5433,30 +5433,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -5466,15 +5466,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -5538,7 +5538,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5546,7 +5546,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5554,15 +5554,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5574,7 +5574,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5583,7 +5583,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5594,7 +5594,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5605,7 +5605,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5617,7 +5617,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5627,7 +5627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5637,7 +5637,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5648,7 +5648,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5869,27 +5869,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5897,29 +5897,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5927,7 +5927,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -6059,27 +6059,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -6087,11 +6087,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6099,22 +6099,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6123,7 +6123,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -6132,35 +6132,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6170,7 +6170,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6230,7 +6230,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6286,19 +6286,19 @@ impl Default for crypto_ex_data_st {
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6311,7 +6311,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6325,7 +6325,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6336,29 +6336,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6414,7 +6414,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6425,7 +6425,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6438,7 +6438,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6450,7 +6450,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6459,7 +6459,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6470,7 +6470,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6497,23 +6497,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6521,7 +6521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6529,7 +6529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6537,7 +6537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6545,15 +6545,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6562,7 +6562,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6570,7 +6570,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6579,67 +6579,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6665,7 +6665,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6673,68 +6673,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6742,7 +6742,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6750,7 +6750,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6759,11 +6759,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -6772,15 +6772,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -6788,11 +6788,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -6800,22 +6800,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -6823,30 +6823,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -6854,89 +6854,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -6945,34 +6945,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -6981,13 +6981,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -6996,13 +6996,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7015,7 +7015,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7028,7 +7028,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7041,7 +7041,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7053,7 +7053,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7067,7 +7067,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7080,7 +7080,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7093,7 +7093,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7105,23 +7105,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7131,7 +7131,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7139,37 +7139,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7181,7 +7181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7551,193 +7551,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7746,15 +7746,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7764,11 +7764,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -7776,47 +7776,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7824,11 +7824,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7836,43 +7836,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -7881,7 +7881,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7891,7 +7891,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7900,7 +7900,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7910,7 +7910,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7919,7 +7919,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7929,7 +7929,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7938,7 +7938,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7948,7 +7948,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7957,7 +7957,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7966,7 +7966,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7974,7 +7974,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7983,7 +7983,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7992,7 +7992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8001,11 +8001,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8013,7 +8013,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8073,15 +8073,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8095,7 +8095,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8103,11 +8103,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8122,7 +8122,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8132,7 +8132,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8143,7 +8143,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8153,7 +8153,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8162,7 +8162,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8171,7 +8171,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8180,7 +8180,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8190,7 +8190,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8200,23 +8200,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8225,7 +8225,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8234,7 +8234,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8244,7 +8244,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8253,7 +8253,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8263,7 +8263,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8274,7 +8274,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8285,15 +8285,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8304,7 +8304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8317,11 +8317,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8329,7 +8329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8337,7 +8337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -8485,15 +8485,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8517,15 +8517,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8534,7 +8534,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8542,14 +8542,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8557,7 +8557,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8565,7 +8565,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8573,7 +8573,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8581,14 +8581,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8596,7 +8596,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8604,22 +8604,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8695,54 +8695,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8750,7 +8750,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8758,79 +8758,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -8838,7 +8838,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -8846,7 +8846,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -8854,7 +8854,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -8862,7 +8862,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -8870,7 +8870,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -8878,7 +8878,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -8886,7 +8886,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -8894,7 +8894,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -8902,117 +8902,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9020,14 +9020,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9037,7 +9037,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9049,7 +9049,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9059,7 +9059,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9069,15 +9069,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9085,26 +9085,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9112,23 +9112,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9136,14 +9136,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9151,25 +9151,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9177,7 +9177,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9185,14 +9185,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9221,19 +9221,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9241,11 +9241,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9253,54 +9253,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9308,59 +9308,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9368,23 +9368,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, t: time_t) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         t: time_t,
@@ -9393,26 +9393,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9420,29 +9420,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
@@ -9451,22 +9451,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9474,15 +9474,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9491,11 +9491,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, t: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         t: time_t,
@@ -9504,41 +9504,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9546,11 +9546,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9575,7 +9575,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9585,11 +9585,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9597,11 +9597,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9609,7 +9609,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9943,15 +9943,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -9959,19 +9959,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9979,7 +9979,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9987,12 +9987,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10000,14 +10000,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10015,33 +10015,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10049,7 +10049,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10057,19 +10057,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10077,7 +10077,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10085,7 +10085,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10095,7 +10095,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10105,11 +10105,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10117,33 +10117,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10151,34 +10151,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -10788,7 +10788,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10813,19 +10813,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -10835,19 +10835,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10857,7 +10857,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10865,11 +10865,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10879,7 +10879,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10887,7 +10887,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11097,11 +11097,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11109,11 +11109,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11168,19 +11168,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11189,7 +11189,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11250,23 +11250,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11274,82 +11274,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11357,7 +11357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11365,11 +11365,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11377,7 +11377,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11386,7 +11386,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11397,22 +11397,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11421,7 +11421,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11430,7 +11430,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11439,7 +11439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11448,33 +11448,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11482,7 +11482,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11490,7 +11490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -11797,23 +11797,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11821,40 +11821,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -11862,15 +11862,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11878,55 +11878,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -11934,11 +11934,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -11946,7 +11946,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -11954,11 +11954,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -11966,11 +11966,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -11981,114 +11981,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12099,7 +12099,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12109,7 +12109,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12119,7 +12119,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12129,7 +12129,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12137,7 +12137,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12147,7 +12147,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12155,7 +12155,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12165,7 +12165,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12173,47 +12173,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12222,45 +12222,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12273,23 +12273,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12299,7 +12299,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12308,7 +12308,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12317,7 +12317,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12325,7 +12325,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12333,7 +12333,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12341,7 +12341,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12350,118 +12350,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -12698,7 +12698,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -12708,19 +12708,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12730,15 +12730,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -12833,15 +12833,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -12849,7 +12849,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -12857,14 +12857,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -12872,7 +12872,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -12880,23 +12880,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12904,15 +12904,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12999,11 +12999,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13011,19 +13011,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13031,19 +13031,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -13141,11 +13141,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13153,19 +13153,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13173,15 +13173,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13279,11 +13279,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13291,34 +13291,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -13326,34 +13326,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13361,7 +13361,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13370,7 +13370,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13379,7 +13379,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13387,7 +13387,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13395,21 +13395,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13417,7 +13417,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13425,7 +13425,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -13433,7 +13433,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -13442,7 +13442,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -13450,11 +13450,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -13481,51 +13481,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -13535,70 +13535,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13606,15 +13606,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13623,7 +13623,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13632,7 +13632,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13643,7 +13643,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13653,11 +13653,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13668,7 +13668,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13741,15 +13741,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13758,7 +13758,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13769,7 +13769,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13780,7 +13780,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13793,7 +13793,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13805,7 +13805,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_decrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13814,7 +13814,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_encrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13823,43 +13823,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13867,7 +13867,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13875,7 +13875,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13884,7 +13884,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13893,40 +13893,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13935,11 +13935,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13947,7 +13947,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13958,19 +13958,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13978,19 +13978,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -14005,7 +14005,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -14013,14 +14013,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14028,114 +14028,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -14143,11 +14143,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -14155,7 +14155,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14163,7 +14163,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14171,7 +14171,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -14182,75 +14182,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -14258,19 +14258,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14362,15 +14362,15 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -14378,11 +14378,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -14390,15 +14390,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_METHOD_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_METHOD_unref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -14444,43 +14444,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14488,7 +14488,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14497,7 +14497,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14505,7 +14505,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14514,7 +14514,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14526,11 +14526,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14584,28 +14584,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14614,7 +14614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14624,7 +14624,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14635,7 +14635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14646,7 +14646,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14657,47 +14657,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14707,7 +14707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14715,14 +14715,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14730,11 +14730,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14742,11 +14742,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14754,11 +14754,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14766,7 +14766,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14922,19 +14922,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14942,19 +14942,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14962,7 +14962,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14972,53 +14972,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15026,7 +15026,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -15035,7 +15035,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15045,7 +15045,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15055,7 +15055,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15065,7 +15065,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15075,7 +15075,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15086,7 +15086,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -15096,7 +15096,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15106,7 +15106,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15116,7 +15116,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15126,7 +15126,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15135,7 +15135,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -15143,7 +15143,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15154,7 +15154,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -15163,7 +15163,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -15172,7 +15172,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -15180,11 +15180,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15194,15 +15194,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -15256,92 +15256,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -15349,7 +15349,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15358,15 +15358,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15374,11 +15374,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15386,22 +15386,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15411,7 +15411,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15419,7 +15419,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15541,11 +15541,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15553,11 +15553,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15565,11 +15565,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15577,14 +15577,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15601,7 +15601,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15610,7 +15610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15621,7 +15621,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15632,7 +15632,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15686,23 +15686,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15710,7 +15710,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15718,7 +15718,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15726,7 +15726,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15735,19 +15735,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15755,11 +15755,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15769,7 +15769,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15777,83 +15777,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15991,11 +15991,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -16004,11 +16004,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16019,11 +16019,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16038,7 +16038,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16053,7 +16053,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16071,7 +16071,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16086,66 +16086,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16156,7 +16156,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -16164,7 +16164,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -16173,7 +16173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -16181,102 +16181,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16284,40 +16284,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16326,7 +16326,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16335,7 +16335,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16343,7 +16343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16351,7 +16351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16361,7 +16361,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16369,7 +16369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16377,7 +16377,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16387,7 +16387,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16397,7 +16397,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16405,7 +16405,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16413,7 +16413,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16423,7 +16423,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16431,11 +16431,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16443,7 +16443,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16452,7 +16452,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16460,11 +16460,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16472,7 +16472,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16481,7 +16481,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16490,7 +16490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16499,7 +16499,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16508,7 +16508,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16521,7 +16521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16533,7 +16533,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16548,31 +16548,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16582,11 +16582,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16596,11 +16596,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16610,11 +16610,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16624,11 +16624,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16638,18 +16638,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16657,18 +16657,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16678,7 +16678,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16688,102 +16688,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16791,28 +16791,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16820,7 +16820,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16828,7 +16828,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16838,31 +16838,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16876,7 +16876,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16890,15 +16890,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16907,7 +16907,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16915,7 +16915,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16924,22 +16924,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16947,40 +16947,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16988,11 +16988,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -17000,11 +17000,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -17012,11 +17012,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -17024,14 +17024,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -17205,7 +17205,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -17219,7 +17219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -17231,7 +17231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -17243,11 +17243,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17255,15 +17255,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17350,7 +17350,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17362,27 +17362,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17392,7 +17392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17400,7 +17400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17408,23 +17408,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17433,7 +17433,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17609,82 +17609,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17693,18 +17693,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17713,7 +17713,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17722,23 +17722,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17754,7 +17754,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17772,7 +17772,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17785,7 +17785,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17798,7 +17798,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17811,7 +17811,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17821,19 +17821,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -18092,7 +18092,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -18100,7 +18100,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -18109,7 +18109,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -18118,22 +18118,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18141,15 +18141,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18236,66 +18236,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -18304,7 +18304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -18312,7 +18312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -18320,7 +18320,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -18401,7 +18401,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -18420,7 +18420,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18428,47 +18428,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18762,51 +18762,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18832,15 +18832,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18848,18 +18848,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18867,79 +18867,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18948,11 +18948,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18961,7 +18961,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18970,12 +18970,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18984,7 +18984,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18993,7 +18993,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19001,7 +19001,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19013,7 +19013,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19025,7 +19025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19035,7 +19035,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19045,7 +19045,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19056,7 +19056,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19070,7 +19070,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19082,7 +19082,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19093,7 +19093,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19106,7 +19106,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19118,7 +19118,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19128,7 +19128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19138,31 +19138,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19173,7 +19173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19184,7 +19184,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19197,7 +19197,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19208,19 +19208,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19228,19 +19228,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19248,7 +19248,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19258,7 +19258,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19266,26 +19266,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19294,7 +19294,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19302,11 +19302,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19314,11 +19314,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19328,7 +19328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19338,7 +19338,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19349,7 +19349,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19357,7 +19357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -19858,27 +19858,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19886,51 +19886,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19943,15 +19943,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19959,7 +19959,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19967,7 +19967,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19975,15 +19975,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19991,68 +19991,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -20060,7 +20060,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -20068,25 +20068,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -20094,14 +20094,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -20109,7 +20109,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -20117,7 +20117,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -20125,14 +20125,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -20154,23 +20154,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -20178,23 +20178,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -20203,19 +20203,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20223,7 +20223,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20231,7 +20231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20239,11 +20239,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20251,55 +20251,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20307,7 +20307,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20315,25 +20315,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20341,19 +20341,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20361,23 +20361,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20385,33 +20385,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20419,22 +20419,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20484,19 +20484,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20504,15 +20504,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20520,15 +20520,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20536,7 +20536,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20544,21 +20544,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20567,7 +20567,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20579,7 +20579,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20591,7 +20591,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20603,19 +20603,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20623,33 +20623,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20658,11 +20658,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20672,7 +20672,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20682,7 +20682,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20692,19 +20692,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20712,18 +20712,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20732,7 +20732,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20741,33 +20741,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20791,11 +20791,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20803,18 +20803,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20822,7 +20822,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20830,7 +20830,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20838,21 +20838,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -20881,23 +20881,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -20905,11 +20905,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -20918,7 +20918,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -20927,15 +20927,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -20943,7 +20943,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -20951,7 +20951,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20960,7 +20960,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20969,7 +20969,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -20978,7 +20978,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -20987,7 +20987,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -20996,259 +20996,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -21256,11 +21256,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21270,7 +21270,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -21278,14 +21278,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21295,7 +21295,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -21303,42 +21303,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -21347,7 +21347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -21920,11 +21920,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -21932,7 +21932,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -21940,54 +21940,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21995,23 +21995,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22019,7 +22019,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22028,44 +22028,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22073,34 +22073,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22108,26 +22108,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22135,18 +22135,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -22154,38 +22154,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22193,25 +22193,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22219,7 +22219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22227,23 +22227,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22251,26 +22251,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22278,26 +22278,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22305,7 +22305,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22315,7 +22315,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22325,7 +22325,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22335,7 +22335,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22347,7 +22347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22358,15 +22358,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -22374,18 +22374,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22393,7 +22393,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22401,28 +22401,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22432,7 +22432,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22442,7 +22442,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -22452,37 +22452,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -22492,66 +22492,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -22560,19 +22560,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22581,7 +22581,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22589,7 +22589,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22598,7 +22598,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22607,15 +22607,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22624,11 +22624,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -22637,7 +22637,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -22647,7 +22647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22656,7 +22656,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22666,11 +22666,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22678,7 +22678,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -22686,7 +22686,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -22694,21 +22694,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -22716,7 +22716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22725,7 +22725,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22735,11 +22735,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22747,7 +22747,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22755,28 +22755,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22786,7 +22786,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22796,7 +22796,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22806,7 +22806,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22816,7 +22816,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22826,7 +22826,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22836,14 +22836,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -22852,7 +22852,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -22861,34 +22861,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22896,26 +22896,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -22926,7 +22926,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -22936,11 +22936,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -22948,19 +22948,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -22977,19 +22977,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23076,15 +23076,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23092,14 +23092,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -23218,18 +23218,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23237,7 +23237,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23245,202 +23245,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23448,15 +23448,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -23465,50 +23465,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23517,7 +23517,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23527,7 +23527,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23535,7 +23535,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23543,7 +23543,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23551,19 +23551,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -23572,11 +23572,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23584,81 +23584,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -23667,11 +23667,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23679,7 +23679,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23691,105 +23691,105 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23797,7 +23797,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23805,20 +23805,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -23826,7 +23826,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -23834,42 +23834,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -23881,14 +23881,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -23898,7 +23898,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23908,7 +23908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -23918,7 +23918,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -23930,7 +23930,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23941,7 +23941,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23955,7 +23955,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -23964,7 +23964,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23974,7 +23974,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -23984,7 +23984,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23995,7 +23995,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24009,7 +24009,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -24018,7 +24018,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -24027,11 +24027,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_proc_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_dek_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -24040,7 +24040,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24049,7 +24049,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24058,15 +24058,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24075,7 +24075,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24084,15 +24084,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -24101,7 +24101,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -24110,23 +24110,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -24135,7 +24135,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -24144,15 +24144,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -24161,7 +24161,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -24170,15 +24170,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -24187,7 +24187,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -24196,15 +24196,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24213,7 +24213,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24222,21 +24222,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24245,7 +24245,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24254,7 +24254,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -24266,7 +24266,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -24278,7 +24278,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24287,7 +24287,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24296,15 +24296,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24313,7 +24313,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24322,15 +24322,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24339,7 +24339,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24348,7 +24348,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -24360,7 +24360,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -24372,7 +24372,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24381,7 +24381,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24390,15 +24390,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24407,7 +24407,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24416,15 +24416,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24433,7 +24433,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24442,7 +24442,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -24454,7 +24454,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -24466,7 +24466,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24475,7 +24475,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24484,15 +24484,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -24501,7 +24501,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -24510,15 +24510,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24527,7 +24527,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24536,7 +24536,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24548,7 +24548,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24560,7 +24560,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24569,7 +24569,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24578,15 +24578,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24598,7 +24598,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -24610,7 +24610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24622,7 +24622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24634,7 +24634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24643,7 +24643,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24655,7 +24655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24667,7 +24667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24679,7 +24679,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24688,7 +24688,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24700,7 +24700,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -24713,7 +24713,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -24727,7 +24727,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -24735,7 +24735,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -24743,7 +24743,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -24752,11 +24752,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -24764,27 +24764,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24794,7 +24794,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24802,7 +24802,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -24817,74 +24817,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24985,19 +24985,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25062,11 +25062,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -25153,11 +25153,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -25165,42 +25165,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -25275,15 +25275,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25296,7 +25296,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25311,18 +25311,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25331,14 +25331,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25347,7 +25347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25358,7 +25358,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25367,7 +25367,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25379,7 +25379,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -25391,18 +25391,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25410,14 +25410,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25425,7 +25425,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25439,7 +25439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25454,7 +25454,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25467,7 +25467,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25482,7 +25482,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -27190,15 +27190,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27206,26 +27206,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27233,14 +27233,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -27472,15 +27472,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27488,26 +27488,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27515,26 +27515,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27542,29 +27542,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -27572,19 +27572,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27592,18 +27592,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -27611,7 +27611,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27619,15 +27619,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27635,26 +27635,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27662,22 +27662,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -27685,14 +27685,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -27700,7 +27700,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -27708,14 +27708,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27723,15 +27723,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27739,33 +27739,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27773,26 +27773,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27800,26 +27800,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27827,26 +27827,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27854,26 +27854,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27881,26 +27881,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27908,26 +27908,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27935,26 +27935,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27962,26 +27962,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27989,38 +27989,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28028,26 +28028,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28055,70 +28055,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28129,7 +28129,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -28137,7 +28137,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28147,7 +28147,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -28245,7 +28245,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -28256,11 +28256,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28269,7 +28269,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28278,7 +28278,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -28287,7 +28287,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28296,7 +28296,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28305,7 +28305,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28314,7 +28314,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28323,67 +28323,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28392,14 +28392,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -28407,7 +28407,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28417,7 +28417,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -28426,7 +28426,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -28435,7 +28435,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -28444,7 +28444,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -28454,11 +28454,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -28466,70 +28466,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_akid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -28547,43 +28547,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28593,7 +28593,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28602,7 +28602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -28611,7 +28611,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -28619,11 +28619,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -28689,119 +28689,119 @@ impl static_assertion_at_line_255_error_is_max_overheads_are_inconsistent {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLS_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLS_method"]
     pub fn TLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLS_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLS_method"]
     pub fn DTLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLS_with_buffers_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLS_with_buffers_method"]
     pub fn TLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLS_with_buffers_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLS_with_buffers_method"]
     pub fn DTLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_new"]
     pub fn SSL_CTX_new(method: *const SSL_METHOD) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_up_ref"]
     pub fn SSL_CTX_up_ref(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_free"]
     pub fn SSL_CTX_free(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_new"]
     pub fn SSL_new(ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_free"]
     pub fn SSL_free(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_SSL_CTX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_SSL_CTX"]
     pub fn SSL_get_SSL_CTX(ssl: *const SSL) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_connect_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_connect_state"]
     pub fn SSL_set_connect_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_accept_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_accept_state"]
     pub fn SSL_set_accept_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_is_server"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_is_server"]
     pub fn SSL_is_server(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_is_dtls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_is_dtls"]
     pub fn SSL_is_dtls(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_bio"]
     pub fn SSL_set_bio(ssl: *mut SSL, rbio: *mut BIO, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set0_rbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set0_rbio"]
     pub fn SSL_set0_rbio(ssl: *mut SSL, rbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set0_wbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set0_wbio"]
     pub fn SSL_set0_wbio(ssl: *mut SSL, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_rbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_rbio"]
     pub fn SSL_get_rbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_wbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_wbio"]
     pub fn SSL_get_wbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_fd"]
     pub fn SSL_get_fd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_rfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_rfd"]
     pub fn SSL_get_rfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_wfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_wfd"]
     pub fn SSL_get_wfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_fd"]
     pub fn SSL_set_fd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_rfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_rfd"]
     pub fn SSL_set_rfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_wfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_wfd"]
     pub fn SSL_set_wfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_do_handshake"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_do_handshake"]
     pub fn SSL_do_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_connect"]
     pub fn SSL_connect(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_accept"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_accept"]
     pub fn SSL_accept(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_read"]
     pub fn SSL_read(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -28809,7 +28809,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_peek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_peek"]
     pub fn SSL_peek(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -28817,15 +28817,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_pending"]
     pub fn SSL_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_has_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_has_pending"]
     pub fn SSL_has_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_write"]
     pub fn SSL_write(
         ssl: *mut SSL,
         buf: *const ::std::os::raw::c_void,
@@ -28833,220 +28833,220 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_key_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_key_update"]
     pub fn SSL_key_update(
         ssl: *mut SSL,
         request_type: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_shutdown"]
     pub fn SSL_shutdown(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_quiet_shutdown"]
     pub fn SSL_CTX_set_quiet_shutdown(ctx: *mut SSL_CTX, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_quiet_shutdown"]
     pub fn SSL_CTX_get_quiet_shutdown(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_quiet_shutdown"]
     pub fn SSL_set_quiet_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_quiet_shutdown"]
     pub fn SSL_get_quiet_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_error"]
     pub fn SSL_get_error(ssl: *const SSL, ret_code: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_error_description"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_error_description"]
     pub fn SSL_error_description(err: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_mtu"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_mtu"]
     pub fn SSL_set_mtu(ssl: *mut SSL, mtu: ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_set_initial_timeout_duration"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_set_initial_timeout_duration"]
     pub fn DTLSv1_set_initial_timeout_duration(ssl: *mut SSL, duration_ms: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_get_timeout"]
     pub fn DTLSv1_get_timeout(ssl: *const SSL, out: *mut timeval) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_handle_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_handle_timeout"]
     pub fn DTLSv1_handle_timeout(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_min_proto_version"]
     pub fn SSL_CTX_set_min_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_max_proto_version"]
     pub fn SSL_CTX_set_max_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_min_proto_version"]
     pub fn SSL_CTX_get_min_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_max_proto_version"]
     pub fn SSL_CTX_get_max_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_min_proto_version"]
     pub fn SSL_set_min_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_max_proto_version"]
     pub fn SSL_set_max_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_min_proto_version"]
     pub fn SSL_get_min_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_max_proto_version"]
     pub fn SSL_get_max_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_version"]
     pub fn SSL_version(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_options"]
     pub fn SSL_CTX_set_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_clear_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_clear_options"]
     pub fn SSL_CTX_clear_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_options"]
     pub fn SSL_CTX_get_options(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_options"]
     pub fn SSL_set_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_clear_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_clear_options"]
     pub fn SSL_clear_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_options"]
     pub fn SSL_get_options(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_mode"]
     pub fn SSL_CTX_set_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_clear_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_clear_mode"]
     pub fn SSL_CTX_clear_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_mode"]
     pub fn SSL_CTX_get_mode(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_mode"]
     pub fn SSL_set_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_clear_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_clear_mode"]
     pub fn SSL_clear_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_mode"]
     pub fn SSL_get_mode(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set0_buffer_pool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set0_buffer_pool"]
     pub fn SSL_CTX_set0_buffer_pool(ctx: *mut SSL_CTX, pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_certificate"]
     pub fn SSL_CTX_use_certificate(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_certificate"]
     pub fn SSL_use_certificate(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_PrivateKey"]
     pub fn SSL_CTX_use_PrivateKey(ctx: *mut SSL_CTX, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_PrivateKey"]
     pub fn SSL_use_PrivateKey(ssl: *mut SSL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set0_chain"]
     pub fn SSL_CTX_set0_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_chain"]
     pub fn SSL_CTX_set1_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set0_chain"]
     pub fn SSL_set0_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_chain"]
     pub fn SSL_set1_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add0_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add0_chain_cert"]
     pub fn SSL_CTX_add0_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add1_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add1_chain_cert"]
     pub fn SSL_CTX_add1_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add0_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add0_chain_cert"]
     pub fn SSL_add0_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add_extra_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add_extra_chain_cert"]
     pub fn SSL_CTX_add_extra_chain_cert(
         ctx: *mut SSL_CTX,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add1_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add1_chain_cert"]
     pub fn SSL_add1_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_clear_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_clear_chain_certs"]
     pub fn SSL_CTX_clear_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_clear_extra_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_clear_extra_chain_certs"]
     pub fn SSL_CTX_clear_extra_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_clear_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_clear_chain_certs"]
     pub fn SSL_clear_chain_certs(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_cert_cb"]
     pub fn SSL_CTX_set_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -29059,7 +29059,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_cert_cb"]
     pub fn SSL_set_cert_cb(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -29072,71 +29072,71 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_certificate_types"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_certificate_types"]
     pub fn SSL_get0_certificate_types(ssl: *const SSL, out_types: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_peer_verify_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_peer_verify_algorithms"]
     pub fn SSL_get0_peer_verify_algorithms(ssl: *const SSL, out_sigalgs: *mut *const u16) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_peer_delegation_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_peer_delegation_algorithms"]
     pub fn SSL_get0_peer_delegation_algorithms(
         ssl: *const SSL,
         out_sigalgs: *mut *const u16,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_certs_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_certs_clear"]
     pub fn SSL_certs_clear(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_check_private_key"]
     pub fn SSL_CTX_check_private_key(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_check_private_key"]
     pub fn SSL_check_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get0_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get0_certificate"]
     pub fn SSL_CTX_get0_certificate(ctx: *const SSL_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_certificate"]
     pub fn SSL_get_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get0_privatekey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get0_privatekey"]
     pub fn SSL_CTX_get0_privatekey(ctx: *const SSL_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_privatekey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_privatekey"]
     pub fn SSL_get_privatekey(ssl: *const SSL) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get0_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get0_chain_certs"]
     pub fn SSL_CTX_get0_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_extra_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_extra_chain_certs"]
     pub fn SSL_CTX_get_extra_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_chain_certs"]
     pub fn SSL_get0_chain_certs(
         ssl: *const SSL,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_signed_cert_timestamp_list"]
     pub fn SSL_CTX_set_signed_cert_timestamp_list(
         ctx: *mut SSL_CTX,
         list: *const u8,
@@ -29144,7 +29144,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_signed_cert_timestamp_list"]
     pub fn SSL_set_signed_cert_timestamp_list(
         ctx: *mut SSL,
         list: *const u8,
@@ -29152,7 +29152,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_ocsp_response"]
     pub fn SSL_CTX_set_ocsp_response(
         ctx: *mut SSL_CTX,
         response: *const u8,
@@ -29160,7 +29160,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_ocsp_response"]
     pub fn SSL_set_ocsp_response(
         ssl: *mut SSL,
         response: *const u8,
@@ -29168,26 +29168,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_signature_algorithm_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_signature_algorithm_name"]
     pub fn SSL_get_signature_algorithm_name(
         sigalg: u16,
         include_curve: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_signature_algorithm_key_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_signature_algorithm_key_type"]
     pub fn SSL_get_signature_algorithm_key_type(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_signature_algorithm_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_signature_algorithm_digest"]
     pub fn SSL_get_signature_algorithm_digest(sigalg: u16) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_is_signature_algorithm_rsa_pss"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_is_signature_algorithm_rsa_pss"]
     pub fn SSL_is_signature_algorithm_rsa_pss(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_signing_algorithm_prefs"]
     pub fn SSL_CTX_set_signing_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -29195,7 +29195,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_signing_algorithm_prefs"]
     pub fn SSL_set_signing_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -29203,7 +29203,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_chain_and_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_chain_and_key"]
     pub fn SSL_CTX_set_chain_and_key(
         ctx: *mut SSL_CTX,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29213,7 +29213,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_chain_and_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_chain_and_key"]
     pub fn SSL_set_chain_and_key(
         ssl: *mut SSL,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29223,19 +29223,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get0_chain"]
     pub fn SSL_CTX_get0_chain(ctx: *const SSL_CTX) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_RSAPrivateKey"]
     pub fn SSL_CTX_use_RSAPrivateKey(ctx: *mut SSL_CTX, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_RSAPrivateKey"]
     pub fn SSL_use_RSAPrivateKey(ssl: *mut SSL, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_certificate_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_certificate_ASN1"]
     pub fn SSL_CTX_use_certificate_ASN1(
         ctx: *mut SSL_CTX,
         der_len: usize,
@@ -29243,7 +29243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_certificate_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_certificate_ASN1"]
     pub fn SSL_use_certificate_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29251,7 +29251,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_PrivateKey_ASN1"]
     pub fn SSL_CTX_use_PrivateKey_ASN1(
         pk: ::std::os::raw::c_int,
         ctx: *mut SSL_CTX,
@@ -29260,7 +29260,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_PrivateKey_ASN1"]
     pub fn SSL_use_PrivateKey_ASN1(
         type_: ::std::os::raw::c_int,
         ssl: *mut SSL,
@@ -29269,7 +29269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_RSAPrivateKey_ASN1"]
     pub fn SSL_CTX_use_RSAPrivateKey_ASN1(
         ctx: *mut SSL_CTX,
         der: *const u8,
@@ -29277,7 +29277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_RSAPrivateKey_ASN1"]
     pub fn SSL_use_RSAPrivateKey_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29285,7 +29285,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_RSAPrivateKey_file"]
     pub fn SSL_CTX_use_RSAPrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29293,7 +29293,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_RSAPrivateKey_file"]
     pub fn SSL_use_RSAPrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29301,7 +29301,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_certificate_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_certificate_file"]
     pub fn SSL_CTX_use_certificate_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29309,7 +29309,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_certificate_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_certificate_file"]
     pub fn SSL_use_certificate_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29317,7 +29317,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_PrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_PrivateKey_file"]
     pub fn SSL_CTX_use_PrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29325,7 +29325,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_PrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_PrivateKey_file"]
     pub fn SSL_use_PrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29333,29 +29333,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_certificate_chain_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_certificate_chain_file"]
     pub fn SSL_CTX_use_certificate_chain_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_default_passwd_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_default_passwd_cb"]
     pub fn SSL_CTX_set_default_passwd_cb(ctx: *mut SSL_CTX, cb: pem_password_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_default_passwd_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_default_passwd_cb"]
     pub fn SSL_CTX_get_default_passwd_cb(ctx: *const SSL_CTX) -> pem_password_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_default_passwd_cb_userdata"]
     pub fn SSL_CTX_set_default_passwd_cb_userdata(
         ctx: *mut SSL_CTX,
         data: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_default_passwd_cb_userdata"]
     pub fn SSL_CTX_get_default_passwd_cb_userdata(
         ctx: *const SSL_CTX,
     ) -> *mut ::std::os::raw::c_void;
@@ -29444,18 +29444,18 @@ fn bindgen_test_layout_ssl_private_key_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_private_key_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_private_key_method"]
     pub fn SSL_set_private_key_method(ssl: *mut SSL, key_method: *const SSL_PRIVATE_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_private_key_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_private_key_method"]
     pub fn SSL_CTX_set_private_key_method(
         ctx: *mut SSL_CTX,
         key_method: *const SSL_PRIVATE_KEY_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_can_release_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_can_release_private_key"]
     pub fn SSL_can_release_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -29480,149 +29480,149 @@ pub type sk_SSL_CIPHER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_cipher_by_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_cipher_by_value"]
     pub fn SSL_get_cipher_by_value(value: u16) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_id"]
     pub fn SSL_CIPHER_get_id(cipher: *const SSL_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_protocol_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_protocol_id"]
     pub fn SSL_CIPHER_get_protocol_id(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_is_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_is_aead"]
     pub fn SSL_CIPHER_is_aead(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_is_block_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_is_block_cipher"]
     pub fn SSL_CIPHER_is_block_cipher(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_cipher_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_cipher_nid"]
     pub fn SSL_CIPHER_get_cipher_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_digest_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_digest_nid"]
     pub fn SSL_CIPHER_get_digest_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_kx_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_kx_nid"]
     pub fn SSL_CIPHER_get_kx_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_auth_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_auth_nid"]
     pub fn SSL_CIPHER_get_auth_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_prf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_prf_nid"]
     pub fn SSL_CIPHER_get_prf_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_min_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_min_version"]
     pub fn SSL_CIPHER_get_min_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_max_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_max_version"]
     pub fn SSL_CIPHER_get_max_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_standard_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_standard_name"]
     pub fn SSL_CIPHER_standard_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_name"]
     pub fn SSL_CIPHER_get_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_kx_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_kx_name"]
     pub fn SSL_CIPHER_get_kx_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_bits"]
     pub fn SSL_CIPHER_get_bits(
         cipher: *const SSL_CIPHER,
         out_alg_bits: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_strict_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_strict_cipher_list"]
     pub fn SSL_CTX_set_strict_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_cipher_list"]
     pub fn SSL_CTX_set_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_strict_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_strict_cipher_list"]
     pub fn SSL_set_strict_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_ciphersuites"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_ciphersuites"]
     pub fn SSL_CTX_set_ciphersuites(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_cipher_list"]
     pub fn SSL_set_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_ciphers"]
     pub fn SSL_CTX_get_ciphers(ctx: *const SSL_CTX) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_cipher_in_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_cipher_in_group"]
     pub fn SSL_CTX_cipher_in_group(ctx: *const SSL_CTX, i: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ciphers"]
     pub fn SSL_get_ciphers(ssl: *const SSL) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_is_init_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_is_init_finished"]
     pub fn SSL_is_init_finished(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_in_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_in_init"]
     pub fn SSL_in_init(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_in_false_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_in_false_start"]
     pub fn SSL_in_false_start(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_certificate"]
     pub fn SSL_get_peer_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_cert_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_cert_chain"]
     pub fn SSL_get_peer_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_full_cert_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_full_cert_chain"]
     pub fn SSL_get_peer_full_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_peer_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_peer_certificates"]
     pub fn SSL_get0_peer_certificates(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_signed_cert_timestamp_list"]
     pub fn SSL_get0_signed_cert_timestamp_list(
         ssl: *const SSL,
         out: *mut *const u8,
@@ -29630,11 +29630,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_ocsp_response"]
     pub fn SSL_get0_ocsp_response(ssl: *const SSL, out: *mut *const u8, out_len: *mut usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_tls_unique"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_tls_unique"]
     pub fn SSL_get_tls_unique(
         ssl: *const SSL,
         out: *mut u8,
@@ -29643,23 +29643,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_extms_support"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_extms_support"]
     pub fn SSL_get_extms_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_current_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_current_cipher"]
     pub fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_session_reused"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_session_reused"]
     pub fn SSL_session_reused(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_secure_renegotiation_support"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_secure_renegotiation_support"]
     pub fn SSL_get_secure_renegotiation_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_export_keying_material"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_export_keying_material"]
     pub fn SSL_export_keying_material(
         ssl: *mut SSL,
         out: *mut u8,
@@ -29672,7 +29672,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_SSL_SESSION"]
     pub fn PEM_read_bio_SSL_SESSION(
         bp: *mut BIO,
         x: *mut *mut SSL_SESSION,
@@ -29681,7 +29681,7 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_SSL_SESSION"]
     pub fn PEM_read_SSL_SESSION(
         fp: *mut FILE,
         x: *mut *mut SSL_SESSION,
@@ -29690,27 +29690,27 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_SSL_SESSION"]
     pub fn PEM_write_bio_SSL_SESSION(bp: *mut BIO, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_SSL_SESSION"]
     pub fn PEM_write_SSL_SESSION(fp: *mut FILE, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_new"]
     pub fn SSL_SESSION_new(ctx: *const SSL_CTX) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_up_ref"]
     pub fn SSL_SESSION_up_ref(session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_free"]
     pub fn SSL_SESSION_free(session: *mut SSL_SESSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_to_bytes"]
     pub fn SSL_SESSION_to_bytes(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -29718,7 +29718,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_to_bytes_for_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_to_bytes_for_ticket"]
     pub fn SSL_SESSION_to_bytes_for_ticket(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -29726,7 +29726,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_from_bytes"]
     pub fn SSL_SESSION_from_bytes(
         in_: *const u8,
         in_len: usize,
@@ -29734,29 +29734,29 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_version"]
     pub fn SSL_SESSION_get_version(session: *const SSL_SESSION) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_protocol_version"]
     pub fn SSL_SESSION_get_protocol_version(session: *const SSL_SESSION) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set_protocol_version"]
     pub fn SSL_SESSION_set_protocol_version(
         session: *mut SSL_SESSION,
         version: u16,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_id"]
     pub fn SSL_SESSION_get_id(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set1_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set1_id"]
     pub fn SSL_SESSION_set1_id(
         session: *mut SSL_SESSION,
         sid: *const u8,
@@ -29764,25 +29764,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_time"]
     pub fn SSL_SESSION_get_time(session: *const SSL_SESSION) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_timeout"]
     pub fn SSL_SESSION_get_timeout(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_peer"]
     pub fn SSL_SESSION_get0_peer(session: *const SSL_SESSION) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_peer_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_peer_certificates"]
     pub fn SSL_SESSION_get0_peer_certificates(
         session: *const SSL_SESSION,
     ) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_signed_cert_timestamp_list"]
     pub fn SSL_SESSION_get0_signed_cert_timestamp_list(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -29790,7 +29790,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_ocsp_response"]
     pub fn SSL_SESSION_get0_ocsp_response(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -29798,7 +29798,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_master_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_master_key"]
     pub fn SSL_SESSION_get_master_key(
         session: *const SSL_SESSION,
         out: *mut u8,
@@ -29806,22 +29806,22 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set_time"]
     pub fn SSL_SESSION_set_time(session: *mut SSL_SESSION, time: u64) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set_timeout"]
     pub fn SSL_SESSION_set_timeout(session: *mut SSL_SESSION, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_id_context"]
     pub fn SSL_SESSION_get0_id_context(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set1_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set1_id_context"]
     pub fn SSL_SESSION_set1_id_context(
         session: *mut SSL_SESSION,
         sid_ctx: *const u8,
@@ -29829,19 +29829,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_should_be_single_use"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_should_be_single_use"]
     pub fn SSL_SESSION_should_be_single_use(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_is_resumable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_is_resumable"]
     pub fn SSL_SESSION_is_resumable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_has_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_has_ticket"]
     pub fn SSL_SESSION_has_ticket(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_ticket"]
     pub fn SSL_SESSION_get0_ticket(
         session: *const SSL_SESSION,
         out_ticket: *mut *const u8,
@@ -29849,7 +29849,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set_ticket"]
     pub fn SSL_SESSION_set_ticket(
         session: *mut SSL_SESSION,
         ticket: *const u8,
@@ -29857,19 +29857,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_ticket_lifetime_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_ticket_lifetime_hint"]
     pub fn SSL_SESSION_get_ticket_lifetime_hint(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_cipher"]
     pub fn SSL_SESSION_get0_cipher(session: *const SSL_SESSION) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_has_peer_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_has_peer_sha256"]
     pub fn SSL_SESSION_has_peer_sha256(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_peer_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_peer_sha256"]
     pub fn SSL_SESSION_get0_peer_sha256(
         session: *const SSL_SESSION,
         out_ptr: *mut *const u8,
@@ -29877,34 +29877,34 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_session_cache_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_session_cache_mode"]
     pub fn SSL_CTX_set_session_cache_mode(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_session_cache_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_session_cache_mode"]
     pub fn SSL_CTX_get_session_cache_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_session"]
     pub fn SSL_set_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_timeout"]
     pub fn SSL_CTX_set_timeout(ctx: *mut SSL_CTX, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_session_psk_dhe_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_session_psk_dhe_timeout"]
     pub fn SSL_CTX_set_session_psk_dhe_timeout(ctx: *mut SSL_CTX, timeout: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_timeout"]
     pub fn SSL_CTX_get_timeout(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_session_id_context"]
     pub fn SSL_CTX_set_session_id_context(
         ctx: *mut SSL_CTX,
         sid_ctx: *const u8,
@@ -29912,7 +29912,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_session_id_context"]
     pub fn SSL_set_session_id_context(
         ssl: *mut SSL,
         sid_ctx: *const u8,
@@ -29920,44 +29920,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_session_id_context"]
     pub fn SSL_get0_session_id_context(ssl: *const SSL, out_len: *mut usize) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_set_cache_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_set_cache_size"]
     pub fn SSL_CTX_sess_set_cache_size(
         ctx: *mut SSL_CTX,
         size: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_get_cache_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_get_cache_size"]
     pub fn SSL_CTX_sess_get_cache_size(ctx: *const SSL_CTX) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_number"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_number"]
     pub fn SSL_CTX_sess_number(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add_session"]
     pub fn SSL_CTX_add_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_remove_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_remove_session"]
     pub fn SSL_CTX_remove_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_flush_sessions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_flush_sessions"]
     pub fn SSL_CTX_flush_sessions(ctx: *mut SSL_CTX, time: u64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_set_new_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_set_new_cb"]
     pub fn SSL_CTX_sess_set_new_cb(
         ctx: *mut SSL_CTX,
         new_session_cb: ::std::option::Option<
@@ -29966,7 +29966,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_get_new_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_get_new_cb"]
     pub fn SSL_CTX_sess_get_new_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -29974,7 +29974,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_set_remove_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_set_remove_cb"]
     pub fn SSL_CTX_sess_set_remove_cb(
         ctx: *mut SSL_CTX,
         remove_session_cb: ::std::option::Option<
@@ -29983,13 +29983,13 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_get_remove_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_get_remove_cb"]
     pub fn SSL_CTX_sess_get_remove_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<unsafe extern "C" fn(ctx: *mut SSL_CTX, arg1: *mut SSL_SESSION)>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_set_get_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_set_get_cb"]
     pub fn SSL_CTX_sess_set_get_cb(
         ctx: *mut SSL_CTX,
         get_session_cb: ::std::option::Option<
@@ -30003,7 +30003,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_get_get_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_get_get_cb"]
     pub fn SSL_CTX_sess_get_get_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30016,11 +30016,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_magic_pending_session_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_magic_pending_session_ptr"]
     pub fn SSL_magic_pending_session_ptr() -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_tlsext_ticket_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_tlsext_ticket_keys"]
     pub fn SSL_CTX_get_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         out: *mut ::std::os::raw::c_void,
@@ -30028,7 +30028,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_ticket_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_ticket_keys"]
     pub fn SSL_CTX_set_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         in_: *const ::std::os::raw::c_void,
@@ -30036,7 +30036,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_ticket_key_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_ticket_key_cb"]
     pub fn SSL_CTX_set_tlsext_ticket_key_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30128,14 +30128,14 @@ fn bindgen_test_layout_ssl_ticket_aead_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_ticket_aead_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_ticket_aead_method"]
     pub fn SSL_CTX_set_ticket_aead_method(
         ctx: *mut SSL_CTX,
         aead_method: *const SSL_TICKET_AEAD_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_process_tls13_new_session_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_process_tls13_new_session_ticket"]
     pub fn SSL_process_tls13_new_session_ticket(
         ssl: *mut SSL,
         buf: *const u8,
@@ -30143,15 +30143,15 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_num_tickets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_num_tickets"]
     pub fn SSL_CTX_set_num_tickets(ctx: *mut SSL_CTX, num_tickets: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_num_tickets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_num_tickets"]
     pub fn SSL_CTX_get_num_tickets(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_curves"]
     pub fn SSL_CTX_set1_curves(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_int,
@@ -30159,7 +30159,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_curves"]
     pub fn SSL_set1_curves(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_int,
@@ -30167,29 +30167,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_curves_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_curves_list"]
     pub fn SSL_CTX_set1_curves_list(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_curves_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_curves_list"]
     pub fn SSL_set1_curves_list(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_curve_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_curve_id"]
     pub fn SSL_get_curve_id(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_curve_name"]
     pub fn SSL_get_curve_name(curve_id: u16) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_to_bytes"]
     pub fn SSL_to_bytes(
         in_: *const SSL,
         out_data: *mut *mut u8,
@@ -30197,11 +30197,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_from_bytes"]
     pub fn SSL_from_bytes(in_: *const u8, in_len: usize, ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_groups"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_groups"]
     pub fn SSL_CTX_set1_groups(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_int,
@@ -30209,7 +30209,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_groups"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_groups"]
     pub fn SSL_set1_groups(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_int,
@@ -30217,21 +30217,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_groups_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_groups_list"]
     pub fn SSL_CTX_set1_groups_list(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_groups_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_groups_list"]
     pub fn SSL_set1_groups_list(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_verify"]
     pub fn SSL_CTX_set_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30244,7 +30244,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_verify"]
     pub fn SSL_set_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30261,7 +30261,7 @@ pub const ssl_verify_result_t_ssl_verify_invalid: ssl_verify_result_t = 1;
 pub const ssl_verify_result_t_ssl_verify_retry: ssl_verify_result_t = 2;
 pub type ssl_verify_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_custom_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_custom_verify"]
     pub fn SSL_CTX_set_custom_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30271,7 +30271,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_custom_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_custom_verify"]
     pub fn SSL_set_custom_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30281,15 +30281,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_verify_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_verify_mode"]
     pub fn SSL_CTX_get_verify_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_verify_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_verify_mode"]
     pub fn SSL_get_verify_mode(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_verify_callback"]
     pub fn SSL_CTX_get_verify_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -30300,7 +30300,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_verify_callback"]
     pub fn SSL_get_verify_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -30311,83 +30311,83 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_host"]
     pub fn SSL_set1_host(
         ssl: *mut SSL,
         hostname: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_verify_depth"]
     pub fn SSL_CTX_set_verify_depth(ctx: *mut SSL_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_verify_depth"]
     pub fn SSL_set_verify_depth(ssl: *mut SSL, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_verify_depth"]
     pub fn SSL_CTX_get_verify_depth(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_verify_depth"]
     pub fn SSL_get_verify_depth(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_param"]
     pub fn SSL_CTX_set1_param(
         ctx: *mut SSL_CTX,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_param"]
     pub fn SSL_set1_param(ssl: *mut SSL, param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get0_param"]
     pub fn SSL_CTX_get0_param(ctx: *mut SSL_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_param"]
     pub fn SSL_get0_param(ssl: *mut SSL) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_purpose"]
     pub fn SSL_CTX_set_purpose(
         ctx: *mut SSL_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_purpose"]
     pub fn SSL_set_purpose(ssl: *mut SSL, purpose: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_trust"]
     pub fn SSL_CTX_set_trust(
         ctx: *mut SSL_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_trust"]
     pub fn SSL_set_trust(ssl: *mut SSL, trust: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_cert_store"]
     pub fn SSL_CTX_set_cert_store(ctx: *mut SSL_CTX, store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_cert_store"]
     pub fn SSL_CTX_get_cert_store(ctx: *const SSL_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_default_verify_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_default_verify_paths"]
     pub fn SSL_CTX_set_default_verify_paths(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_load_verify_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_load_verify_locations"]
     pub fn SSL_CTX_load_verify_locations(
         ctx: *mut SSL_CTX,
         ca_file: *const ::std::os::raw::c_char,
@@ -30395,19 +30395,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_verify_result"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_verify_result"]
     pub fn SSL_get_verify_result(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_alert_from_verify_result"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_alert_from_verify_result"]
     pub fn SSL_alert_from_verify_result(result: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ex_data_X509_STORE_CTX_idx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ex_data_X509_STORE_CTX_idx"]
     pub fn SSL_get_ex_data_X509_STORE_CTX_idx() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_cert_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_cert_verify_callback"]
     pub fn SSL_CTX_set_cert_verify_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30420,51 +30420,51 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_enable_signed_cert_timestamps"]
     pub fn SSL_enable_signed_cert_timestamps(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_enable_signed_cert_timestamps"]
     pub fn SSL_CTX_enable_signed_cert_timestamps(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_enable_ocsp_stapling"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_enable_ocsp_stapling"]
     pub fn SSL_enable_ocsp_stapling(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_enable_ocsp_stapling"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_enable_ocsp_stapling"]
     pub fn SSL_CTX_enable_ocsp_stapling(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set0_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set0_verify_cert_store"]
     pub fn SSL_CTX_set0_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_verify_cert_store"]
     pub fn SSL_CTX_set1_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set0_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set0_verify_cert_store"]
     pub fn SSL_set0_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_verify_cert_store"]
     pub fn SSL_set1_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_verify_algorithm_prefs"]
     pub fn SSL_CTX_set_verify_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -30472,7 +30472,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_verify_algorithm_prefs"]
     pub fn SSL_set_verify_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -30480,87 +30480,87 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_hostflags"]
     pub fn SSL_set_hostflags(ssl: *mut SSL, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_client_CA_list"]
     pub fn SSL_set_client_CA_list(ssl: *mut SSL, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_client_CA_list"]
     pub fn SSL_CTX_set_client_CA_list(ctx: *mut SSL_CTX, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set0_client_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set0_client_CAs"]
     pub fn SSL_set0_client_CAs(ssl: *mut SSL, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set0_client_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set0_client_CAs"]
     pub fn SSL_CTX_set0_client_CAs(ctx: *mut SSL_CTX, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_client_CA_list"]
     pub fn SSL_get_client_CA_list(ssl: *const SSL) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_server_requested_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_server_requested_CAs"]
     pub fn SSL_get0_server_requested_CAs(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_client_CA_list"]
     pub fn SSL_CTX_get_client_CA_list(ctx: *const SSL_CTX) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add_client_CA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add_client_CA"]
     pub fn SSL_add_client_CA(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add_client_CA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add_client_CA"]
     pub fn SSL_CTX_add_client_CA(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_load_client_CA_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_load_client_CA_file"]
     pub fn SSL_load_client_CA_file(file: *const ::std::os::raw::c_char) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_dup_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_dup_CA_list"]
     pub fn SSL_dup_CA_list(list: *mut stack_st_X509_NAME) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add_file_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add_file_cert_subjects_to_stack"]
     pub fn SSL_add_file_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add_bio_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add_bio_cert_subjects_to_stack"]
     pub fn SSL_add_bio_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tlsext_host_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tlsext_host_name"]
     pub fn SSL_set_tlsext_host_name(
         ssl: *mut SSL,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_servername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_servername"]
     pub fn SSL_get_servername(
         ssl: *const SSL,
         type_: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_servername_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_servername_type"]
     pub fn SSL_get_servername_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_servername_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_servername_callback"]
     pub fn SSL_CTX_set_tlsext_servername_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30573,18 +30573,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_servername_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_servername_arg"]
     pub fn SSL_CTX_set_tlsext_servername_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_SSL_CTX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_SSL_CTX"]
     pub fn SSL_set_SSL_CTX(ssl: *mut SSL, ctx: *mut SSL_CTX) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_alpn_protos"]
     pub fn SSL_CTX_set_alpn_protos(
         ctx: *mut SSL_CTX,
         protos: *const u8,
@@ -30592,7 +30592,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_alpn_protos"]
     pub fn SSL_set_alpn_protos(
         ssl: *mut SSL,
         protos: *const u8,
@@ -30600,7 +30600,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_alpn_select_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_alpn_select_cb"]
     pub fn SSL_CTX_set_alpn_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30617,7 +30617,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_alpn_selected"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_alpn_selected"]
     pub fn SSL_get0_alpn_selected(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30625,11 +30625,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_allow_unknown_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_allow_unknown_alpn_protos"]
     pub fn SSL_CTX_set_allow_unknown_alpn_protos(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add_application_settings"]
     pub fn SSL_add_application_settings(
         ssl: *mut SSL,
         proto: *const u8,
@@ -30639,7 +30639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_peer_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_peer_application_settings"]
     pub fn SSL_get0_peer_application_settings(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30647,7 +30647,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_has_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_has_application_settings"]
     pub fn SSL_has_application_settings(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub type ssl_cert_compression_func_t = ::std::option::Option<
@@ -30668,7 +30668,7 @@ pub type ssl_cert_decompression_func_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add_cert_compression_alg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add_cert_compression_alg"]
     pub fn SSL_CTX_add_cert_compression_alg(
         ctx: *mut SSL_CTX,
         alg_id: u16,
@@ -30677,7 +30677,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_next_protos_advertised_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_next_protos_advertised_cb"]
     pub fn SSL_CTX_set_next_protos_advertised_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30692,7 +30692,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_next_proto_select_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_next_proto_select_cb"]
     pub fn SSL_CTX_set_next_proto_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30709,7 +30709,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_next_proto_negotiated"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_next_proto_negotiated"]
     pub fn SSL_get0_next_proto_negotiated(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30717,7 +30717,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_select_next_proto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_select_next_proto"]
     pub fn SSL_select_next_proto(
         out: *mut *mut u8,
         out_len: *mut u8,
@@ -30728,29 +30728,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tls_channel_id_enabled"]
     pub fn SSL_CTX_set_tls_channel_id_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tls_channel_id_enabled"]
     pub fn SSL_set_tls_channel_id_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_tls_channel_id"]
     pub fn SSL_CTX_set1_tls_channel_id(
         ctx: *mut SSL_CTX,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_tls_channel_id"]
     pub fn SSL_set1_tls_channel_id(
         ssl: *mut SSL,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_tls_channel_id"]
     pub fn SSL_get_tls_channel_id(ssl: *mut SSL, out: *mut u8, max_out: usize) -> usize;
 }
 #[repr(C)]
@@ -30827,29 +30827,29 @@ pub type sk_SRTP_PROTECTION_PROFILE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_srtp_profiles"]
     pub fn SSL_CTX_set_srtp_profiles(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_srtp_profiles"]
     pub fn SSL_set_srtp_profiles(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_srtp_profiles"]
     pub fn SSL_get_srtp_profiles(ssl: *const SSL) -> *const stack_st_SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_selected_srtp_profile"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_selected_srtp_profile"]
     pub fn SSL_get_selected_srtp_profile(ssl: *mut SSL) -> *const SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_psk_client_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_psk_client_callback"]
     pub fn SSL_CTX_set_psk_client_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30865,7 +30865,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_psk_client_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_psk_client_callback"]
     pub fn SSL_set_psk_client_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -30881,7 +30881,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_psk_server_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_psk_server_callback"]
     pub fn SSL_CTX_set_psk_server_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30895,7 +30895,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_psk_server_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_psk_server_callback"]
     pub fn SSL_set_psk_server_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -30909,29 +30909,29 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_psk_identity_hint"]
     pub fn SSL_CTX_use_psk_identity_hint(
         ctx: *mut SSL_CTX,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_psk_identity_hint"]
     pub fn SSL_use_psk_identity_hint(
         ssl: *mut SSL,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_psk_identity_hint"]
     pub fn SSL_get_psk_identity_hint(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_psk_identity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_psk_identity"]
     pub fn SSL_get_psk_identity(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_delegated_credential"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_delegated_credential"]
     pub fn SSL_set1_delegated_credential(
         ssl: *mut SSL,
         dc: *mut CRYPTO_BUFFER,
@@ -30940,7 +30940,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_delegated_credential_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_delegated_credential_used"]
     pub fn SSL_delegated_credential_used(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub const ssl_encryption_level_t_ssl_encryption_initial: ssl_encryption_level_t = 0;
@@ -31053,22 +31053,22 @@ fn bindgen_test_layout_ssl_quic_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_quic_max_handshake_flight_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_quic_max_handshake_flight_len"]
     pub fn SSL_quic_max_handshake_flight_len(
         ssl: *const SSL,
         level: ssl_encryption_level_t,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_quic_read_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_quic_read_level"]
     pub fn SSL_quic_read_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_quic_write_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_quic_write_level"]
     pub fn SSL_quic_write_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_provide_quic_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_provide_quic_data"]
     pub fn SSL_provide_quic_data(
         ssl: *mut SSL,
         level: ssl_encryption_level_t,
@@ -31077,25 +31077,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_process_quic_post_handshake"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_process_quic_post_handshake"]
     pub fn SSL_process_quic_post_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_quic_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_quic_method"]
     pub fn SSL_CTX_set_quic_method(
         ctx: *mut SSL_CTX,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_quic_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_quic_method"]
     pub fn SSL_set_quic_method(
         ssl: *mut SSL,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_quic_transport_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_quic_transport_params"]
     pub fn SSL_set_quic_transport_params(
         ssl: *mut SSL,
         params: *const u8,
@@ -31103,7 +31103,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_quic_transport_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_quic_transport_params"]
     pub fn SSL_get_peer_quic_transport_params(
         ssl: *const SSL,
         out_params: *mut *const u8,
@@ -31111,11 +31111,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_quic_use_legacy_codepoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_quic_use_legacy_codepoint"]
     pub fn SSL_set_quic_use_legacy_codepoint(ssl: *mut SSL, use_legacy: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_quic_early_data_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_quic_early_data_context"]
     pub fn SSL_set_quic_early_data_context(
         ssl: *mut SSL,
         context: *const u8,
@@ -31123,35 +31123,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_early_data_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_early_data_enabled"]
     pub fn SSL_CTX_set_early_data_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_early_data_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_early_data_enabled"]
     pub fn SSL_set_early_data_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_in_early_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_in_early_data"]
     pub fn SSL_in_early_data(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_early_data_capable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_early_data_capable"]
     pub fn SSL_SESSION_early_data_capable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_copy_without_early_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_copy_without_early_data"]
     pub fn SSL_SESSION_copy_without_early_data(session: *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_early_data_accepted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_early_data_accepted"]
     pub fn SSL_early_data_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_reset_early_data_reject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_reset_early_data_reject"]
     pub fn SSL_reset_early_data_reject(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ticket_age_skew"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ticket_age_skew"]
     pub fn SSL_get_ticket_age_skew(ssl: *const SSL) -> i32;
 }
 pub const ssl_early_data_reason_t_ssl_early_data_unknown: ssl_early_data_reason_t = 0;
@@ -31173,21 +31173,21 @@ pub const ssl_early_data_reason_t_ssl_early_data_alps_mismatch: ssl_early_data_r
 pub const ssl_early_data_reason_t_ssl_early_data_reason_max_value: ssl_early_data_reason_t = 14;
 pub type ssl_early_data_reason_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_early_data_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_early_data_reason"]
     pub fn SSL_get_early_data_reason(ssl: *const SSL) -> ssl_early_data_reason_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_early_data_reason_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_early_data_reason_string"]
     pub fn SSL_early_data_reason_string(
         reason: ssl_early_data_reason_t,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_enable_ech_grease"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_enable_ech_grease"]
     pub fn SSL_set_enable_ech_grease(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_ech_config_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_ech_config_list"]
     pub fn SSL_set1_ech_config_list(
         ssl: *mut SSL,
         ech_config_list: *const u8,
@@ -31195,7 +31195,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_ech_name_override"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_ech_name_override"]
     pub fn SSL_get0_ech_name_override(
         ssl: *const SSL,
         out_name: *mut *const ::std::os::raw::c_char,
@@ -31203,7 +31203,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_ech_retry_configs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_ech_retry_configs"]
     pub fn SSL_get0_ech_retry_configs(
         ssl: *const SSL,
         out_retry_configs: *mut *const u8,
@@ -31211,7 +31211,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_marshal_ech_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_marshal_ech_config"]
     pub fn SSL_marshal_ech_config(
         out: *mut *mut u8,
         out_len: *mut usize,
@@ -31222,19 +31222,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_new"]
     pub fn SSL_ECH_KEYS_new() -> *mut SSL_ECH_KEYS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_up_ref"]
     pub fn SSL_ECH_KEYS_up_ref(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_free"]
     pub fn SSL_ECH_KEYS_free(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_add"]
     pub fn SSL_ECH_KEYS_add(
         keys: *mut SSL_ECH_KEYS,
         is_retry_config: ::std::os::raw::c_int,
@@ -31244,12 +31244,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_has_duplicate_config_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_has_duplicate_config_id"]
     pub fn SSL_ECH_KEYS_has_duplicate_config_id(keys: *const SSL_ECH_KEYS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_marshal_retry_configs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_marshal_retry_configs"]
     pub fn SSL_ECH_KEYS_marshal_retry_configs(
         keys: *const SSL_ECH_KEYS,
         out: *mut *mut u8,
@@ -31257,34 +31257,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_ech_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_ech_keys"]
     pub fn SSL_CTX_set1_ech_keys(
         ctx: *mut SSL_CTX,
         keys: *mut SSL_ECH_KEYS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ech_accepted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ech_accepted"]
     pub fn SSL_ech_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_alert_type_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_alert_type_string_long"]
     pub fn SSL_alert_type_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_alert_desc_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_alert_desc_string_long"]
     pub fn SSL_alert_desc_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_send_fatal_alert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_send_fatal_alert"]
     pub fn SSL_send_fatal_alert(ssl: *mut SSL, alert: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_ex_data"]
     pub fn SSL_set_ex_data(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -31292,14 +31292,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ex_data"]
     pub fn SSL_get_ex_data(
         ssl: *const SSL,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ex_new_index"]
     pub fn SSL_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31309,7 +31309,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set_ex_data"]
     pub fn SSL_SESSION_set_ex_data(
         session: *mut SSL_SESSION,
         idx: ::std::os::raw::c_int,
@@ -31317,14 +31317,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_ex_data"]
     pub fn SSL_SESSION_get_ex_data(
         session: *const SSL_SESSION,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_ex_new_index"]
     pub fn SSL_SESSION_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31334,7 +31334,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_ex_data"]
     pub fn SSL_CTX_set_ex_data(
         ctx: *mut SSL_CTX,
         idx: ::std::os::raw::c_int,
@@ -31342,14 +31342,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_ex_data"]
     pub fn SSL_CTX_get_ex_data(
         ctx: *const SSL_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_ex_new_index"]
     pub fn SSL_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31359,7 +31359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ivs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ivs"]
     pub fn SSL_get_ivs(
         ssl: *const SSL,
         out_read_iv: *mut *const u8,
@@ -31368,11 +31368,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_key_block_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_key_block_len"]
     pub fn SSL_get_key_block_len(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_generate_key_block"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_generate_key_block"]
     pub fn SSL_generate_key_block(
         ssl: *const SSL,
         out: *mut u8,
@@ -31380,26 +31380,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_read_sequence"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_read_sequence"]
     pub fn SSL_get_read_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_write_sequence"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_write_sequence"]
     pub fn SSL_get_write_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_record_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_record_protocol_version"]
     pub fn SSL_CTX_set_record_protocol_version(
         ctx: *mut SSL_CTX,
         version: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_serialize_capabilities"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_serialize_capabilities"]
     pub fn SSL_serialize_capabilities(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_request_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_request_handshake_hints"]
     pub fn SSL_request_handshake_hints(
         ssl: *mut SSL,
         client_hello: *const u8,
@@ -31409,11 +31409,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_serialize_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_serialize_handshake_hints"]
     pub fn SSL_serialize_handshake_hints(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_handshake_hints"]
     pub fn SSL_set_handshake_hints(
         ssl: *mut SSL,
         hints: *const u8,
@@ -31421,7 +31421,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_msg_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_msg_callback"]
     pub fn SSL_CTX_set_msg_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31438,11 +31438,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_msg_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_msg_callback_arg"]
     pub fn SSL_CTX_set_msg_callback_arg(ctx: *mut SSL_CTX, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_msg_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_msg_callback"]
     pub fn SSL_set_msg_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31459,11 +31459,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_msg_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_msg_callback_arg"]
     pub fn SSL_set_msg_callback_arg(ssl: *mut SSL, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_keylog_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_keylog_callback"]
     pub fn SSL_CTX_set_keylog_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31472,7 +31472,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_keylog_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_keylog_callback"]
     pub fn SSL_CTX_get_keylog_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -31480,14 +31480,14 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_current_time_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_current_time_cb"]
     pub fn SSL_CTX_set_current_time_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<unsafe extern "C" fn(ssl: *const SSL, out_clock: *mut timeval)>,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_shed_handshake_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_shed_handshake_config"]
     pub fn SSL_set_shed_handshake_config(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_never: ssl_renegotiate_mode_t = 0;
@@ -31497,46 +31497,46 @@ pub const ssl_renegotiate_mode_t_ssl_renegotiate_ignore: ssl_renegotiate_mode_t 
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_explicit: ssl_renegotiate_mode_t = 4;
 pub type ssl_renegotiate_mode_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_renegotiate_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_renegotiate_mode"]
     pub fn SSL_set_renegotiate_mode(ssl: *mut SSL, mode: ssl_renegotiate_mode_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_renegotiate"]
     pub fn SSL_renegotiate(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_renegotiate_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_renegotiate_pending"]
     pub fn SSL_renegotiate_pending(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_total_renegotiations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_total_renegotiations"]
     pub fn SSL_total_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_max_cert_list"]
     pub fn SSL_CTX_get_max_cert_list(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_max_cert_list"]
     pub fn SSL_CTX_set_max_cert_list(ctx: *mut SSL_CTX, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_max_cert_list"]
     pub fn SSL_get_max_cert_list(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_max_cert_list"]
     pub fn SSL_set_max_cert_list(ssl: *mut SSL, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_max_send_fragment"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_max_send_fragment"]
     pub fn SSL_CTX_set_max_send_fragment(
         ctx: *mut SSL_CTX,
         max_send_fragment: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_max_send_fragment"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_max_send_fragment"]
     pub fn SSL_set_max_send_fragment(
         ssl: *mut SSL,
         max_send_fragment: usize,
@@ -31730,7 +31730,7 @@ pub const ssl_select_cert_result_t_ssl_select_cert_retry: ssl_select_cert_result
 pub const ssl_select_cert_result_t_ssl_select_cert_error: ssl_select_cert_result_t = -1;
 pub type ssl_select_cert_result_t = ::std::os::raw::c_int;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_early_callback_ctx_extension_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_early_callback_ctx_extension_get"]
     pub fn SSL_early_callback_ctx_extension_get(
         client_hello: *const SSL_CLIENT_HELLO,
         extension_type: u16,
@@ -31739,7 +31739,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_select_certificate_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_select_certificate_cb"]
     pub fn SSL_CTX_set_select_certificate_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31748,7 +31748,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_dos_protection_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_dos_protection_cb"]
     pub fn SSL_CTX_set_dos_protection_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31757,19 +31757,19 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_reverify_on_resume"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_reverify_on_resume"]
     pub fn SSL_CTX_set_reverify_on_resume(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_enforce_rsa_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_enforce_rsa_key_usage"]
     pub fn SSL_set_enforce_rsa_key_usage(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_was_key_usage_invalid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_was_key_usage_invalid"]
     pub fn SSL_was_key_usage_invalid(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_info_callback"]
     pub fn SSL_CTX_set_info_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31782,7 +31782,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_info_callback"]
     pub fn SSL_CTX_get_info_callback(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -31794,7 +31794,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_info_callback"]
     pub fn SSL_set_info_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31807,7 +31807,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_info_callback"]
     pub fn SSL_get_info_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -31819,77 +31819,77 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_state_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_state_string_long"]
     pub fn SSL_state_string_long(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_shutdown"]
     pub fn SSL_get_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_signature_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_signature_algorithm"]
     pub fn SSL_get_peer_signature_algorithm(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_client_random"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_client_random"]
     pub fn SSL_get_client_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_server_random"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_server_random"]
     pub fn SSL_get_server_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_pending_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_pending_cipher"]
     pub fn SSL_get_pending_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_set_retain_only_sha256_of_client_certs(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_CTX_set_retain_only_sha256_of_client_certs(
         ctx: *mut SSL_CTX,
         enable: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_grease_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_grease_enabled"]
     pub fn SSL_CTX_set_grease_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_permute_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_permute_extensions"]
     pub fn SSL_CTX_set_permute_extensions(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_permute_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_permute_extensions"]
     pub fn SSL_set_permute_extensions(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_max_seal_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_max_seal_overhead"]
     pub fn SSL_max_seal_overhead(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_false_start_allowed_without_alpn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_false_start_allowed_without_alpn"]
     pub fn SSL_CTX_set_false_start_allowed_without_alpn(
         ctx: *mut SSL_CTX,
         allowed: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_used_hello_retry_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_used_hello_retry_request"]
     pub fn SSL_used_hello_retry_request(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_jdk11_workaround"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_jdk11_workaround"]
     pub fn SSL_set_jdk11_workaround(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_library_init"]
     pub fn SSL_library_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_description"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_description"]
     pub fn SSL_CIPHER_description(
         cipher: *const SSL_CIPHER,
         buf: *mut ::std::os::raw::c_char,
@@ -31897,11 +31897,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_version"]
     pub fn SSL_CIPHER_get_version(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_rfc_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_rfc_name"]
     pub fn SSL_CIPHER_get_rfc_name(cipher: *const SSL_CIPHER) -> *mut ::std::os::raw::c_char;
 }
 pub type COMP_METHOD = ::std::os::raw::c_void;
@@ -31912,126 +31912,126 @@ pub struct stack_st_SSL_COMP {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_get_compression_methods"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_get_compression_methods"]
     pub fn SSL_COMP_get_compression_methods() -> *mut stack_st_SSL_COMP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_add_compression_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_add_compression_method"]
     pub fn SSL_COMP_add_compression_method(
         id: ::std::os::raw::c_int,
         cm: *mut COMP_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_get_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_get_name"]
     pub fn SSL_COMP_get_name(comp: *const COMP_METHOD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_get0_name"]
     pub fn SSL_COMP_get0_name(comp: *const SSL_COMP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_get_id"]
     pub fn SSL_COMP_get_id(comp: *const SSL_COMP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_free_compression_methods"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_free_compression_methods"]
     pub fn SSL_COMP_free_compression_methods();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLv23_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLv23_method"]
     pub fn SSLv23_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_method"]
     pub fn TLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_1_method"]
     pub fn TLSv1_1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_2_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_2_method"]
     pub fn TLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_method"]
     pub fn DTLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_2_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_2_method"]
     pub fn DTLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLS_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLS_server_method"]
     pub fn TLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLS_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLS_client_method"]
     pub fn TLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLv23_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLv23_server_method"]
     pub fn SSLv23_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLv23_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLv23_client_method"]
     pub fn SSLv23_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_server_method"]
     pub fn TLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_client_method"]
     pub fn TLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_1_server_method"]
     pub fn TLSv1_1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_1_client_method"]
     pub fn TLSv1_1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_2_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_2_server_method"]
     pub fn TLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_2_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_2_client_method"]
     pub fn TLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLS_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLS_server_method"]
     pub fn DTLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLS_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLS_client_method"]
     pub fn DTLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_server_method"]
     pub fn DTLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_client_method"]
     pub fn DTLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_2_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_2_server_method"]
     pub fn DTLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_2_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_2_client_method"]
     pub fn DTLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_clear"]
     pub fn SSL_clear(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tmp_rsa_callback"]
     pub fn SSL_CTX_set_tmp_rsa_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32044,7 +32044,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tmp_rsa_callback"]
     pub fn SSL_set_tmp_rsa_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32057,98 +32057,98 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_connect"]
     pub fn SSL_CTX_sess_connect(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_connect_good"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_connect_good"]
     pub fn SSL_CTX_sess_connect_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_connect_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_connect_renegotiate"]
     pub fn SSL_CTX_sess_connect_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_accept"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_accept"]
     pub fn SSL_CTX_sess_accept(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_accept_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_accept_renegotiate"]
     pub fn SSL_CTX_sess_accept_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_accept_good"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_accept_good"]
     pub fn SSL_CTX_sess_accept_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_hits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_hits"]
     pub fn SSL_CTX_sess_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_cb_hits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_cb_hits"]
     pub fn SSL_CTX_sess_cb_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_misses"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_misses"]
     pub fn SSL_CTX_sess_misses(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_timeouts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_timeouts"]
     pub fn SSL_CTX_sess_timeouts(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_cache_full"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_cache_full"]
     pub fn SSL_CTX_sess_cache_full(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_cutthrough_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_cutthrough_complete"]
     pub fn SSL_cutthrough_complete(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_num_renegotiations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_num_renegotiations"]
     pub fn SSL_num_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_need_tmp_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_need_tmp_RSA"]
     pub fn SSL_CTX_need_tmp_RSA(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_need_tmp_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_need_tmp_RSA"]
     pub fn SSL_need_tmp_RSA(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tmp_rsa"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tmp_rsa"]
     pub fn SSL_CTX_set_tmp_rsa(ctx: *mut SSL_CTX, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tmp_rsa"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tmp_rsa"]
     pub fn SSL_set_tmp_rsa(ssl: *mut SSL, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_read_ahead"]
     pub fn SSL_CTX_get_read_ahead(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_read_ahead"]
     pub fn SSL_CTX_set_read_ahead(
         ctx: *mut SSL_CTX,
         yes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_read_ahead"]
     pub fn SSL_get_read_ahead(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_read_ahead"]
     pub fn SSL_set_read_ahead(ssl: *mut SSL, yes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_state"]
     pub fn SSL_set_state(ssl: *mut SSL, state: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_shared_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_shared_ciphers"]
     pub fn SSL_get_shared_ciphers(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_char,
@@ -32156,7 +32156,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_shared_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_shared_sigalgs"]
     pub fn SSL_get_shared_sigalgs(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -32168,11 +32168,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_SSL_SESSION"]
     pub fn i2d_SSL_SESSION(in_: *mut SSL_SESSION, pp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_SSL_SESSION"]
     pub fn d2i_SSL_SESSION(
         a: *mut *mut SSL_SESSION,
         pp: *mut *const u8,
@@ -32180,61 +32180,61 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_SSL_SESSION_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_SSL_SESSION_bio"]
     pub fn i2d_SSL_SESSION_bio(bio: *mut BIO, session: *const SSL_SESSION)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_SSL_SESSION_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_SSL_SESSION_bio"]
     pub fn d2i_SSL_SESSION_bio(bio: *mut BIO, out: *mut *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_SSL_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_SSL_strings"]
     pub fn ERR_load_SSL_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_load_error_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_load_error_strings"]
     pub fn SSL_load_error_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_use_srtp"]
     pub fn SSL_CTX_set_tlsext_use_srtp(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tlsext_use_srtp"]
     pub fn SSL_set_tlsext_use_srtp(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_current_compression"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_current_compression"]
     pub fn SSL_get_current_compression(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_current_expansion"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_current_expansion"]
     pub fn SSL_get_current_expansion(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_server_tmp_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_server_tmp_key"]
     pub fn SSL_get_server_tmp_key(
         ssl: *mut SSL,
         out_key: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tmp_dh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tmp_dh"]
     pub fn SSL_CTX_set_tmp_dh(ctx: *mut SSL_CTX, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tmp_dh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tmp_dh"]
     pub fn SSL_set_tmp_dh(ssl: *mut SSL, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tmp_dh_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tmp_dh_callback"]
     pub fn SSL_CTX_set_tmp_dh_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32247,7 +32247,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tmp_dh_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tmp_dh_callback"]
     pub fn SSL_set_tmp_dh_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32260,7 +32260,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_sigalgs"]
     pub fn SSL_CTX_set1_sigalgs(
         ctx: *mut SSL_CTX,
         values: *const ::std::os::raw::c_int,
@@ -32268,7 +32268,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_sigalgs"]
     pub fn SSL_set1_sigalgs(
         ssl: *mut SSL,
         values: *const ::std::os::raw::c_int,
@@ -32276,25 +32276,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_sigalgs_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_sigalgs_list"]
     pub fn SSL_CTX_set1_sigalgs_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_sigalgs_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_sigalgs_list"]
     pub fn SSL_set1_sigalgs_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_security_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_security_level"]
     pub fn SSL_CTX_get_security_level(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_security_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_security_level"]
     pub fn SSL_CTX_set_security_level(ctx: *const SSL_CTX, level: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -32374,26 +32374,26 @@ pub type sk_SSL_COMP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_cache_hit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_cache_hit"]
     pub fn SSL_cache_hit(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_default_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_default_timeout"]
     pub fn SSL_get_default_timeout(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_version"]
     pub fn SSL_get_version(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_cipher_list"]
     pub fn SSL_get_cipher_list(
         ssl: *const SSL,
         n: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_client_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_client_cert_cb"]
     pub fn SSL_CTX_set_client_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32406,11 +32406,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_want"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_want"]
     pub fn SSL_want(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_finished"]
     pub fn SSL_get_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32418,7 +32418,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_finished"]
     pub fn SSL_get_peer_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32426,15 +32426,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_alert_type_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_alert_type_string"]
     pub fn SSL_alert_type_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_alert_desc_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_alert_desc_string"]
     pub fn SSL_alert_desc_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_state_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_state_string"]
     pub fn SSL_state_string(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 #[repr(C)]
@@ -32444,42 +32444,42 @@ pub struct ssl_conf_ctx_st {
 }
 pub type SSL_CONF_CTX = ssl_conf_ctx_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_state"]
     pub fn SSL_state(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_shutdown"]
     pub fn SSL_set_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tmp_ecdh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tmp_ecdh"]
     pub fn SSL_CTX_set_tmp_ecdh(ctx: *mut SSL_CTX, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tmp_ecdh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tmp_ecdh"]
     pub fn SSL_set_tmp_ecdh(ssl: *mut SSL, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add_dir_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add_dir_cert_subjects_to_stack"]
     pub fn SSL_add_dir_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         dir: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_enable_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_enable_tls_channel_id"]
     pub fn SSL_CTX_enable_tls_channel_id(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_enable_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_enable_tls_channel_id"]
     pub fn SSL_enable_tls_channel_id(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_f_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_f_ssl"]
     pub fn BIO_f_ssl() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_ssl"]
     pub fn BIO_set_ssl(
         bio: *mut BIO,
         ssl: *mut SSL,
@@ -32487,33 +32487,33 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_session"]
     pub fn SSL_get_session(ssl: *const SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get1_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get1_session"]
     pub fn SSL_get1_session(ssl: *mut SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_init_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_init_ssl"]
     pub fn OPENSSL_init_ssl(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tlsext_status_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tlsext_status_type"]
     pub fn SSL_set_tlsext_status_type(
         ssl: *mut SSL,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_tlsext_status_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_tlsext_status_type"]
     pub fn SSL_get_tlsext_status_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tlsext_status_ocsp_resp"]
     pub fn SSL_set_tlsext_status_ocsp_resp(
         ssl: *mut SSL,
         resp: *mut u8,
@@ -32521,11 +32521,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_tlsext_status_ocsp_resp"]
     pub fn SSL_get_tlsext_status_ocsp_resp(ssl: *const SSL, out: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_status_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_status_cb"]
     pub fn SSL_CTX_set_tlsext_status_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -32537,18 +32537,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_status_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_status_arg"]
     pub fn SSL_CTX_set_tlsext_status_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_value"]
     pub fn SSL_CIPHER_get_value(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,

--- a/aws-lc-fips-sys/src/x86_64_apple_darwin_crypto.rs
+++ b/aws-lc-fips-sys/src/x86_64_apple_darwin_crypto.rs
@@ -4551,38 +4551,38 @@ pub type X509_STORE = x509_store_st;
 pub type X509_TRUST = x509_trust_st;
 pub type OPENSSL_BLOCK = *mut ::std::os::raw::c_void;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_free_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_get_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_get_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4591,18 +4591,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4611,18 +4611,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_last_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4631,7 +4631,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_error_string_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -4639,11 +4639,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_lib_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_reason_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -4654,30 +4654,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_print_errors_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_print_errors_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_clear_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_set_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_pop_to_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_get_next_error_library"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -4716,30 +4716,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_remove_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_remove_thread_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_func_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_clear_system_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_put_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -4749,15 +4749,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_add_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_add_error_dataf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_set_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -4821,7 +4821,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_set_encrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4829,7 +4829,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_set_decrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4837,15 +4837,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4857,7 +4857,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4866,7 +4866,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4877,7 +4877,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4888,7 +4888,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4900,7 +4900,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_wrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4910,7 +4910,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_unwrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4920,7 +4920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_wrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4931,7 +4931,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5152,27 +5152,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_grow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_append"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5180,29 +5180,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5210,7 +5210,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5342,27 +5342,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_new_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -5370,11 +5370,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_pop_free_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -5382,22 +5382,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_insert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_delete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_delete_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_delete_if"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -5406,7 +5406,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_find"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -5415,35 +5415,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_shift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_is_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_set_cmp_func"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_deep_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -5453,7 +5453,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_pop_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -5513,7 +5513,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -5569,19 +5569,19 @@ impl Default for crypto_ex_data_st {
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_num_locks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5594,7 +5594,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5608,7 +5608,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5619,29 +5619,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -5697,7 +5697,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5708,7 +5708,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5721,7 +5721,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5733,7 +5733,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -5742,7 +5742,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5753,7 +5753,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -5780,23 +5780,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_vfree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -5804,7 +5804,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -5812,7 +5812,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5820,7 +5820,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_write_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5828,15 +5828,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5845,7 +5845,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5853,7 +5853,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_int_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5862,67 +5862,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_eof"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_should_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_should_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_should_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_should_io_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_retry_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_retry_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_method_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -5948,7 +5948,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5956,68 +5956,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_ctrl_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_wpending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_close"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_number_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_number_written"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_callback_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_next"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_free_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_find_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_copy_next_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_printf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6025,7 +6025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_indent"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6033,7 +6033,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_hexdump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6042,11 +6042,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_print_errors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_read_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -6055,15 +6055,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_s_mem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_mem_contents"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -6071,11 +6071,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -6083,22 +6083,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_s_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -6106,30 +6106,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_s_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -6137,89 +6137,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_read_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_write_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_append_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_rw_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_tell"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_seek"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_s_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_s_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_conn_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_nbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_do_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_bio_pair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -6228,34 +6228,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_shutdown_wr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -6264,13 +6264,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -6279,13 +6279,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -6298,7 +6298,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -6311,7 +6311,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -6324,7 +6324,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6336,7 +6336,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -6350,7 +6350,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6363,7 +6363,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -6376,7 +6376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6388,23 +6388,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -6414,7 +6414,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -6422,37 +6422,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_f_base64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_retry_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -6464,7 +6464,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6834,193 +6834,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_value_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_set_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_set_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_set_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bin2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2bin"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_le2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2le_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2bin_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2hex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_hex2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2dec"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_dec2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_asc2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_marshal_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_CTX_start"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_CTX_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_CTX_end"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_uadd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_add_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_usub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_sub_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7029,15 +7029,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mul_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_div"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7047,11 +7047,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_div_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -7059,47 +7059,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_cmp_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_ucmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_equal_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_abs_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7107,11 +7107,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_rshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7119,43 +7119,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_rshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_clear_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_bit_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mask_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_nnmod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_nnmod"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -7164,7 +7164,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7174,7 +7174,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_add_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7183,7 +7183,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7193,7 +7193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_sub_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7202,7 +7202,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7212,7 +7212,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7221,7 +7221,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7231,7 +7231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7240,7 +7240,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7249,7 +7249,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7257,7 +7257,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7266,7 +7266,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7275,7 +7275,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_pseudo_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7284,11 +7284,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_rand_range_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -7296,7 +7296,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -7356,15 +7356,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_GENCB_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_GENCB_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_GENCB_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -7378,7 +7378,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_GENCB_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -7386,11 +7386,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_generate_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7405,7 +7405,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -7415,7 +7415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -7426,7 +7426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7436,7 +7436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7445,7 +7445,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_gcd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7454,7 +7454,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_inverse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7463,7 +7463,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7473,7 +7473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7483,23 +7483,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_to_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7508,7 +7508,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_from_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7517,7 +7517,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7527,7 +7527,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7536,7 +7536,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7546,7 +7546,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_exp_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7557,7 +7557,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7568,15 +7568,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2mpi"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mpi2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -7587,7 +7587,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -7600,11 +7600,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -7612,7 +7612,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2binpad"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -7620,7 +7620,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_secure_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -7768,15 +7768,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_num_bits_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_tag2bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_tag2str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -7800,15 +7800,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7817,7 +7817,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -7825,14 +7825,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -7840,7 +7840,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -7848,7 +7848,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -7856,7 +7856,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -7864,14 +7864,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_unpack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_pack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -7879,7 +7879,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7887,22 +7887,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -7978,54 +7978,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8033,7 +8033,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8041,79 +8041,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -8121,7 +8121,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -8129,7 +8129,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -8137,7 +8137,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -8145,7 +8145,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -8153,7 +8153,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -8161,7 +8161,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -8169,7 +8169,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -8177,7 +8177,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -8185,117 +8185,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -8303,14 +8303,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8320,7 +8320,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8332,7 +8332,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -8342,7 +8342,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -8352,15 +8352,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8368,26 +8368,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8395,23 +8395,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8419,14 +8419,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8434,25 +8434,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -8460,7 +8460,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -8468,14 +8468,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -8504,19 +8504,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -8524,11 +8524,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -8536,54 +8536,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -8591,59 +8591,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -8651,23 +8651,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, t: time_t) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         t: time_t,
@@ -8676,26 +8676,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -8703,29 +8703,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
@@ -8734,22 +8734,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -8757,15 +8757,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_diff"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -8774,11 +8774,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, t: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         t: time_t,
@@ -8787,41 +8787,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_NULL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_NULL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -8829,11 +8829,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_NULL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8858,7 +8858,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -8868,11 +8868,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8880,11 +8880,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8892,7 +8892,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9226,15 +9226,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -9242,19 +9242,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ANY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9262,7 +9262,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9270,12 +9270,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9283,14 +9283,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9298,33 +9298,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -9332,7 +9332,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -9340,19 +9340,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -9360,7 +9360,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -9368,7 +9368,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -9378,7 +9378,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_put_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -9388,11 +9388,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_put_eoc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_object_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -9400,33 +9400,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9434,34 +9434,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -10071,7 +10071,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10096,19 +10096,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodeBase64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -10118,19 +10118,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10140,7 +10140,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10148,11 +10148,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10162,7 +10162,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10170,7 +10170,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -10380,11 +10380,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BLAKE2B256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BLAKE2B256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -10392,11 +10392,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BLAKE2B256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BLAKE2B256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -10451,19 +10451,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BF_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BF_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BF_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BF_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10472,7 +10472,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BF_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10533,23 +10533,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_skip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_stow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -10557,82 +10557,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_mem_equal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_last_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_copy_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_until_first"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10640,7 +10640,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10648,11 +10648,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_any_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10660,7 +10660,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10669,7 +10669,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10680,22 +10680,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10704,7 +10704,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10713,7 +10713,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -10722,7 +10722,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -10731,33 +10731,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10765,7 +10765,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_parse_utc_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10773,7 +10773,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -11080,23 +11080,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_init_fixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11104,40 +11104,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -11145,15 +11145,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_zeros"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_space"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11161,55 +11161,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_did_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_discard_child"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -11217,11 +11217,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -11229,7 +11229,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -11237,11 +11237,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -11249,11 +11249,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -11264,114 +11264,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_rc4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ede"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ede3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_xts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_enc_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_rc2_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11382,7 +11382,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11392,7 +11392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11402,7 +11402,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11412,7 +11412,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11420,7 +11420,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11430,7 +11430,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11438,7 +11438,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CipherUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11448,7 +11448,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11456,47 +11456,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -11505,45 +11505,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_BytesToKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -11556,23 +11556,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CipherInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11582,7 +11582,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11591,7 +11591,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11600,7 +11600,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CipherFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11608,7 +11608,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11616,7 +11616,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11624,7 +11624,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_Cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11633,118 +11633,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_bf_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_bf_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_bf_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_cast5_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_cast5_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -11981,7 +11981,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_CMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -11991,19 +11991,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12013,15 +12013,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_Reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -12116,15 +12116,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_load"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -12132,7 +12132,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_load_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -12140,14 +12140,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_get_section"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_get_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -12155,7 +12155,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CONF_modules_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -12163,23 +12163,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CONF_modules_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_no_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA1_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA1_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12187,15 +12187,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA1_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA1_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12282,11 +12282,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA224_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA224_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12294,19 +12294,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA224_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12314,19 +12314,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -12424,11 +12424,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA384_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA384_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12436,19 +12436,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA384_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12456,15 +12456,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12562,11 +12562,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12574,34 +12574,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_memcmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -12609,34 +12609,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_hash32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strhash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_tolower"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -12644,7 +12644,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_snprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12653,7 +12653,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_vsnprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12662,7 +12662,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12670,7 +12670,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_asprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12678,21 +12678,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12700,7 +12700,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12708,7 +12708,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -12716,7 +12716,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -12725,7 +12725,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -12733,11 +12733,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -12764,51 +12764,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_secure_used"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_library_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_has_asm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BORINGSSL_self_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_FIPS_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -12818,70 +12818,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_FIPS_read_counter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OpenSSL_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSLeay_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OpenSSL_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_awslc_api_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_FIPS_mode_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X25519"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -12889,15 +12889,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X25519_public_from_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ED25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ED25519_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -12906,7 +12906,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ED25519_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -12915,7 +12915,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -12926,7 +12926,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -12936,11 +12936,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -12951,7 +12951,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SPAKE2_process_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13024,15 +13024,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_set_odd_parity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13041,7 +13041,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13052,7 +13052,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13063,7 +13063,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13076,7 +13076,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13088,7 +13088,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_decrypt3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13097,7 +13097,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_encrypt3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13106,43 +13106,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13150,7 +13150,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13158,7 +13158,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13167,7 +13167,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13176,40 +13176,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_set_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13218,11 +13218,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_compute_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13230,7 +13230,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_compute_key_hashed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13241,19 +13241,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_check_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13261,19 +13261,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DHparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_generate_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13288,7 +13288,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13296,14 +13296,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13311,114 +13311,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get_2048_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_md4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_md5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_ripemd160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha3_224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha3_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha3_384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha3_512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_blake2b256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_md5_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_get_digestbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13426,11 +13426,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13438,7 +13438,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13446,7 +13446,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13454,7 +13454,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_Digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13465,75 +13465,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_add_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_get_digestbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13541,19 +13541,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -13645,15 +13645,15 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -13661,11 +13661,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -13673,15 +13673,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_METHOD_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_METHOD_unref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -13727,43 +13727,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -13771,7 +13771,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -13780,7 +13780,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -13788,7 +13788,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -13797,7 +13797,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -13809,11 +13809,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSAparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13867,28 +13867,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -13897,7 +13897,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_do_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13907,7 +13907,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13918,7 +13918,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13929,7 +13929,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13940,47 +13940,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_dup_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -13990,7 +13990,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -13998,14 +13998,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14013,11 +14013,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14025,11 +14025,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14037,11 +14037,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14049,7 +14049,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14205,19 +14205,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14225,19 +14225,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14245,7 +14245,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14255,53 +14255,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_curve_nid2nist"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_curve_nist2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14309,7 +14309,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14318,7 +14318,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14328,7 +14328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14338,7 +14338,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14348,7 +14348,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14358,7 +14358,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_point2oct"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14369,7 +14369,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14379,7 +14379,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_oct2point"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14389,7 +14389,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14399,7 +14399,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14409,7 +14409,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_dbl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14418,7 +14418,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_invert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14426,7 +14426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14437,7 +14437,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14446,7 +14446,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14455,7 +14455,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14463,11 +14463,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14477,15 +14477,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_method_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -14539,92 +14539,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_get_builtin_curves"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get0_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -14632,7 +14632,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_key2buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -14641,15 +14641,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -14657,11 +14657,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -14669,22 +14669,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14694,7 +14694,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14702,7 +14702,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14824,11 +14824,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14836,11 +14836,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14848,11 +14848,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_o2i_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14860,14 +14860,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2o_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -14884,7 +14884,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -14893,7 +14893,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14904,7 +14904,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14915,7 +14915,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -14969,23 +14969,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -14993,7 +14993,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15001,7 +15001,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15009,7 +15009,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15018,19 +15018,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15038,11 +15038,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15052,7 +15052,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15060,83 +15060,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15274,11 +15274,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15287,11 +15287,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15302,11 +15302,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15321,7 +15321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15336,7 +15336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15354,7 +15354,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15369,66 +15369,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15439,7 +15439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15447,7 +15447,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15456,7 +15456,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15464,102 +15464,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_assign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -15567,40 +15567,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15609,7 +15609,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15618,7 +15618,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15626,7 +15626,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15634,7 +15634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestSignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15644,7 +15644,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15652,7 +15652,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15660,7 +15660,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestSign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15670,7 +15670,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15680,7 +15680,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15688,7 +15688,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15696,7 +15696,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestVerify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15706,7 +15706,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_SignInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15714,11 +15714,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_SignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_SignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15726,7 +15726,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_SignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -15735,7 +15735,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15743,11 +15743,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_VerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15755,7 +15755,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_VerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15764,7 +15764,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15773,7 +15773,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15782,7 +15782,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15791,7 +15791,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15804,7 +15804,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15816,7 +15816,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15831,31 +15831,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -15865,11 +15865,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -15879,11 +15879,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15893,11 +15893,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15907,11 +15907,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15921,18 +15921,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_derive"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -15940,18 +15940,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -15961,7 +15961,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -15971,102 +15971,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16074,28 +16074,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16103,7 +16103,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16111,7 +16111,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16121,31 +16121,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16159,7 +16159,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16173,15 +16173,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16190,7 +16190,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16198,7 +16198,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16207,22 +16207,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16230,40 +16230,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16271,11 +16271,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16283,11 +16283,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16295,11 +16295,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16307,14 +16307,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -16488,7 +16488,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HKDF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16502,7 +16502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HKDF_extract"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16514,7 +16514,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HKDF_expand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -16526,11 +16526,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD5_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD5_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16538,15 +16538,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD5_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD5_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -16633,7 +16633,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -16645,27 +16645,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_Init_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16675,7 +16675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -16683,7 +16683,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16691,23 +16691,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16716,7 +16716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -16892,82 +16892,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -16976,18 +16976,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -16996,7 +16996,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17005,23 +17005,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17037,7 +17037,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17055,7 +17055,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17068,7 +17068,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17081,7 +17081,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17094,7 +17094,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17104,19 +17104,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17375,7 +17375,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HRSS_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17383,7 +17383,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HRSS_encap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17392,7 +17392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HRSS_decap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17401,22 +17401,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HRSS_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD4_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD4_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17424,15 +17424,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD4_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD4_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17519,66 +17519,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_obj2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_cbs2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_sn2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_ln2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_txt2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_nid2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_nid2sn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_nid2ln"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_nid2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_txt2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_obj2txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -17587,7 +17587,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -17595,7 +17595,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -17603,7 +17603,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -17684,7 +17684,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -17703,7 +17703,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -17711,47 +17711,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_get_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18045,51 +18045,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18115,15 +18115,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18131,18 +18131,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18150,79 +18150,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_dmp1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_dmq1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_iqmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18231,11 +18231,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18244,7 +18244,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18253,12 +18253,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_set0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_set0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18267,7 +18267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_generate_key_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18276,7 +18276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18284,7 +18284,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18296,7 +18296,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18308,7 +18308,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_public_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -18318,7 +18318,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_private_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -18328,7 +18328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18339,7 +18339,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18353,7 +18353,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_sign_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18365,7 +18365,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18376,7 +18376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -18389,7 +18389,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_verify_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18401,7 +18401,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_private_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -18411,7 +18411,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_public_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -18421,31 +18421,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSAPublicKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18456,7 +18456,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18467,7 +18467,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -18480,7 +18480,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -18491,19 +18491,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18511,19 +18511,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18531,7 +18531,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -18541,7 +18541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -18549,26 +18549,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_blinding_on"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -18577,7 +18577,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18585,11 +18585,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18597,11 +18597,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18611,7 +18611,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18621,7 +18621,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -18632,7 +18632,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -18640,7 +18640,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_pss_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -19141,27 +19141,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_chain_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19169,51 +19169,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_parse_from_buffer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_uids"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19226,15 +19226,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19242,7 +19242,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19250,7 +19250,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19258,15 +19258,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19274,68 +19274,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set1_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set1_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_getm_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_getm_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19343,7 +19343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19351,25 +19351,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19377,14 +19377,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -19392,7 +19392,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_alias_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -19400,7 +19400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_keyid_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -19408,14 +19408,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_alias_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_keyid_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -19437,23 +19437,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19461,23 +19461,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -19486,19 +19486,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19506,7 +19506,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -19514,7 +19514,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -19522,11 +19522,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19534,55 +19534,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -19590,7 +19590,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -19598,25 +19598,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -19624,19 +19624,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -19644,23 +19644,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19668,33 +19668,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -19702,22 +19702,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -19767,19 +19767,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -19787,15 +19787,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get0_der"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -19803,15 +19803,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_entry_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19819,7 +19819,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19827,21 +19827,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_add_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -19850,7 +19850,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19862,7 +19862,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19874,7 +19874,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -19886,19 +19886,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -19906,33 +19906,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -19941,11 +19941,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -19955,7 +19955,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -19965,7 +19965,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -19975,19 +19975,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -19995,18 +19995,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20015,7 +20015,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20024,33 +20024,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20074,11 +20074,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20086,18 +20086,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20105,7 +20105,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20113,7 +20113,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20121,21 +20121,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -20164,23 +20164,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -20188,11 +20188,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -20201,7 +20201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -20210,15 +20210,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_signature_dump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -20226,7 +20226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_signature_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -20234,7 +20234,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_pubkey_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20243,7 +20243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20252,7 +20252,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -20261,7 +20261,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -20270,7 +20270,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -20279,259 +20279,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -20539,11 +20539,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_find_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20553,7 +20553,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -20561,14 +20561,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20578,7 +20578,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -20586,42 +20586,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20630,7 +20630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -21203,11 +21203,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_pathlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -21215,7 +21215,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_SIG_getm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -21223,54 +21223,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21278,23 +21278,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_cmp_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_cmp_current_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_time_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -21302,7 +21302,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_time_adj_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -21311,44 +21311,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_gmtime_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_cert_area"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_private_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21356,34 +21356,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21391,26 +21391,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_SIG_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21418,18 +21418,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21437,38 +21437,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_add1_trust_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_add1_reject_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_trust_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_reject_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21476,25 +21476,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21502,7 +21502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21510,23 +21510,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21534,26 +21534,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21561,26 +21561,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_oneline"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -21588,7 +21588,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -21598,7 +21598,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -21608,7 +21608,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -21618,7 +21618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21630,7 +21630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21641,15 +21641,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -21657,18 +21657,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21676,7 +21676,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21684,28 +21684,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21715,7 +21715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21725,7 +21725,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -21735,37 +21735,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_diff"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -21775,66 +21775,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_issuer_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_subject_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_subject_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_match"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -21843,19 +21843,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -21864,7 +21864,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -21872,7 +21872,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -21881,7 +21881,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -21890,15 +21890,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -21907,11 +21907,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -21920,7 +21920,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -21930,7 +21930,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21939,7 +21939,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21949,11 +21949,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21961,7 +21961,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -21969,7 +21969,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -21977,21 +21977,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -21999,7 +21999,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22008,7 +22008,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22018,11 +22018,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_get_attr_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22030,7 +22030,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22038,28 +22038,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_get_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_delete_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_add1_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22069,7 +22069,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22079,7 +22079,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22089,7 +22089,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22099,7 +22099,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22109,7 +22109,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22119,14 +22119,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -22135,7 +22135,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -22144,34 +22144,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_verify_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22179,26 +22179,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -22209,7 +22209,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -22219,11 +22219,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -22231,19 +22231,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -22260,19 +22260,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22359,15 +22359,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22375,14 +22375,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -22501,18 +22501,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22520,7 +22520,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22528,202 +22528,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set1_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -22731,15 +22731,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -22748,50 +22748,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_add_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_add_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -22800,7 +22800,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -22810,7 +22810,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_load_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22818,7 +22818,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_load_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22826,7 +22826,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22834,19 +22834,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -22855,11 +22855,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_load_locations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -22867,81 +22867,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -22950,11 +22950,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -22962,7 +22962,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -22974,105 +22974,105 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23080,7 +23080,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23088,20 +23088,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -23109,7 +23109,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -23117,42 +23117,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -23164,14 +23164,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_do_header"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -23181,7 +23181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23191,7 +23191,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -23201,7 +23201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -23213,7 +23213,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23224,7 +23224,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23238,7 +23238,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -23247,7 +23247,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23257,7 +23257,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -23267,7 +23267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_ASN1_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23278,7 +23278,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_ASN1_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23292,7 +23292,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -23301,7 +23301,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_def_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -23310,11 +23310,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_proc_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_dek_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -23323,7 +23323,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23332,7 +23332,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23341,15 +23341,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23358,7 +23358,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23367,15 +23367,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -23384,7 +23384,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -23393,23 +23393,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -23418,7 +23418,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -23427,15 +23427,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -23444,7 +23444,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -23453,15 +23453,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -23470,7 +23470,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -23479,15 +23479,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23496,7 +23496,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23505,21 +23505,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23528,7 +23528,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23537,7 +23537,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -23549,7 +23549,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -23561,7 +23561,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23570,7 +23570,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23579,15 +23579,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23596,7 +23596,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23605,15 +23605,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23622,7 +23622,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23631,7 +23631,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -23643,7 +23643,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -23655,7 +23655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23664,7 +23664,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23673,15 +23673,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23690,7 +23690,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23699,15 +23699,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23716,7 +23716,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23725,7 +23725,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -23737,7 +23737,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -23749,7 +23749,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23758,7 +23758,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23767,15 +23767,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -23784,7 +23784,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -23793,15 +23793,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23810,7 +23810,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23819,7 +23819,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23831,7 +23831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23843,7 +23843,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23852,7 +23852,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23861,15 +23861,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23881,7 +23881,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -23893,7 +23893,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23905,7 +23905,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23917,7 +23917,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23926,7 +23926,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23938,7 +23938,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23950,7 +23950,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23962,7 +23962,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23971,7 +23971,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23983,7 +23983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -23996,7 +23996,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -24010,7 +24010,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -24018,7 +24018,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -24026,7 +24026,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -24035,11 +24035,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_PBE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -24047,27 +24047,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24077,7 +24077,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_verify_mac"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24085,7 +24085,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -24100,74 +24100,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_file_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_egd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_poll"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24268,19 +24268,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_OpenSSL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_get_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_set_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24345,11 +24345,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RC4_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RC4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -24436,11 +24436,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RIPEMD160_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RIPEMD160_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -24448,42 +24448,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RIPEMD160_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RIPEMD160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_awslc_version_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SIPHASH_24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -24558,15 +24558,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24579,7 +24579,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24594,18 +24594,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24614,14 +24614,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24630,7 +24630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24641,7 +24641,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24650,7 +24650,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24662,7 +24662,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -24674,18 +24674,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24693,14 +24693,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24708,7 +24708,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24722,7 +24722,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24737,7 +24737,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24750,7 +24750,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24765,7 +24765,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -26473,15 +26473,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_POLICY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_POLICY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26489,26 +26489,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_POLICY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26516,14 +26516,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -26755,15 +26755,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26771,26 +26771,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26798,26 +26798,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26825,29 +26825,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -26855,19 +26855,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26875,18 +26875,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -26894,7 +26894,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -26902,15 +26902,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OTHERNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OTHERNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_OTHERNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26918,26 +26918,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_OTHERNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OTHERNAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26945,22 +26945,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OTHERNAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -26968,14 +26968,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -26983,7 +26983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -26991,14 +26991,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27006,15 +27006,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27022,33 +27022,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27056,26 +27056,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27083,26 +27083,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27110,26 +27110,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_USERNOTICE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_USERNOTICE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27137,26 +27137,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_USERNOTICE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NOTICEREF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NOTICEREF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27164,26 +27164,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NOTICEREF_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27191,26 +27191,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27218,26 +27218,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27245,26 +27245,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27272,38 +27272,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27311,26 +27311,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27338,70 +27338,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27412,7 +27412,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27420,7 +27420,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27430,7 +27430,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_conf_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -27528,7 +27528,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_set_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -27539,11 +27539,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_set_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27552,7 +27552,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27561,7 +27561,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -27570,7 +27570,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27579,7 +27579,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27588,7 +27588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27597,7 +27597,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27606,67 +27606,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_parse_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_get_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27675,14 +27675,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -27690,7 +27690,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_add1_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27700,7 +27700,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -27709,7 +27709,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -27718,7 +27718,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -27727,7 +27727,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_extensions_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -27737,11 +27737,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_ca"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -27749,70 +27749,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_supported_extension"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_akid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_extension_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_authority_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -27830,43 +27830,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_email_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get1_ocsp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27876,7 +27876,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27885,7 +27885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -27894,7 +27894,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -27902,15 +27902,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_a2i_IPADDRESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,

--- a/aws-lc-fips-sys/src/x86_64_apple_darwin_crypto_ssl.rs
+++ b/aws-lc-fips-sys/src/x86_64_apple_darwin_crypto_ssl.rs
@@ -5503,38 +5503,38 @@ pub type X509_STORE = x509_store_st;
 pub type X509_TRUST = x509_trust_st;
 pub type OPENSSL_BLOCK = *mut ::std::os::raw::c_void;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_free_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_get_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_get_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5543,18 +5543,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5563,18 +5563,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_last_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5583,7 +5583,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_error_string_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -5591,11 +5591,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_lib_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_reason_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -5606,30 +5606,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_print_errors_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_print_errors_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_clear_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_set_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_pop_to_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_get_next_error_library"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -5668,30 +5668,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_remove_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_remove_thread_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_func_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_clear_system_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_put_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -5701,15 +5701,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_add_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_add_error_dataf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_set_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -5773,7 +5773,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_set_encrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5781,7 +5781,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_set_decrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5789,15 +5789,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5809,7 +5809,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5818,7 +5818,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5829,7 +5829,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5840,7 +5840,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5852,7 +5852,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_wrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5862,7 +5862,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_unwrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5872,7 +5872,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_wrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5883,7 +5883,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -6104,27 +6104,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_grow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_MEM_append"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -6132,29 +6132,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -6162,7 +6162,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BUF_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -6294,27 +6294,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_new_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -6322,11 +6322,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_pop_free_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6334,22 +6334,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_insert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_delete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_delete_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_delete_if"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6358,7 +6358,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_find"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -6367,35 +6367,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_shift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_is_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_set_cmp_func"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_deep_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6405,7 +6405,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_sk_pop_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6465,7 +6465,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6521,19 +6521,19 @@ impl Default for crypto_ex_data_st {
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_num_locks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6546,7 +6546,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6560,7 +6560,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6571,29 +6571,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6649,7 +6649,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6660,7 +6660,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6673,7 +6673,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6685,7 +6685,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6694,7 +6694,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6705,7 +6705,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6732,23 +6732,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_vfree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6756,7 +6756,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6764,7 +6764,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6772,7 +6772,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_write_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6780,15 +6780,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6797,7 +6797,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6805,7 +6805,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_int_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6814,67 +6814,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_eof"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_should_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_should_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_should_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_should_io_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_retry_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_retry_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_method_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6900,7 +6900,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6908,68 +6908,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_ctrl_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_wpending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_close"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_number_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_number_written"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_callback_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_next"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_free_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_find_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_copy_next_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_printf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6977,7 +6977,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_indent"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6985,7 +6985,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_hexdump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6994,11 +6994,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_print_errors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_read_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -7007,15 +7007,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_s_mem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_mem_contents"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -7023,11 +7023,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -7035,22 +7035,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_s_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -7058,30 +7058,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_s_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -7089,89 +7089,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_read_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_write_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_append_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_rw_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_tell"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_seek"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_s_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_s_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_conn_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_nbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_do_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_new_bio_pair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -7180,34 +7180,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_shutdown_wr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -7216,13 +7216,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -7231,13 +7231,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7250,7 +7250,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7263,7 +7263,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7276,7 +7276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7288,7 +7288,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7302,7 +7302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7315,7 +7315,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7328,7 +7328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7340,23 +7340,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7366,7 +7366,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7374,37 +7374,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_f_base64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_retry_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_get_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_set_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7416,7 +7416,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_meth_get_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7786,193 +7786,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_value_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_set_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_set_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_set_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bin2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2bin"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_le2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2le_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2bin_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2hex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_hex2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2dec"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_dec2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_asc2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_marshal_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_CTX_start"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_CTX_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_CTX_end"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_uadd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_add_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_usub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_sub_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7981,15 +7981,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mul_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_div"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7999,11 +7999,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_div_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -8011,47 +8011,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_cmp_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_ucmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_equal_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_abs_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8059,11 +8059,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_rshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8071,43 +8071,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_rshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_clear_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_bit_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mask_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_nnmod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_nnmod"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -8116,7 +8116,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8126,7 +8126,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_add_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8135,7 +8135,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8145,7 +8145,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_sub_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8154,7 +8154,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8164,7 +8164,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8173,7 +8173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8183,7 +8183,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8192,7 +8192,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8201,7 +8201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8209,7 +8209,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8218,7 +8218,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8227,7 +8227,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_pseudo_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8236,11 +8236,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_rand_range_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8248,7 +8248,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8308,15 +8308,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_GENCB_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_GENCB_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_GENCB_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8330,7 +8330,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_GENCB_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8338,11 +8338,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_generate_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8357,7 +8357,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8367,7 +8367,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8378,7 +8378,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8388,7 +8388,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_is_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8397,7 +8397,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_gcd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8406,7 +8406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_inverse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8415,7 +8415,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8425,7 +8425,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8435,23 +8435,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_to_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8460,7 +8460,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_from_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8469,7 +8469,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8479,7 +8479,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8488,7 +8488,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8498,7 +8498,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_exp_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8509,7 +8509,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8520,15 +8520,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2mpi"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mpi2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8539,7 +8539,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8552,11 +8552,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8564,7 +8564,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_bn2binpad"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8572,7 +8572,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_secure_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -8720,15 +8720,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_num_bits_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_tag2bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_tag2str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8752,15 +8752,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8769,7 +8769,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8777,14 +8777,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8792,7 +8792,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8800,7 +8800,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8808,7 +8808,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8816,14 +8816,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_unpack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_pack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8831,7 +8831,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8839,22 +8839,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8930,54 +8930,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8985,7 +8985,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8993,79 +8993,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -9073,7 +9073,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -9081,7 +9081,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -9089,7 +9089,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -9097,7 +9097,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -9105,7 +9105,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -9113,7 +9113,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -9121,7 +9121,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -9129,7 +9129,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -9137,117 +9137,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9255,14 +9255,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9272,7 +9272,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9284,7 +9284,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9294,7 +9294,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9304,15 +9304,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9320,26 +9320,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9347,23 +9347,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9371,14 +9371,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9386,25 +9386,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9412,7 +9412,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9420,14 +9420,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9456,19 +9456,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9476,11 +9476,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9488,54 +9488,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9543,59 +9543,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9603,23 +9603,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, t: time_t) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         t: time_t,
@@ -9628,26 +9628,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9655,29 +9655,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
@@ -9686,22 +9686,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9709,15 +9709,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_diff"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9726,11 +9726,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, t: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         t: time_t,
@@ -9739,41 +9739,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_NULL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_NULL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9781,11 +9781,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_NULL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9810,7 +9810,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9820,11 +9820,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9832,11 +9832,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9844,7 +9844,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10178,15 +10178,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10194,19 +10194,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ANY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10214,7 +10214,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10222,12 +10222,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10235,14 +10235,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10250,33 +10250,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_TIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10284,7 +10284,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10292,19 +10292,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10312,7 +10312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10320,7 +10320,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10330,7 +10330,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_put_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10340,11 +10340,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_put_eoc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_object_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10352,33 +10352,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10386,34 +10386,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -11023,7 +11023,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -11048,19 +11048,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodeBase64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -11070,19 +11070,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11092,7 +11092,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11100,11 +11100,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11114,7 +11114,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11122,7 +11122,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11332,11 +11332,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BLAKE2B256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BLAKE2B256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11344,11 +11344,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BLAKE2B256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BLAKE2B256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11403,19 +11403,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BF_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BF_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BF_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BF_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11424,7 +11424,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BF_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11485,23 +11485,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_skip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_stow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11509,82 +11509,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_mem_equal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_last_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_copy_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_until_first"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11592,7 +11592,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11600,11 +11600,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_any_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11612,7 +11612,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11621,7 +11621,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11632,22 +11632,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11656,7 +11656,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11665,7 +11665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11674,7 +11674,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11683,33 +11683,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11717,7 +11717,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_parse_utc_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11725,7 +11725,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -12032,23 +12032,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_init_fixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12056,40 +12056,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -12097,15 +12097,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_zeros"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_space"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12113,55 +12113,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_did_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_discard_child"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -12169,11 +12169,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -12181,7 +12181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12189,11 +12189,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12201,11 +12201,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12216,114 +12216,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_rc4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ede"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ede3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_xts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_enc_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_rc2_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12334,7 +12334,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12344,7 +12344,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12354,7 +12354,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12364,7 +12364,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12372,7 +12372,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12382,7 +12382,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12390,7 +12390,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CipherUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12400,7 +12400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12408,47 +12408,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12457,45 +12457,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_BytesToKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12508,23 +12508,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CipherInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12534,7 +12534,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12543,7 +12543,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12552,7 +12552,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CipherFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12560,7 +12560,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_EncryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12568,7 +12568,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DecryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12576,7 +12576,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_Cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12585,118 +12585,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_bf_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_bf_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_bf_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_cast5_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_cast5_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -12933,7 +12933,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AES_CMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -12943,19 +12943,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12965,15 +12965,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_Reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -13068,15 +13068,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_load"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -13084,7 +13084,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_load_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -13092,14 +13092,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_get_section"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NCONF_get_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -13107,7 +13107,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CONF_modules_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -13115,23 +13115,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CONF_modules_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_no_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA1_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA1_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13139,15 +13139,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA1_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA1_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13234,11 +13234,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA224_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA224_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13246,19 +13246,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA224_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13266,19 +13266,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -13376,11 +13376,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA384_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA384_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13388,19 +13388,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA384_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13408,15 +13408,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13514,11 +13514,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13526,11 +13526,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SHA512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 #[repr(C)]
@@ -13575,26 +13575,26 @@ fn bindgen_test_layout_timeval() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_memcmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -13602,34 +13602,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_hash32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strhash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_tolower"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13637,7 +13637,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_snprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13646,7 +13646,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_vsnprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13655,7 +13655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13663,7 +13663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_asprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13671,21 +13671,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13693,7 +13693,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13701,7 +13701,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -13709,7 +13709,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -13718,7 +13718,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -13726,11 +13726,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -13757,51 +13757,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_secure_used"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_library_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_has_asm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BORINGSSL_self_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_FIPS_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -13811,70 +13811,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_FIPS_read_counter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OpenSSL_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSLeay_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OpenSSL_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_awslc_api_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_FIPS_mode_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X25519"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13882,15 +13882,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X25519_public_from_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ED25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ED25519_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13899,7 +13899,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ED25519_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13908,7 +13908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13919,7 +13919,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13929,11 +13929,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13944,7 +13944,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SPAKE2_process_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -14017,15 +14017,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_set_odd_parity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -14034,7 +14034,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14045,7 +14045,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -14056,7 +14056,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14069,7 +14069,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14081,7 +14081,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_decrypt3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -14090,7 +14090,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DES_encrypt3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -14099,43 +14099,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -14143,7 +14143,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -14151,7 +14151,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -14160,7 +14160,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -14169,40 +14169,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_set_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -14211,11 +14211,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_compute_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14223,7 +14223,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_compute_key_hashed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -14234,19 +14234,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_check_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -14254,19 +14254,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DHparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_generate_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -14281,7 +14281,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -14289,14 +14289,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14304,114 +14304,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DH_get_2048_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_md4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_md5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_ripemd160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha3_224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha3_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha3_384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_sha3_512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_blake2b256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_md5_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_get_digestbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -14419,11 +14419,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -14431,7 +14431,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14439,7 +14439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14447,7 +14447,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_Digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -14458,75 +14458,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_add_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_get_digestbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -14534,19 +14534,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14638,15 +14638,15 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -14654,11 +14654,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -14666,15 +14666,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_METHOD_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_METHOD_unref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -14720,43 +14720,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14764,7 +14764,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14773,7 +14773,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14781,7 +14781,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14790,7 +14790,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14802,11 +14802,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSAparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14860,28 +14860,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14890,7 +14890,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_do_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14900,7 +14900,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14911,7 +14911,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14922,7 +14922,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14933,47 +14933,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_dup_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14983,7 +14983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14991,14 +14991,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -15006,11 +15006,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15018,11 +15018,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15030,11 +15030,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15042,7 +15042,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15198,19 +15198,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -15218,19 +15218,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -15238,7 +15238,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -15248,53 +15248,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_curve_nid2nist"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_curve_nist2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15302,7 +15302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -15311,7 +15311,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15321,7 +15321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15331,7 +15331,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15341,7 +15341,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15351,7 +15351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_point2oct"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15362,7 +15362,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -15372,7 +15372,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_oct2point"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15382,7 +15382,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15392,7 +15392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15402,7 +15402,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_dbl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15411,7 +15411,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_invert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -15419,7 +15419,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15430,7 +15430,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -15439,7 +15439,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -15448,7 +15448,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -15456,11 +15456,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15470,15 +15470,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_method_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -15532,92 +15532,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_get_builtin_curves"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_POINT_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get0_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -15625,7 +15625,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_key2buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15634,15 +15634,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15650,11 +15650,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15662,22 +15662,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15687,7 +15687,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15695,7 +15695,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15817,11 +15817,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15829,11 +15829,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15841,11 +15841,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_o2i_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15853,14 +15853,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2o_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15877,7 +15877,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15886,7 +15886,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15897,7 +15897,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15908,7 +15908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15962,23 +15962,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15986,7 +15986,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15994,7 +15994,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -16002,7 +16002,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -16011,19 +16011,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -16031,11 +16031,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -16045,7 +16045,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -16053,83 +16053,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -16267,11 +16267,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -16280,11 +16280,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16295,11 +16295,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16314,7 +16314,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16329,7 +16329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16347,7 +16347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16362,66 +16362,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16432,7 +16432,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -16440,7 +16440,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -16449,7 +16449,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -16457,102 +16457,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_assign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16560,40 +16560,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16602,7 +16602,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16611,7 +16611,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16619,7 +16619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16627,7 +16627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestSignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16637,7 +16637,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16645,7 +16645,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16653,7 +16653,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestSign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16663,7 +16663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16673,7 +16673,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16681,7 +16681,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16689,7 +16689,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_DigestVerify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16699,7 +16699,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_SignInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16707,11 +16707,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_SignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_SignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16719,7 +16719,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_SignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16728,7 +16728,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16736,11 +16736,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_VerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16748,7 +16748,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_VerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16757,7 +16757,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16766,7 +16766,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16775,7 +16775,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16784,7 +16784,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16797,7 +16797,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16809,7 +16809,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16824,31 +16824,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16858,11 +16858,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16872,11 +16872,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16886,11 +16886,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16900,11 +16900,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16914,18 +16914,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_derive"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16933,18 +16933,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16954,7 +16954,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16964,102 +16964,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -17067,28 +17067,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -17096,7 +17096,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -17104,7 +17104,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -17114,31 +17114,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -17152,7 +17152,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -17166,15 +17166,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -17183,7 +17183,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -17191,7 +17191,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -17200,22 +17200,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -17223,40 +17223,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -17264,11 +17264,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -17276,11 +17276,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -17288,11 +17288,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -17300,14 +17300,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -17481,7 +17481,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HKDF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -17495,7 +17495,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HKDF_extract"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -17507,7 +17507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HKDF_expand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -17519,11 +17519,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD5_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD5_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17531,15 +17531,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD5_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD5_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17626,7 +17626,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17638,27 +17638,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_Init_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17668,7 +17668,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17676,7 +17676,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17684,23 +17684,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17709,7 +17709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17885,82 +17885,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17969,18 +17969,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17989,7 +17989,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17998,23 +17998,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -18030,7 +18030,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -18048,7 +18048,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -18061,7 +18061,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -18074,7 +18074,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -18087,7 +18087,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -18097,19 +18097,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -18368,7 +18368,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HRSS_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -18376,7 +18376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HRSS_encap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -18385,7 +18385,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HRSS_decap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -18394,22 +18394,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_HRSS_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD4_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD4_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18417,15 +18417,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD4_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_MD4_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18512,66 +18512,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_obj2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_cbs2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_sn2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_ln2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_txt2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_nid2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_nid2sn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_nid2ln"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_nid2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_txt2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_obj2txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -18580,7 +18580,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -18588,7 +18588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -18596,7 +18596,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -18677,7 +18677,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OBJ_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -18696,7 +18696,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18704,47 +18704,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_get_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -19038,51 +19038,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS7_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19108,15 +19108,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -19124,18 +19124,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -19143,79 +19143,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_dmp1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_dmq1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_iqmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -19224,11 +19224,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -19237,7 +19237,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -19246,12 +19246,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_set0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_set0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -19260,7 +19260,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_generate_key_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19269,7 +19269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19277,7 +19277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19289,7 +19289,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19301,7 +19301,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_public_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19311,7 +19311,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_private_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19321,7 +19321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19332,7 +19332,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19346,7 +19346,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_sign_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19358,7 +19358,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19369,7 +19369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19382,7 +19382,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_verify_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19394,7 +19394,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_private_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19404,7 +19404,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_public_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19414,31 +19414,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSAPublicKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19449,7 +19449,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19460,7 +19460,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19473,7 +19473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19484,19 +19484,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19504,19 +19504,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19524,7 +19524,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19534,7 +19534,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19542,26 +19542,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_blinding_on"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19570,7 +19570,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19578,11 +19578,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19590,11 +19590,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19604,7 +19604,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19614,7 +19614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19625,7 +19625,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19633,7 +19633,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_get0_pss_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -20134,27 +20134,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_chain_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -20162,51 +20162,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_parse_from_buffer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_uids"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -20219,15 +20219,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -20235,7 +20235,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -20243,7 +20243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -20251,15 +20251,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -20267,68 +20267,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set1_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set1_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_getm_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_getm_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -20336,7 +20336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -20344,25 +20344,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -20370,14 +20370,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -20385,7 +20385,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_alias_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -20393,7 +20393,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_keyid_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -20401,14 +20401,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_alias_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_keyid_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -20430,23 +20430,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -20454,23 +20454,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -20479,19 +20479,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20499,7 +20499,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20507,7 +20507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20515,11 +20515,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20527,55 +20527,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20583,7 +20583,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20591,25 +20591,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20617,19 +20617,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20637,23 +20637,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20661,33 +20661,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20695,22 +20695,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20760,19 +20760,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20780,15 +20780,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get0_der"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20796,15 +20796,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_entry_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20812,7 +20812,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20820,21 +20820,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_add_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20843,7 +20843,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20855,7 +20855,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20867,7 +20867,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20879,19 +20879,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20899,33 +20899,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20934,11 +20934,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20948,7 +20948,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20958,7 +20958,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20968,19 +20968,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20988,18 +20988,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -21008,7 +21008,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -21017,33 +21017,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -21067,11 +21067,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -21079,18 +21079,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -21098,7 +21098,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -21106,7 +21106,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -21114,21 +21114,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509v3_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21157,23 +21157,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21181,11 +21181,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21194,7 +21194,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21203,15 +21203,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_signature_dump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -21219,7 +21219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_signature_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -21227,7 +21227,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_pubkey_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -21236,7 +21236,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -21245,7 +21245,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -21254,7 +21254,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -21263,7 +21263,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -21272,259 +21272,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -21532,11 +21532,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_find_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21546,7 +21546,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -21554,14 +21554,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21571,7 +21571,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -21579,42 +21579,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_set_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -21623,7 +21623,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -22196,11 +22196,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_pathlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22208,7 +22208,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_SIG_getm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22216,54 +22216,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -22271,23 +22271,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_cmp_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_cmp_current_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_time_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22295,7 +22295,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_time_adj_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22304,44 +22304,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_gmtime_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_cert_area"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_default_private_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22349,34 +22349,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22384,26 +22384,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_SIG_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22411,18 +22411,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -22430,38 +22430,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_add1_trust_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_add1_reject_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_trust_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_reject_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22469,25 +22469,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22495,7 +22495,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22503,23 +22503,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22527,26 +22527,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22554,26 +22554,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_oneline"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22581,7 +22581,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22591,7 +22591,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22601,7 +22601,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22611,7 +22611,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22623,7 +22623,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22634,15 +22634,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -22650,18 +22650,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22669,7 +22669,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22677,28 +22677,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22708,7 +22708,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22718,7 +22718,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -22728,37 +22728,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_diff"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -22768,66 +22768,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_issuer_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_subject_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_subject_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_match"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -22836,19 +22836,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22857,7 +22857,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22865,7 +22865,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_NAME_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22874,7 +22874,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22883,15 +22883,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22900,11 +22900,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -22913,7 +22913,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -22923,7 +22923,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22932,7 +22932,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22942,11 +22942,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22954,7 +22954,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -22962,7 +22962,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -22970,21 +22970,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -22992,7 +22992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -23001,7 +23001,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -23011,11 +23011,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_get_attr_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23023,7 +23023,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23031,28 +23031,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_get_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_delete_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_add1_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23062,7 +23062,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23072,7 +23072,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -23082,7 +23082,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23092,7 +23092,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23102,7 +23102,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -23112,14 +23112,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -23128,7 +23128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -23137,34 +23137,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_verify_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23172,26 +23172,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -23202,7 +23202,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -23212,11 +23212,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -23224,19 +23224,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -23253,19 +23253,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23352,15 +23352,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23368,14 +23368,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -23494,18 +23494,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23513,7 +23513,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23521,202 +23521,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set1_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23724,15 +23724,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -23741,50 +23741,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_add_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_add_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23793,7 +23793,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23803,7 +23803,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_load_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23811,7 +23811,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_load_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23819,7 +23819,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23827,19 +23827,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -23848,11 +23848,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_load_locations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23860,81 +23860,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -23943,11 +23943,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23955,7 +23955,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23967,105 +23967,105 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -24073,7 +24073,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -24081,20 +24081,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -24102,7 +24102,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -24110,42 +24110,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -24157,14 +24157,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_do_header"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -24174,7 +24174,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -24184,7 +24184,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -24194,7 +24194,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -24206,7 +24206,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24217,7 +24217,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24231,7 +24231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -24240,7 +24240,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -24250,7 +24250,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -24260,7 +24260,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_ASN1_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24271,7 +24271,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_ASN1_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24285,7 +24285,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -24294,7 +24294,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_def_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -24303,11 +24303,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_proc_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_dek_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -24316,7 +24316,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24325,7 +24325,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24334,15 +24334,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24351,7 +24351,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24360,15 +24360,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -24377,7 +24377,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -24386,23 +24386,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -24411,7 +24411,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -24420,15 +24420,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -24437,7 +24437,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -24446,15 +24446,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -24463,7 +24463,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -24472,15 +24472,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24489,7 +24489,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24498,21 +24498,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24521,7 +24521,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24530,7 +24530,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -24542,7 +24542,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -24554,7 +24554,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24563,7 +24563,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24572,15 +24572,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24589,7 +24589,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24598,15 +24598,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24615,7 +24615,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24624,7 +24624,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -24636,7 +24636,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -24648,7 +24648,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24657,7 +24657,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24666,15 +24666,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24683,7 +24683,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24692,15 +24692,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24709,7 +24709,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24718,7 +24718,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -24730,7 +24730,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -24742,7 +24742,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24751,7 +24751,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24760,15 +24760,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -24777,7 +24777,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -24786,15 +24786,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24803,7 +24803,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24812,7 +24812,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24824,7 +24824,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24836,7 +24836,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24845,7 +24845,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24854,15 +24854,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24874,7 +24874,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -24886,7 +24886,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24898,7 +24898,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24910,7 +24910,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24919,7 +24919,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24931,7 +24931,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24943,7 +24943,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24955,7 +24955,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24964,7 +24964,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24976,7 +24976,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -24989,7 +24989,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -25003,7 +25003,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -25011,7 +25011,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -25019,7 +25019,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -25028,11 +25028,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_PBE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -25040,27 +25040,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -25070,7 +25070,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_verify_mac"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -25078,7 +25078,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -25093,74 +25093,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PKCS12_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_file_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_egd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_poll"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25261,19 +25261,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_OpenSSL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_get_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RAND_set_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25338,11 +25338,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RC4_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RC4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -25429,11 +25429,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RIPEMD160_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RIPEMD160_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -25441,42 +25441,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RIPEMD160_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_RIPEMD160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_awslc_version_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SIPHASH_24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -25551,15 +25551,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25572,7 +25572,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25587,18 +25587,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25607,14 +25607,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25623,7 +25623,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25634,7 +25634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25643,7 +25643,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25655,7 +25655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -25667,18 +25667,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25686,14 +25686,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25701,7 +25701,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25715,7 +25715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25730,7 +25730,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25743,7 +25743,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25758,7 +25758,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -27466,15 +27466,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_POLICY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_POLICY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27482,26 +27482,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_POLICY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27509,14 +27509,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -27748,15 +27748,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27764,26 +27764,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27791,26 +27791,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27818,29 +27818,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -27848,19 +27848,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27868,18 +27868,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -27887,7 +27887,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27895,15 +27895,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OTHERNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OTHERNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_OTHERNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27911,26 +27911,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_OTHERNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OTHERNAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27938,22 +27938,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OTHERNAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -27961,14 +27961,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -27976,7 +27976,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -27984,14 +27984,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27999,15 +27999,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28015,33 +28015,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28049,26 +28049,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28076,26 +28076,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28103,26 +28103,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_USERNOTICE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_USERNOTICE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28130,26 +28130,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_USERNOTICE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NOTICEREF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NOTICEREF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28157,26 +28157,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NOTICEREF_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28184,26 +28184,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28211,26 +28211,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28238,26 +28238,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28265,38 +28265,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28304,26 +28304,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28331,70 +28331,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28405,7 +28405,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -28413,7 +28413,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28423,7 +28423,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_conf_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -28521,7 +28521,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_set_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -28532,11 +28532,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_set_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28545,7 +28545,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28554,7 +28554,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -28563,7 +28563,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28572,7 +28572,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28581,7 +28581,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28590,7 +28590,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28599,67 +28599,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_parse_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_get_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28668,14 +28668,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -28683,7 +28683,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_add1_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28693,7 +28693,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -28702,7 +28702,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -28711,7 +28711,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -28720,7 +28720,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509V3_extensions_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -28730,11 +28730,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_ca"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -28742,70 +28742,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_supported_extension"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_akid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_extension_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get0_authority_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -28823,43 +28823,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_REQ_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_email_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_get1_ocsp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28869,7 +28869,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28878,7 +28878,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -28887,7 +28887,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_X509_check_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -28895,11 +28895,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_a2i_IPADDRESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -28965,119 +28965,119 @@ impl static_assertion_at_line_255_error_is_max_overheads_are_inconsistent {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLS_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLS_method"]
     pub fn TLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLS_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLS_method"]
     pub fn DTLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLS_with_buffers_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLS_with_buffers_method"]
     pub fn TLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLS_with_buffers_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLS_with_buffers_method"]
     pub fn DTLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_new"]
     pub fn SSL_CTX_new(method: *const SSL_METHOD) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_up_ref"]
     pub fn SSL_CTX_up_ref(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_free"]
     pub fn SSL_CTX_free(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_new"]
     pub fn SSL_new(ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_free"]
     pub fn SSL_free(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_SSL_CTX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_SSL_CTX"]
     pub fn SSL_get_SSL_CTX(ssl: *const SSL) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_connect_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_connect_state"]
     pub fn SSL_set_connect_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_accept_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_accept_state"]
     pub fn SSL_set_accept_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_is_server"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_is_server"]
     pub fn SSL_is_server(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_is_dtls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_is_dtls"]
     pub fn SSL_is_dtls(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_bio"]
     pub fn SSL_set_bio(ssl: *mut SSL, rbio: *mut BIO, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set0_rbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set0_rbio"]
     pub fn SSL_set0_rbio(ssl: *mut SSL, rbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set0_wbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set0_wbio"]
     pub fn SSL_set0_wbio(ssl: *mut SSL, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_rbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_rbio"]
     pub fn SSL_get_rbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_wbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_wbio"]
     pub fn SSL_get_wbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_fd"]
     pub fn SSL_get_fd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_rfd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_rfd"]
     pub fn SSL_get_rfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_wfd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_wfd"]
     pub fn SSL_get_wfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_fd"]
     pub fn SSL_set_fd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_rfd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_rfd"]
     pub fn SSL_set_rfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_wfd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_wfd"]
     pub fn SSL_set_wfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_do_handshake"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_do_handshake"]
     pub fn SSL_do_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_connect"]
     pub fn SSL_connect(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_accept"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_accept"]
     pub fn SSL_accept(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_read"]
     pub fn SSL_read(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -29085,7 +29085,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_peek"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_peek"]
     pub fn SSL_peek(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -29093,15 +29093,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_pending"]
     pub fn SSL_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_has_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_has_pending"]
     pub fn SSL_has_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_write"]
     pub fn SSL_write(
         ssl: *mut SSL,
         buf: *const ::std::os::raw::c_void,
@@ -29109,220 +29109,220 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_key_update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_key_update"]
     pub fn SSL_key_update(
         ssl: *mut SSL,
         request_type: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_shutdown"]
     pub fn SSL_shutdown(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_quiet_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_quiet_shutdown"]
     pub fn SSL_CTX_set_quiet_shutdown(ctx: *mut SSL_CTX, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_quiet_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_quiet_shutdown"]
     pub fn SSL_CTX_get_quiet_shutdown(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_quiet_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_quiet_shutdown"]
     pub fn SSL_set_quiet_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_quiet_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_quiet_shutdown"]
     pub fn SSL_get_quiet_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_error"]
     pub fn SSL_get_error(ssl: *const SSL, ret_code: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_error_description"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_error_description"]
     pub fn SSL_error_description(err: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_mtu"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_mtu"]
     pub fn SSL_set_mtu(ssl: *mut SSL, mtu: ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLSv1_set_initial_timeout_duration"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLSv1_set_initial_timeout_duration"]
     pub fn DTLSv1_set_initial_timeout_duration(ssl: *mut SSL, duration_ms: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLSv1_get_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLSv1_get_timeout"]
     pub fn DTLSv1_get_timeout(ssl: *const SSL, out: *mut timeval) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLSv1_handle_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLSv1_handle_timeout"]
     pub fn DTLSv1_handle_timeout(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_min_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_min_proto_version"]
     pub fn SSL_CTX_set_min_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_max_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_max_proto_version"]
     pub fn SSL_CTX_set_max_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_min_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_min_proto_version"]
     pub fn SSL_CTX_get_min_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_max_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_max_proto_version"]
     pub fn SSL_CTX_get_max_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_min_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_min_proto_version"]
     pub fn SSL_set_min_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_max_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_max_proto_version"]
     pub fn SSL_set_max_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_min_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_min_proto_version"]
     pub fn SSL_get_min_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_max_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_max_proto_version"]
     pub fn SSL_get_max_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_version"]
     pub fn SSL_version(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_options"]
     pub fn SSL_CTX_set_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_clear_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_clear_options"]
     pub fn SSL_CTX_clear_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_options"]
     pub fn SSL_CTX_get_options(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_options"]
     pub fn SSL_set_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_clear_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_clear_options"]
     pub fn SSL_clear_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_options"]
     pub fn SSL_get_options(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_mode"]
     pub fn SSL_CTX_set_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_clear_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_clear_mode"]
     pub fn SSL_CTX_clear_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_mode"]
     pub fn SSL_CTX_get_mode(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_mode"]
     pub fn SSL_set_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_clear_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_clear_mode"]
     pub fn SSL_clear_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_mode"]
     pub fn SSL_get_mode(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set0_buffer_pool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set0_buffer_pool"]
     pub fn SSL_CTX_set0_buffer_pool(ctx: *mut SSL_CTX, pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_certificate"]
     pub fn SSL_CTX_use_certificate(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_use_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_use_certificate"]
     pub fn SSL_use_certificate(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_PrivateKey"]
     pub fn SSL_CTX_use_PrivateKey(ctx: *mut SSL_CTX, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_use_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_use_PrivateKey"]
     pub fn SSL_use_PrivateKey(ssl: *mut SSL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set0_chain"]
     pub fn SSL_CTX_set0_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_chain"]
     pub fn SSL_CTX_set1_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set0_chain"]
     pub fn SSL_set0_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_chain"]
     pub fn SSL_set1_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_add0_chain_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_add0_chain_cert"]
     pub fn SSL_CTX_add0_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_add1_chain_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_add1_chain_cert"]
     pub fn SSL_CTX_add1_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_add0_chain_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_add0_chain_cert"]
     pub fn SSL_add0_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_add_extra_chain_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_add_extra_chain_cert"]
     pub fn SSL_CTX_add_extra_chain_cert(
         ctx: *mut SSL_CTX,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_add1_chain_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_add1_chain_cert"]
     pub fn SSL_add1_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_clear_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_clear_chain_certs"]
     pub fn SSL_CTX_clear_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_clear_extra_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_clear_extra_chain_certs"]
     pub fn SSL_CTX_clear_extra_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_clear_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_clear_chain_certs"]
     pub fn SSL_clear_chain_certs(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_cert_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_cert_cb"]
     pub fn SSL_CTX_set_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -29335,7 +29335,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_cert_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_cert_cb"]
     pub fn SSL_set_cert_cb(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -29348,71 +29348,71 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_certificate_types"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_certificate_types"]
     pub fn SSL_get0_certificate_types(ssl: *const SSL, out_types: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_peer_verify_algorithms"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_peer_verify_algorithms"]
     pub fn SSL_get0_peer_verify_algorithms(ssl: *const SSL, out_sigalgs: *mut *const u16) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_peer_delegation_algorithms"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_peer_delegation_algorithms"]
     pub fn SSL_get0_peer_delegation_algorithms(
         ssl: *const SSL,
         out_sigalgs: *mut *const u16,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_certs_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_certs_clear"]
     pub fn SSL_certs_clear(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_check_private_key"]
     pub fn SSL_CTX_check_private_key(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_check_private_key"]
     pub fn SSL_check_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get0_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get0_certificate"]
     pub fn SSL_CTX_get0_certificate(ctx: *const SSL_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_certificate"]
     pub fn SSL_get_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get0_privatekey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get0_privatekey"]
     pub fn SSL_CTX_get0_privatekey(ctx: *const SSL_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_privatekey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_privatekey"]
     pub fn SSL_get_privatekey(ssl: *const SSL) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get0_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get0_chain_certs"]
     pub fn SSL_CTX_get0_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_extra_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_extra_chain_certs"]
     pub fn SSL_CTX_get_extra_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_chain_certs"]
     pub fn SSL_get0_chain_certs(
         ssl: *const SSL,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_signed_cert_timestamp_list"]
     pub fn SSL_CTX_set_signed_cert_timestamp_list(
         ctx: *mut SSL_CTX,
         list: *const u8,
@@ -29420,7 +29420,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_signed_cert_timestamp_list"]
     pub fn SSL_set_signed_cert_timestamp_list(
         ctx: *mut SSL,
         list: *const u8,
@@ -29428,7 +29428,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_ocsp_response"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_ocsp_response"]
     pub fn SSL_CTX_set_ocsp_response(
         ctx: *mut SSL_CTX,
         response: *const u8,
@@ -29436,7 +29436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_ocsp_response"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_ocsp_response"]
     pub fn SSL_set_ocsp_response(
         ssl: *mut SSL,
         response: *const u8,
@@ -29444,26 +29444,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_signature_algorithm_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_signature_algorithm_name"]
     pub fn SSL_get_signature_algorithm_name(
         sigalg: u16,
         include_curve: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_signature_algorithm_key_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_signature_algorithm_key_type"]
     pub fn SSL_get_signature_algorithm_key_type(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_signature_algorithm_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_signature_algorithm_digest"]
     pub fn SSL_get_signature_algorithm_digest(sigalg: u16) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_is_signature_algorithm_rsa_pss"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_is_signature_algorithm_rsa_pss"]
     pub fn SSL_is_signature_algorithm_rsa_pss(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_signing_algorithm_prefs"]
     pub fn SSL_CTX_set_signing_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -29471,7 +29471,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_signing_algorithm_prefs"]
     pub fn SSL_set_signing_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -29479,7 +29479,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_chain_and_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_chain_and_key"]
     pub fn SSL_CTX_set_chain_and_key(
         ctx: *mut SSL_CTX,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29489,7 +29489,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_chain_and_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_chain_and_key"]
     pub fn SSL_set_chain_and_key(
         ssl: *mut SSL,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29499,19 +29499,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get0_chain"]
     pub fn SSL_CTX_get0_chain(ctx: *const SSL_CTX) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_RSAPrivateKey"]
     pub fn SSL_CTX_use_RSAPrivateKey(ctx: *mut SSL_CTX, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_use_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_use_RSAPrivateKey"]
     pub fn SSL_use_RSAPrivateKey(ssl: *mut SSL, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_certificate_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_certificate_ASN1"]
     pub fn SSL_CTX_use_certificate_ASN1(
         ctx: *mut SSL_CTX,
         der_len: usize,
@@ -29519,7 +29519,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_use_certificate_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_use_certificate_ASN1"]
     pub fn SSL_use_certificate_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29527,7 +29527,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_PrivateKey_ASN1"]
     pub fn SSL_CTX_use_PrivateKey_ASN1(
         pk: ::std::os::raw::c_int,
         ctx: *mut SSL_CTX,
@@ -29536,7 +29536,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_use_PrivateKey_ASN1"]
     pub fn SSL_use_PrivateKey_ASN1(
         type_: ::std::os::raw::c_int,
         ssl: *mut SSL,
@@ -29545,7 +29545,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_RSAPrivateKey_ASN1"]
     pub fn SSL_CTX_use_RSAPrivateKey_ASN1(
         ctx: *mut SSL_CTX,
         der: *const u8,
@@ -29553,7 +29553,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_use_RSAPrivateKey_ASN1"]
     pub fn SSL_use_RSAPrivateKey_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29561,7 +29561,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_RSAPrivateKey_file"]
     pub fn SSL_CTX_use_RSAPrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29569,7 +29569,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_use_RSAPrivateKey_file"]
     pub fn SSL_use_RSAPrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29577,7 +29577,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_certificate_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_certificate_file"]
     pub fn SSL_CTX_use_certificate_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29585,7 +29585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_use_certificate_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_use_certificate_file"]
     pub fn SSL_use_certificate_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29593,7 +29593,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_PrivateKey_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_PrivateKey_file"]
     pub fn SSL_CTX_use_PrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29601,7 +29601,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_use_PrivateKey_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_use_PrivateKey_file"]
     pub fn SSL_use_PrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29609,29 +29609,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_certificate_chain_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_certificate_chain_file"]
     pub fn SSL_CTX_use_certificate_chain_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_default_passwd_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_default_passwd_cb"]
     pub fn SSL_CTX_set_default_passwd_cb(ctx: *mut SSL_CTX, cb: pem_password_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_default_passwd_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_default_passwd_cb"]
     pub fn SSL_CTX_get_default_passwd_cb(ctx: *const SSL_CTX) -> pem_password_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_default_passwd_cb_userdata"]
     pub fn SSL_CTX_set_default_passwd_cb_userdata(
         ctx: *mut SSL_CTX,
         data: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_default_passwd_cb_userdata"]
     pub fn SSL_CTX_get_default_passwd_cb_userdata(
         ctx: *const SSL_CTX,
     ) -> *mut ::std::os::raw::c_void;
@@ -29720,18 +29720,18 @@ fn bindgen_test_layout_ssl_private_key_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_private_key_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_private_key_method"]
     pub fn SSL_set_private_key_method(ssl: *mut SSL, key_method: *const SSL_PRIVATE_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_private_key_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_private_key_method"]
     pub fn SSL_CTX_set_private_key_method(
         ctx: *mut SSL_CTX,
         key_method: *const SSL_PRIVATE_KEY_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_can_release_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_can_release_private_key"]
     pub fn SSL_can_release_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -29756,149 +29756,149 @@ pub type sk_SSL_CIPHER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_cipher_by_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_cipher_by_value"]
     pub fn SSL_get_cipher_by_value(value: u16) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_id"]
     pub fn SSL_CIPHER_get_id(cipher: *const SSL_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_protocol_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_protocol_id"]
     pub fn SSL_CIPHER_get_protocol_id(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_is_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_is_aead"]
     pub fn SSL_CIPHER_is_aead(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_is_block_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_is_block_cipher"]
     pub fn SSL_CIPHER_is_block_cipher(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_cipher_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_cipher_nid"]
     pub fn SSL_CIPHER_get_cipher_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_digest_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_digest_nid"]
     pub fn SSL_CIPHER_get_digest_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_kx_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_kx_nid"]
     pub fn SSL_CIPHER_get_kx_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_auth_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_auth_nid"]
     pub fn SSL_CIPHER_get_auth_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_prf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_prf_nid"]
     pub fn SSL_CIPHER_get_prf_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_min_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_min_version"]
     pub fn SSL_CIPHER_get_min_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_max_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_max_version"]
     pub fn SSL_CIPHER_get_max_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_standard_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_standard_name"]
     pub fn SSL_CIPHER_standard_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_name"]
     pub fn SSL_CIPHER_get_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_kx_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_kx_name"]
     pub fn SSL_CIPHER_get_kx_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_bits"]
     pub fn SSL_CIPHER_get_bits(
         cipher: *const SSL_CIPHER,
         out_alg_bits: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_strict_cipher_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_strict_cipher_list"]
     pub fn SSL_CTX_set_strict_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_cipher_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_cipher_list"]
     pub fn SSL_CTX_set_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_strict_cipher_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_strict_cipher_list"]
     pub fn SSL_set_strict_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_ciphersuites"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_ciphersuites"]
     pub fn SSL_CTX_set_ciphersuites(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_cipher_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_cipher_list"]
     pub fn SSL_set_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_ciphers"]
     pub fn SSL_CTX_get_ciphers(ctx: *const SSL_CTX) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_cipher_in_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_cipher_in_group"]
     pub fn SSL_CTX_cipher_in_group(ctx: *const SSL_CTX, i: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_ciphers"]
     pub fn SSL_get_ciphers(ssl: *const SSL) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_is_init_finished"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_is_init_finished"]
     pub fn SSL_is_init_finished(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_in_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_in_init"]
     pub fn SSL_in_init(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_in_false_start"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_in_false_start"]
     pub fn SSL_in_false_start(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_peer_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_peer_certificate"]
     pub fn SSL_get_peer_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_peer_cert_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_peer_cert_chain"]
     pub fn SSL_get_peer_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_peer_full_cert_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_peer_full_cert_chain"]
     pub fn SSL_get_peer_full_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_peer_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_peer_certificates"]
     pub fn SSL_get0_peer_certificates(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_signed_cert_timestamp_list"]
     pub fn SSL_get0_signed_cert_timestamp_list(
         ssl: *const SSL,
         out: *mut *const u8,
@@ -29906,11 +29906,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_ocsp_response"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_ocsp_response"]
     pub fn SSL_get0_ocsp_response(ssl: *const SSL, out: *mut *const u8, out_len: *mut usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_tls_unique"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_tls_unique"]
     pub fn SSL_get_tls_unique(
         ssl: *const SSL,
         out: *mut u8,
@@ -29919,23 +29919,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_extms_support"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_extms_support"]
     pub fn SSL_get_extms_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_current_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_current_cipher"]
     pub fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_session_reused"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_session_reused"]
     pub fn SSL_session_reused(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_secure_renegotiation_support"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_secure_renegotiation_support"]
     pub fn SSL_get_secure_renegotiation_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_export_keying_material"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_export_keying_material"]
     pub fn SSL_export_keying_material(
         ssl: *mut SSL,
         out: *mut u8,
@@ -29948,7 +29948,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_bio_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_bio_SSL_SESSION"]
     pub fn PEM_read_bio_SSL_SESSION(
         bp: *mut BIO,
         x: *mut *mut SSL_SESSION,
@@ -29957,7 +29957,7 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_read_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_read_SSL_SESSION"]
     pub fn PEM_read_SSL_SESSION(
         fp: *mut FILE,
         x: *mut *mut SSL_SESSION,
@@ -29966,27 +29966,27 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_bio_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_bio_SSL_SESSION"]
     pub fn PEM_write_bio_SSL_SESSION(bp: *mut BIO, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_PEM_write_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_PEM_write_SSL_SESSION"]
     pub fn PEM_write_SSL_SESSION(fp: *mut FILE, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_new"]
     pub fn SSL_SESSION_new(ctx: *const SSL_CTX) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_up_ref"]
     pub fn SSL_SESSION_up_ref(session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_free"]
     pub fn SSL_SESSION_free(session: *mut SSL_SESSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_to_bytes"]
     pub fn SSL_SESSION_to_bytes(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -29994,7 +29994,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_to_bytes_for_ticket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_to_bytes_for_ticket"]
     pub fn SSL_SESSION_to_bytes_for_ticket(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -30002,7 +30002,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_from_bytes"]
     pub fn SSL_SESSION_from_bytes(
         in_: *const u8,
         in_len: usize,
@@ -30010,29 +30010,29 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get_version"]
     pub fn SSL_SESSION_get_version(session: *const SSL_SESSION) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get_protocol_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get_protocol_version"]
     pub fn SSL_SESSION_get_protocol_version(session: *const SSL_SESSION) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_set_protocol_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_set_protocol_version"]
     pub fn SSL_SESSION_set_protocol_version(
         session: *mut SSL_SESSION,
         version: u16,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get_id"]
     pub fn SSL_SESSION_get_id(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_set1_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_set1_id"]
     pub fn SSL_SESSION_set1_id(
         session: *mut SSL_SESSION,
         sid: *const u8,
@@ -30040,25 +30040,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get_time"]
     pub fn SSL_SESSION_get_time(session: *const SSL_SESSION) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get_timeout"]
     pub fn SSL_SESSION_get_timeout(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get0_peer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get0_peer"]
     pub fn SSL_SESSION_get0_peer(session: *const SSL_SESSION) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get0_peer_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get0_peer_certificates"]
     pub fn SSL_SESSION_get0_peer_certificates(
         session: *const SSL_SESSION,
     ) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get0_signed_cert_timestamp_list"]
     pub fn SSL_SESSION_get0_signed_cert_timestamp_list(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -30066,7 +30066,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get0_ocsp_response"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get0_ocsp_response"]
     pub fn SSL_SESSION_get0_ocsp_response(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -30074,7 +30074,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get_master_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get_master_key"]
     pub fn SSL_SESSION_get_master_key(
         session: *const SSL_SESSION,
         out: *mut u8,
@@ -30082,22 +30082,22 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_set_time"]
     pub fn SSL_SESSION_set_time(session: *mut SSL_SESSION, time: u64) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_set_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_set_timeout"]
     pub fn SSL_SESSION_set_timeout(session: *mut SSL_SESSION, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get0_id_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get0_id_context"]
     pub fn SSL_SESSION_get0_id_context(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_set1_id_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_set1_id_context"]
     pub fn SSL_SESSION_set1_id_context(
         session: *mut SSL_SESSION,
         sid_ctx: *const u8,
@@ -30105,19 +30105,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_should_be_single_use"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_should_be_single_use"]
     pub fn SSL_SESSION_should_be_single_use(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_is_resumable"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_is_resumable"]
     pub fn SSL_SESSION_is_resumable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_has_ticket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_has_ticket"]
     pub fn SSL_SESSION_has_ticket(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get0_ticket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get0_ticket"]
     pub fn SSL_SESSION_get0_ticket(
         session: *const SSL_SESSION,
         out_ticket: *mut *const u8,
@@ -30125,7 +30125,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_set_ticket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_set_ticket"]
     pub fn SSL_SESSION_set_ticket(
         session: *mut SSL_SESSION,
         ticket: *const u8,
@@ -30133,19 +30133,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get_ticket_lifetime_hint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get_ticket_lifetime_hint"]
     pub fn SSL_SESSION_get_ticket_lifetime_hint(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get0_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get0_cipher"]
     pub fn SSL_SESSION_get0_cipher(session: *const SSL_SESSION) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_has_peer_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_has_peer_sha256"]
     pub fn SSL_SESSION_has_peer_sha256(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get0_peer_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get0_peer_sha256"]
     pub fn SSL_SESSION_get0_peer_sha256(
         session: *const SSL_SESSION,
         out_ptr: *mut *const u8,
@@ -30153,34 +30153,34 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_session_cache_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_session_cache_mode"]
     pub fn SSL_CTX_set_session_cache_mode(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_session_cache_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_session_cache_mode"]
     pub fn SSL_CTX_get_session_cache_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_session"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_session"]
     pub fn SSL_set_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_timeout"]
     pub fn SSL_CTX_set_timeout(ctx: *mut SSL_CTX, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_session_psk_dhe_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_session_psk_dhe_timeout"]
     pub fn SSL_CTX_set_session_psk_dhe_timeout(ctx: *mut SSL_CTX, timeout: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_timeout"]
     pub fn SSL_CTX_get_timeout(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_session_id_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_session_id_context"]
     pub fn SSL_CTX_set_session_id_context(
         ctx: *mut SSL_CTX,
         sid_ctx: *const u8,
@@ -30188,7 +30188,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_session_id_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_session_id_context"]
     pub fn SSL_set_session_id_context(
         ssl: *mut SSL,
         sid_ctx: *const u8,
@@ -30196,44 +30196,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_session_id_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_session_id_context"]
     pub fn SSL_get0_session_id_context(ssl: *const SSL, out_len: *mut usize) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_set_cache_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_set_cache_size"]
     pub fn SSL_CTX_sess_set_cache_size(
         ctx: *mut SSL_CTX,
         size: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_get_cache_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_get_cache_size"]
     pub fn SSL_CTX_sess_get_cache_size(ctx: *const SSL_CTX) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_number"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_number"]
     pub fn SSL_CTX_sess_number(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_add_session"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_add_session"]
     pub fn SSL_CTX_add_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_remove_session"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_remove_session"]
     pub fn SSL_CTX_remove_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_flush_sessions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_flush_sessions"]
     pub fn SSL_CTX_flush_sessions(ctx: *mut SSL_CTX, time: u64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_set_new_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_set_new_cb"]
     pub fn SSL_CTX_sess_set_new_cb(
         ctx: *mut SSL_CTX,
         new_session_cb: ::std::option::Option<
@@ -30242,7 +30242,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_get_new_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_get_new_cb"]
     pub fn SSL_CTX_sess_get_new_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30250,7 +30250,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_set_remove_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_set_remove_cb"]
     pub fn SSL_CTX_sess_set_remove_cb(
         ctx: *mut SSL_CTX,
         remove_session_cb: ::std::option::Option<
@@ -30259,13 +30259,13 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_get_remove_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_get_remove_cb"]
     pub fn SSL_CTX_sess_get_remove_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<unsafe extern "C" fn(ctx: *mut SSL_CTX, arg1: *mut SSL_SESSION)>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_set_get_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_set_get_cb"]
     pub fn SSL_CTX_sess_set_get_cb(
         ctx: *mut SSL_CTX,
         get_session_cb: ::std::option::Option<
@@ -30279,7 +30279,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_get_get_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_get_get_cb"]
     pub fn SSL_CTX_sess_get_get_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30292,11 +30292,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_magic_pending_session_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_magic_pending_session_ptr"]
     pub fn SSL_magic_pending_session_ptr() -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_tlsext_ticket_keys"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_tlsext_ticket_keys"]
     pub fn SSL_CTX_get_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         out: *mut ::std::os::raw::c_void,
@@ -30304,7 +30304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_ticket_keys"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_ticket_keys"]
     pub fn SSL_CTX_set_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         in_: *const ::std::os::raw::c_void,
@@ -30312,7 +30312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_ticket_key_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_ticket_key_cb"]
     pub fn SSL_CTX_set_tlsext_ticket_key_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30404,14 +30404,14 @@ fn bindgen_test_layout_ssl_ticket_aead_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_ticket_aead_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_ticket_aead_method"]
     pub fn SSL_CTX_set_ticket_aead_method(
         ctx: *mut SSL_CTX,
         aead_method: *const SSL_TICKET_AEAD_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_process_tls13_new_session_ticket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_process_tls13_new_session_ticket"]
     pub fn SSL_process_tls13_new_session_ticket(
         ssl: *mut SSL,
         buf: *const u8,
@@ -30419,15 +30419,15 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_num_tickets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_num_tickets"]
     pub fn SSL_CTX_set_num_tickets(ctx: *mut SSL_CTX, num_tickets: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_num_tickets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_num_tickets"]
     pub fn SSL_CTX_get_num_tickets(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_curves"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_curves"]
     pub fn SSL_CTX_set1_curves(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_int,
@@ -30435,7 +30435,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_curves"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_curves"]
     pub fn SSL_set1_curves(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_int,
@@ -30443,29 +30443,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_curves_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_curves_list"]
     pub fn SSL_CTX_set1_curves_list(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_curves_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_curves_list"]
     pub fn SSL_set1_curves_list(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_curve_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_curve_id"]
     pub fn SSL_get_curve_id(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_curve_name"]
     pub fn SSL_get_curve_name(curve_id: u16) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_to_bytes"]
     pub fn SSL_to_bytes(
         in_: *const SSL,
         out_data: *mut *mut u8,
@@ -30473,11 +30473,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_from_bytes"]
     pub fn SSL_from_bytes(in_: *const u8, in_len: usize, ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_groups"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_groups"]
     pub fn SSL_CTX_set1_groups(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_int,
@@ -30485,7 +30485,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_groups"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_groups"]
     pub fn SSL_set1_groups(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_int,
@@ -30493,21 +30493,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_groups_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_groups_list"]
     pub fn SSL_CTX_set1_groups_list(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_groups_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_groups_list"]
     pub fn SSL_set1_groups_list(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_verify"]
     pub fn SSL_CTX_set_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30520,7 +30520,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_verify"]
     pub fn SSL_set_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30537,7 +30537,7 @@ pub const ssl_verify_result_t_ssl_verify_invalid: ssl_verify_result_t = 1;
 pub const ssl_verify_result_t_ssl_verify_retry: ssl_verify_result_t = 2;
 pub type ssl_verify_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_custom_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_custom_verify"]
     pub fn SSL_CTX_set_custom_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30547,7 +30547,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_custom_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_custom_verify"]
     pub fn SSL_set_custom_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30557,15 +30557,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_verify_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_verify_mode"]
     pub fn SSL_CTX_get_verify_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_verify_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_verify_mode"]
     pub fn SSL_get_verify_mode(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_verify_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_verify_callback"]
     pub fn SSL_CTX_get_verify_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -30576,7 +30576,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_verify_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_verify_callback"]
     pub fn SSL_get_verify_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -30587,83 +30587,83 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_host"]
     pub fn SSL_set1_host(
         ssl: *mut SSL,
         hostname: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_verify_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_verify_depth"]
     pub fn SSL_CTX_set_verify_depth(ctx: *mut SSL_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_verify_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_verify_depth"]
     pub fn SSL_set_verify_depth(ssl: *mut SSL, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_verify_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_verify_depth"]
     pub fn SSL_CTX_get_verify_depth(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_verify_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_verify_depth"]
     pub fn SSL_get_verify_depth(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_param"]
     pub fn SSL_CTX_set1_param(
         ctx: *mut SSL_CTX,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_param"]
     pub fn SSL_set1_param(ssl: *mut SSL, param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get0_param"]
     pub fn SSL_CTX_get0_param(ctx: *mut SSL_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_param"]
     pub fn SSL_get0_param(ssl: *mut SSL) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_purpose"]
     pub fn SSL_CTX_set_purpose(
         ctx: *mut SSL_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_purpose"]
     pub fn SSL_set_purpose(ssl: *mut SSL, purpose: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_trust"]
     pub fn SSL_CTX_set_trust(
         ctx: *mut SSL_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_trust"]
     pub fn SSL_set_trust(ssl: *mut SSL, trust: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_cert_store"]
     pub fn SSL_CTX_set_cert_store(ctx: *mut SSL_CTX, store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_cert_store"]
     pub fn SSL_CTX_get_cert_store(ctx: *const SSL_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_default_verify_paths"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_default_verify_paths"]
     pub fn SSL_CTX_set_default_verify_paths(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_load_verify_locations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_load_verify_locations"]
     pub fn SSL_CTX_load_verify_locations(
         ctx: *mut SSL_CTX,
         ca_file: *const ::std::os::raw::c_char,
@@ -30671,19 +30671,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_verify_result"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_verify_result"]
     pub fn SSL_get_verify_result(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_alert_from_verify_result"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_alert_from_verify_result"]
     pub fn SSL_alert_from_verify_result(result: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_ex_data_X509_STORE_CTX_idx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_ex_data_X509_STORE_CTX_idx"]
     pub fn SSL_get_ex_data_X509_STORE_CTX_idx() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_cert_verify_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_cert_verify_callback"]
     pub fn SSL_CTX_set_cert_verify_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30696,51 +30696,51 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_enable_signed_cert_timestamps"]
     pub fn SSL_enable_signed_cert_timestamps(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_enable_signed_cert_timestamps"]
     pub fn SSL_CTX_enable_signed_cert_timestamps(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_enable_ocsp_stapling"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_enable_ocsp_stapling"]
     pub fn SSL_enable_ocsp_stapling(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_enable_ocsp_stapling"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_enable_ocsp_stapling"]
     pub fn SSL_CTX_enable_ocsp_stapling(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set0_verify_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set0_verify_cert_store"]
     pub fn SSL_CTX_set0_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_verify_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_verify_cert_store"]
     pub fn SSL_CTX_set1_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set0_verify_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set0_verify_cert_store"]
     pub fn SSL_set0_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_verify_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_verify_cert_store"]
     pub fn SSL_set1_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_verify_algorithm_prefs"]
     pub fn SSL_CTX_set_verify_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -30748,7 +30748,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_verify_algorithm_prefs"]
     pub fn SSL_set_verify_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -30756,87 +30756,87 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_hostflags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_hostflags"]
     pub fn SSL_set_hostflags(ssl: *mut SSL, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_client_CA_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_client_CA_list"]
     pub fn SSL_set_client_CA_list(ssl: *mut SSL, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_client_CA_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_client_CA_list"]
     pub fn SSL_CTX_set_client_CA_list(ctx: *mut SSL_CTX, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set0_client_CAs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set0_client_CAs"]
     pub fn SSL_set0_client_CAs(ssl: *mut SSL, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set0_client_CAs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set0_client_CAs"]
     pub fn SSL_CTX_set0_client_CAs(ctx: *mut SSL_CTX, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_client_CA_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_client_CA_list"]
     pub fn SSL_get_client_CA_list(ssl: *const SSL) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_server_requested_CAs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_server_requested_CAs"]
     pub fn SSL_get0_server_requested_CAs(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_client_CA_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_client_CA_list"]
     pub fn SSL_CTX_get_client_CA_list(ctx: *const SSL_CTX) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_add_client_CA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_add_client_CA"]
     pub fn SSL_add_client_CA(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_add_client_CA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_add_client_CA"]
     pub fn SSL_CTX_add_client_CA(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_load_client_CA_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_load_client_CA_file"]
     pub fn SSL_load_client_CA_file(file: *const ::std::os::raw::c_char) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_dup_CA_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_dup_CA_list"]
     pub fn SSL_dup_CA_list(list: *mut stack_st_X509_NAME) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_add_file_cert_subjects_to_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_add_file_cert_subjects_to_stack"]
     pub fn SSL_add_file_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_add_bio_cert_subjects_to_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_add_bio_cert_subjects_to_stack"]
     pub fn SSL_add_bio_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_tlsext_host_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_tlsext_host_name"]
     pub fn SSL_set_tlsext_host_name(
         ssl: *mut SSL,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_servername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_servername"]
     pub fn SSL_get_servername(
         ssl: *const SSL,
         type_: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_servername_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_servername_type"]
     pub fn SSL_get_servername_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_servername_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_servername_callback"]
     pub fn SSL_CTX_set_tlsext_servername_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30849,18 +30849,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_servername_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_servername_arg"]
     pub fn SSL_CTX_set_tlsext_servername_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_SSL_CTX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_SSL_CTX"]
     pub fn SSL_set_SSL_CTX(ssl: *mut SSL, ctx: *mut SSL_CTX) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_alpn_protos"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_alpn_protos"]
     pub fn SSL_CTX_set_alpn_protos(
         ctx: *mut SSL_CTX,
         protos: *const u8,
@@ -30868,7 +30868,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_alpn_protos"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_alpn_protos"]
     pub fn SSL_set_alpn_protos(
         ssl: *mut SSL,
         protos: *const u8,
@@ -30876,7 +30876,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_alpn_select_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_alpn_select_cb"]
     pub fn SSL_CTX_set_alpn_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30893,7 +30893,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_alpn_selected"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_alpn_selected"]
     pub fn SSL_get0_alpn_selected(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30901,11 +30901,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_allow_unknown_alpn_protos"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_allow_unknown_alpn_protos"]
     pub fn SSL_CTX_set_allow_unknown_alpn_protos(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_add_application_settings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_add_application_settings"]
     pub fn SSL_add_application_settings(
         ssl: *mut SSL,
         proto: *const u8,
@@ -30915,7 +30915,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_peer_application_settings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_peer_application_settings"]
     pub fn SSL_get0_peer_application_settings(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30923,7 +30923,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_has_application_settings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_has_application_settings"]
     pub fn SSL_has_application_settings(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub type ssl_cert_compression_func_t = ::std::option::Option<
@@ -30944,7 +30944,7 @@ pub type ssl_cert_decompression_func_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_add_cert_compression_alg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_add_cert_compression_alg"]
     pub fn SSL_CTX_add_cert_compression_alg(
         ctx: *mut SSL_CTX,
         alg_id: u16,
@@ -30953,7 +30953,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_next_protos_advertised_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_next_protos_advertised_cb"]
     pub fn SSL_CTX_set_next_protos_advertised_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30968,7 +30968,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_next_proto_select_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_next_proto_select_cb"]
     pub fn SSL_CTX_set_next_proto_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30985,7 +30985,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_next_proto_negotiated"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_next_proto_negotiated"]
     pub fn SSL_get0_next_proto_negotiated(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30993,7 +30993,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_select_next_proto"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_select_next_proto"]
     pub fn SSL_select_next_proto(
         out: *mut *mut u8,
         out_len: *mut u8,
@@ -31004,29 +31004,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tls_channel_id_enabled"]
     pub fn SSL_CTX_set_tls_channel_id_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_tls_channel_id_enabled"]
     pub fn SSL_set_tls_channel_id_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_tls_channel_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_tls_channel_id"]
     pub fn SSL_CTX_set1_tls_channel_id(
         ctx: *mut SSL_CTX,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_tls_channel_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_tls_channel_id"]
     pub fn SSL_set1_tls_channel_id(
         ssl: *mut SSL,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_tls_channel_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_tls_channel_id"]
     pub fn SSL_get_tls_channel_id(ssl: *mut SSL, out: *mut u8, max_out: usize) -> usize;
 }
 #[repr(C)]
@@ -31103,29 +31103,29 @@ pub type sk_SRTP_PROTECTION_PROFILE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_srtp_profiles"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_srtp_profiles"]
     pub fn SSL_CTX_set_srtp_profiles(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_srtp_profiles"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_srtp_profiles"]
     pub fn SSL_set_srtp_profiles(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_srtp_profiles"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_srtp_profiles"]
     pub fn SSL_get_srtp_profiles(ssl: *const SSL) -> *const stack_st_SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_selected_srtp_profile"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_selected_srtp_profile"]
     pub fn SSL_get_selected_srtp_profile(ssl: *mut SSL) -> *const SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_psk_client_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_psk_client_callback"]
     pub fn SSL_CTX_set_psk_client_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31141,7 +31141,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_psk_client_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_psk_client_callback"]
     pub fn SSL_set_psk_client_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31157,7 +31157,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_psk_server_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_psk_server_callback"]
     pub fn SSL_CTX_set_psk_server_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31171,7 +31171,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_psk_server_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_psk_server_callback"]
     pub fn SSL_set_psk_server_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31185,29 +31185,29 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_use_psk_identity_hint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_use_psk_identity_hint"]
     pub fn SSL_CTX_use_psk_identity_hint(
         ctx: *mut SSL_CTX,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_use_psk_identity_hint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_use_psk_identity_hint"]
     pub fn SSL_use_psk_identity_hint(
         ssl: *mut SSL,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_psk_identity_hint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_psk_identity_hint"]
     pub fn SSL_get_psk_identity_hint(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_psk_identity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_psk_identity"]
     pub fn SSL_get_psk_identity(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_delegated_credential"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_delegated_credential"]
     pub fn SSL_set1_delegated_credential(
         ssl: *mut SSL,
         dc: *mut CRYPTO_BUFFER,
@@ -31216,7 +31216,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_delegated_credential_used"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_delegated_credential_used"]
     pub fn SSL_delegated_credential_used(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub const ssl_encryption_level_t_ssl_encryption_initial: ssl_encryption_level_t = 0;
@@ -31329,22 +31329,22 @@ fn bindgen_test_layout_ssl_quic_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_quic_max_handshake_flight_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_quic_max_handshake_flight_len"]
     pub fn SSL_quic_max_handshake_flight_len(
         ssl: *const SSL,
         level: ssl_encryption_level_t,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_quic_read_level"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_quic_read_level"]
     pub fn SSL_quic_read_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_quic_write_level"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_quic_write_level"]
     pub fn SSL_quic_write_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_provide_quic_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_provide_quic_data"]
     pub fn SSL_provide_quic_data(
         ssl: *mut SSL,
         level: ssl_encryption_level_t,
@@ -31353,25 +31353,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_process_quic_post_handshake"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_process_quic_post_handshake"]
     pub fn SSL_process_quic_post_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_quic_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_quic_method"]
     pub fn SSL_CTX_set_quic_method(
         ctx: *mut SSL_CTX,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_quic_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_quic_method"]
     pub fn SSL_set_quic_method(
         ssl: *mut SSL,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_quic_transport_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_quic_transport_params"]
     pub fn SSL_set_quic_transport_params(
         ssl: *mut SSL,
         params: *const u8,
@@ -31379,7 +31379,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_peer_quic_transport_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_peer_quic_transport_params"]
     pub fn SSL_get_peer_quic_transport_params(
         ssl: *const SSL,
         out_params: *mut *const u8,
@@ -31387,11 +31387,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_quic_use_legacy_codepoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_quic_use_legacy_codepoint"]
     pub fn SSL_set_quic_use_legacy_codepoint(ssl: *mut SSL, use_legacy: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_quic_early_data_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_quic_early_data_context"]
     pub fn SSL_set_quic_early_data_context(
         ssl: *mut SSL,
         context: *const u8,
@@ -31399,35 +31399,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_early_data_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_early_data_enabled"]
     pub fn SSL_CTX_set_early_data_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_early_data_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_early_data_enabled"]
     pub fn SSL_set_early_data_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_in_early_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_in_early_data"]
     pub fn SSL_in_early_data(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_early_data_capable"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_early_data_capable"]
     pub fn SSL_SESSION_early_data_capable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_copy_without_early_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_copy_without_early_data"]
     pub fn SSL_SESSION_copy_without_early_data(session: *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_early_data_accepted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_early_data_accepted"]
     pub fn SSL_early_data_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_reset_early_data_reject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_reset_early_data_reject"]
     pub fn SSL_reset_early_data_reject(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_ticket_age_skew"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_ticket_age_skew"]
     pub fn SSL_get_ticket_age_skew(ssl: *const SSL) -> i32;
 }
 pub const ssl_early_data_reason_t_ssl_early_data_unknown: ssl_early_data_reason_t = 0;
@@ -31449,21 +31449,21 @@ pub const ssl_early_data_reason_t_ssl_early_data_alps_mismatch: ssl_early_data_r
 pub const ssl_early_data_reason_t_ssl_early_data_reason_max_value: ssl_early_data_reason_t = 14;
 pub type ssl_early_data_reason_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_early_data_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_early_data_reason"]
     pub fn SSL_get_early_data_reason(ssl: *const SSL) -> ssl_early_data_reason_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_early_data_reason_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_early_data_reason_string"]
     pub fn SSL_early_data_reason_string(
         reason: ssl_early_data_reason_t,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_enable_ech_grease"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_enable_ech_grease"]
     pub fn SSL_set_enable_ech_grease(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_ech_config_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_ech_config_list"]
     pub fn SSL_set1_ech_config_list(
         ssl: *mut SSL,
         ech_config_list: *const u8,
@@ -31471,7 +31471,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_ech_name_override"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_ech_name_override"]
     pub fn SSL_get0_ech_name_override(
         ssl: *const SSL,
         out_name: *mut *const ::std::os::raw::c_char,
@@ -31479,7 +31479,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get0_ech_retry_configs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get0_ech_retry_configs"]
     pub fn SSL_get0_ech_retry_configs(
         ssl: *const SSL,
         out_retry_configs: *mut *const u8,
@@ -31487,7 +31487,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_marshal_ech_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_marshal_ech_config"]
     pub fn SSL_marshal_ech_config(
         out: *mut *mut u8,
         out_len: *mut usize,
@@ -31498,19 +31498,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_ECH_KEYS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_ECH_KEYS_new"]
     pub fn SSL_ECH_KEYS_new() -> *mut SSL_ECH_KEYS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_ECH_KEYS_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_ECH_KEYS_up_ref"]
     pub fn SSL_ECH_KEYS_up_ref(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_ECH_KEYS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_ECH_KEYS_free"]
     pub fn SSL_ECH_KEYS_free(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_ECH_KEYS_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_ECH_KEYS_add"]
     pub fn SSL_ECH_KEYS_add(
         keys: *mut SSL_ECH_KEYS,
         is_retry_config: ::std::os::raw::c_int,
@@ -31520,12 +31520,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_ECH_KEYS_has_duplicate_config_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_ECH_KEYS_has_duplicate_config_id"]
     pub fn SSL_ECH_KEYS_has_duplicate_config_id(keys: *const SSL_ECH_KEYS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_ECH_KEYS_marshal_retry_configs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_ECH_KEYS_marshal_retry_configs"]
     pub fn SSL_ECH_KEYS_marshal_retry_configs(
         keys: *const SSL_ECH_KEYS,
         out: *mut *mut u8,
@@ -31533,34 +31533,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_ech_keys"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_ech_keys"]
     pub fn SSL_CTX_set1_ech_keys(
         ctx: *mut SSL_CTX,
         keys: *mut SSL_ECH_KEYS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_ech_accepted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_ech_accepted"]
     pub fn SSL_ech_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_alert_type_string_long"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_alert_type_string_long"]
     pub fn SSL_alert_type_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_alert_desc_string_long"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_alert_desc_string_long"]
     pub fn SSL_alert_desc_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_send_fatal_alert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_send_fatal_alert"]
     pub fn SSL_send_fatal_alert(ssl: *mut SSL, alert: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_ex_data"]
     pub fn SSL_set_ex_data(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -31568,14 +31568,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_ex_data"]
     pub fn SSL_get_ex_data(
         ssl: *const SSL,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_ex_new_index"]
     pub fn SSL_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31585,7 +31585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_set_ex_data"]
     pub fn SSL_SESSION_set_ex_data(
         session: *mut SSL_SESSION,
         idx: ::std::os::raw::c_int,
@@ -31593,14 +31593,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get_ex_data"]
     pub fn SSL_SESSION_get_ex_data(
         session: *const SSL_SESSION,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_SESSION_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_SESSION_get_ex_new_index"]
     pub fn SSL_SESSION_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31610,7 +31610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_ex_data"]
     pub fn SSL_CTX_set_ex_data(
         ctx: *mut SSL_CTX,
         idx: ::std::os::raw::c_int,
@@ -31618,14 +31618,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_ex_data"]
     pub fn SSL_CTX_get_ex_data(
         ctx: *const SSL_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_ex_new_index"]
     pub fn SSL_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31635,7 +31635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_ivs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_ivs"]
     pub fn SSL_get_ivs(
         ssl: *const SSL,
         out_read_iv: *mut *const u8,
@@ -31644,11 +31644,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_key_block_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_key_block_len"]
     pub fn SSL_get_key_block_len(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_generate_key_block"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_generate_key_block"]
     pub fn SSL_generate_key_block(
         ssl: *const SSL,
         out: *mut u8,
@@ -31656,26 +31656,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_read_sequence"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_read_sequence"]
     pub fn SSL_get_read_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_write_sequence"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_write_sequence"]
     pub fn SSL_get_write_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_record_protocol_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_record_protocol_version"]
     pub fn SSL_CTX_set_record_protocol_version(
         ctx: *mut SSL_CTX,
         version: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_serialize_capabilities"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_serialize_capabilities"]
     pub fn SSL_serialize_capabilities(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_request_handshake_hints"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_request_handshake_hints"]
     pub fn SSL_request_handshake_hints(
         ssl: *mut SSL,
         client_hello: *const u8,
@@ -31685,11 +31685,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_serialize_handshake_hints"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_serialize_handshake_hints"]
     pub fn SSL_serialize_handshake_hints(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_handshake_hints"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_handshake_hints"]
     pub fn SSL_set_handshake_hints(
         ssl: *mut SSL,
         hints: *const u8,
@@ -31697,7 +31697,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_msg_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_msg_callback"]
     pub fn SSL_CTX_set_msg_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31714,11 +31714,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_msg_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_msg_callback_arg"]
     pub fn SSL_CTX_set_msg_callback_arg(ctx: *mut SSL_CTX, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_msg_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_msg_callback"]
     pub fn SSL_set_msg_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31735,11 +31735,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_msg_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_msg_callback_arg"]
     pub fn SSL_set_msg_callback_arg(ssl: *mut SSL, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_keylog_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_keylog_callback"]
     pub fn SSL_CTX_set_keylog_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31748,7 +31748,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_keylog_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_keylog_callback"]
     pub fn SSL_CTX_get_keylog_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -31756,14 +31756,14 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_current_time_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_current_time_cb"]
     pub fn SSL_CTX_set_current_time_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<unsafe extern "C" fn(ssl: *const SSL, out_clock: *mut timeval)>,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_shed_handshake_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_shed_handshake_config"]
     pub fn SSL_set_shed_handshake_config(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_never: ssl_renegotiate_mode_t = 0;
@@ -31773,46 +31773,46 @@ pub const ssl_renegotiate_mode_t_ssl_renegotiate_ignore: ssl_renegotiate_mode_t 
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_explicit: ssl_renegotiate_mode_t = 4;
 pub type ssl_renegotiate_mode_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_renegotiate_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_renegotiate_mode"]
     pub fn SSL_set_renegotiate_mode(ssl: *mut SSL, mode: ssl_renegotiate_mode_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_renegotiate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_renegotiate"]
     pub fn SSL_renegotiate(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_renegotiate_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_renegotiate_pending"]
     pub fn SSL_renegotiate_pending(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_total_renegotiations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_total_renegotiations"]
     pub fn SSL_total_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_max_cert_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_max_cert_list"]
     pub fn SSL_CTX_get_max_cert_list(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_max_cert_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_max_cert_list"]
     pub fn SSL_CTX_set_max_cert_list(ctx: *mut SSL_CTX, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_max_cert_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_max_cert_list"]
     pub fn SSL_get_max_cert_list(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_max_cert_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_max_cert_list"]
     pub fn SSL_set_max_cert_list(ssl: *mut SSL, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_max_send_fragment"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_max_send_fragment"]
     pub fn SSL_CTX_set_max_send_fragment(
         ctx: *mut SSL_CTX,
         max_send_fragment: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_max_send_fragment"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_max_send_fragment"]
     pub fn SSL_set_max_send_fragment(
         ssl: *mut SSL,
         max_send_fragment: usize,
@@ -32006,7 +32006,7 @@ pub const ssl_select_cert_result_t_ssl_select_cert_retry: ssl_select_cert_result
 pub const ssl_select_cert_result_t_ssl_select_cert_error: ssl_select_cert_result_t = -1;
 pub type ssl_select_cert_result_t = ::std::os::raw::c_int;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_early_callback_ctx_extension_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_early_callback_ctx_extension_get"]
     pub fn SSL_early_callback_ctx_extension_get(
         client_hello: *const SSL_CLIENT_HELLO,
         extension_type: u16,
@@ -32015,7 +32015,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_select_certificate_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_select_certificate_cb"]
     pub fn SSL_CTX_set_select_certificate_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32024,7 +32024,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_dos_protection_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_dos_protection_cb"]
     pub fn SSL_CTX_set_dos_protection_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32033,19 +32033,19 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_reverify_on_resume"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_reverify_on_resume"]
     pub fn SSL_CTX_set_reverify_on_resume(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_enforce_rsa_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_enforce_rsa_key_usage"]
     pub fn SSL_set_enforce_rsa_key_usage(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_was_key_usage_invalid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_was_key_usage_invalid"]
     pub fn SSL_was_key_usage_invalid(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_info_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_info_callback"]
     pub fn SSL_CTX_set_info_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32058,7 +32058,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_info_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_info_callback"]
     pub fn SSL_CTX_get_info_callback(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -32070,7 +32070,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_info_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_info_callback"]
     pub fn SSL_set_info_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32083,7 +32083,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_info_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_info_callback"]
     pub fn SSL_get_info_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -32095,77 +32095,77 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_state_string_long"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_state_string_long"]
     pub fn SSL_state_string_long(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_shutdown"]
     pub fn SSL_get_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_peer_signature_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_peer_signature_algorithm"]
     pub fn SSL_get_peer_signature_algorithm(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_client_random"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_client_random"]
     pub fn SSL_get_client_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_server_random"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_server_random"]
     pub fn SSL_get_server_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_pending_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_pending_cipher"]
     pub fn SSL_get_pending_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_set_retain_only_sha256_of_client_certs(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_CTX_set_retain_only_sha256_of_client_certs(
         ctx: *mut SSL_CTX,
         enable: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_grease_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_grease_enabled"]
     pub fn SSL_CTX_set_grease_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_permute_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_permute_extensions"]
     pub fn SSL_CTX_set_permute_extensions(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_permute_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_permute_extensions"]
     pub fn SSL_set_permute_extensions(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_max_seal_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_max_seal_overhead"]
     pub fn SSL_max_seal_overhead(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_false_start_allowed_without_alpn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_false_start_allowed_without_alpn"]
     pub fn SSL_CTX_set_false_start_allowed_without_alpn(
         ctx: *mut SSL_CTX,
         allowed: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_used_hello_retry_request"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_used_hello_retry_request"]
     pub fn SSL_used_hello_retry_request(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_jdk11_workaround"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_jdk11_workaround"]
     pub fn SSL_set_jdk11_workaround(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_library_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_library_init"]
     pub fn SSL_library_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_description"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_description"]
     pub fn SSL_CIPHER_description(
         cipher: *const SSL_CIPHER,
         buf: *mut ::std::os::raw::c_char,
@@ -32173,11 +32173,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_version"]
     pub fn SSL_CIPHER_get_version(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_rfc_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_rfc_name"]
     pub fn SSL_CIPHER_get_rfc_name(cipher: *const SSL_CIPHER) -> *mut ::std::os::raw::c_char;
 }
 pub type COMP_METHOD = ::std::os::raw::c_void;
@@ -32188,126 +32188,126 @@ pub struct stack_st_SSL_COMP {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_COMP_get_compression_methods"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_COMP_get_compression_methods"]
     pub fn SSL_COMP_get_compression_methods() -> *mut stack_st_SSL_COMP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_COMP_add_compression_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_COMP_add_compression_method"]
     pub fn SSL_COMP_add_compression_method(
         id: ::std::os::raw::c_int,
         cm: *mut COMP_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_COMP_get_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_COMP_get_name"]
     pub fn SSL_COMP_get_name(comp: *const COMP_METHOD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_COMP_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_COMP_get0_name"]
     pub fn SSL_COMP_get0_name(comp: *const SSL_COMP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_COMP_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_COMP_get_id"]
     pub fn SSL_COMP_get_id(comp: *const SSL_COMP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_COMP_free_compression_methods"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_COMP_free_compression_methods"]
     pub fn SSL_COMP_free_compression_methods();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSLv23_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSLv23_method"]
     pub fn SSLv23_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLSv1_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLSv1_method"]
     pub fn TLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLSv1_1_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLSv1_1_method"]
     pub fn TLSv1_1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLSv1_2_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLSv1_2_method"]
     pub fn TLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLSv1_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLSv1_method"]
     pub fn DTLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLSv1_2_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLSv1_2_method"]
     pub fn DTLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLS_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLS_server_method"]
     pub fn TLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLS_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLS_client_method"]
     pub fn TLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSLv23_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSLv23_server_method"]
     pub fn SSLv23_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSLv23_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSLv23_client_method"]
     pub fn SSLv23_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLSv1_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLSv1_server_method"]
     pub fn TLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLSv1_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLSv1_client_method"]
     pub fn TLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLSv1_1_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLSv1_1_server_method"]
     pub fn TLSv1_1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLSv1_1_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLSv1_1_client_method"]
     pub fn TLSv1_1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLSv1_2_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLSv1_2_server_method"]
     pub fn TLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_TLSv1_2_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_TLSv1_2_client_method"]
     pub fn TLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLS_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLS_server_method"]
     pub fn DTLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLS_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLS_client_method"]
     pub fn DTLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLSv1_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLSv1_server_method"]
     pub fn DTLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLSv1_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLSv1_client_method"]
     pub fn DTLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLSv1_2_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLSv1_2_server_method"]
     pub fn DTLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_DTLSv1_2_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_DTLSv1_2_client_method"]
     pub fn DTLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_clear"]
     pub fn SSL_clear(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tmp_rsa_callback"]
     pub fn SSL_CTX_set_tmp_rsa_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32320,7 +32320,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_tmp_rsa_callback"]
     pub fn SSL_set_tmp_rsa_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32333,98 +32333,98 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_connect"]
     pub fn SSL_CTX_sess_connect(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_connect_good"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_connect_good"]
     pub fn SSL_CTX_sess_connect_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_connect_renegotiate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_connect_renegotiate"]
     pub fn SSL_CTX_sess_connect_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_accept"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_accept"]
     pub fn SSL_CTX_sess_accept(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_accept_renegotiate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_accept_renegotiate"]
     pub fn SSL_CTX_sess_accept_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_accept_good"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_accept_good"]
     pub fn SSL_CTX_sess_accept_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_hits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_hits"]
     pub fn SSL_CTX_sess_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_cb_hits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_cb_hits"]
     pub fn SSL_CTX_sess_cb_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_misses"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_misses"]
     pub fn SSL_CTX_sess_misses(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_timeouts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_timeouts"]
     pub fn SSL_CTX_sess_timeouts(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_sess_cache_full"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_sess_cache_full"]
     pub fn SSL_CTX_sess_cache_full(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_cutthrough_complete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_cutthrough_complete"]
     pub fn SSL_cutthrough_complete(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_num_renegotiations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_num_renegotiations"]
     pub fn SSL_num_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_need_tmp_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_need_tmp_RSA"]
     pub fn SSL_CTX_need_tmp_RSA(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_need_tmp_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_need_tmp_RSA"]
     pub fn SSL_need_tmp_RSA(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tmp_rsa"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tmp_rsa"]
     pub fn SSL_CTX_set_tmp_rsa(ctx: *mut SSL_CTX, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_tmp_rsa"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_tmp_rsa"]
     pub fn SSL_set_tmp_rsa(ssl: *mut SSL, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_read_ahead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_read_ahead"]
     pub fn SSL_CTX_get_read_ahead(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_read_ahead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_read_ahead"]
     pub fn SSL_CTX_set_read_ahead(
         ctx: *mut SSL_CTX,
         yes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_read_ahead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_read_ahead"]
     pub fn SSL_get_read_ahead(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_read_ahead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_read_ahead"]
     pub fn SSL_set_read_ahead(ssl: *mut SSL, yes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_state"]
     pub fn SSL_set_state(ssl: *mut SSL, state: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_shared_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_shared_ciphers"]
     pub fn SSL_get_shared_ciphers(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_char,
@@ -32432,7 +32432,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_shared_sigalgs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_shared_sigalgs"]
     pub fn SSL_get_shared_sigalgs(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -32444,11 +32444,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_SSL_SESSION"]
     pub fn i2d_SSL_SESSION(in_: *mut SSL_SESSION, pp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_SSL_SESSION"]
     pub fn d2i_SSL_SESSION(
         a: *mut *mut SSL_SESSION,
         pp: *mut *const u8,
@@ -32456,61 +32456,61 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_i2d_SSL_SESSION_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_i2d_SSL_SESSION_bio"]
     pub fn i2d_SSL_SESSION_bio(bio: *mut BIO, session: *const SSL_SESSION)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_d2i_SSL_SESSION_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_d2i_SSL_SESSION_bio"]
     pub fn d2i_SSL_SESSION_bio(bio: *mut BIO, out: *mut *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_ERR_load_SSL_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_ERR_load_SSL_strings"]
     pub fn ERR_load_SSL_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_load_error_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_load_error_strings"]
     pub fn SSL_load_error_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_use_srtp"]
     pub fn SSL_CTX_set_tlsext_use_srtp(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_tlsext_use_srtp"]
     pub fn SSL_set_tlsext_use_srtp(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_current_compression"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_current_compression"]
     pub fn SSL_get_current_compression(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_current_expansion"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_current_expansion"]
     pub fn SSL_get_current_expansion(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_server_tmp_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_server_tmp_key"]
     pub fn SSL_get_server_tmp_key(
         ssl: *mut SSL,
         out_key: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tmp_dh"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tmp_dh"]
     pub fn SSL_CTX_set_tmp_dh(ctx: *mut SSL_CTX, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_tmp_dh"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_tmp_dh"]
     pub fn SSL_set_tmp_dh(ssl: *mut SSL, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tmp_dh_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tmp_dh_callback"]
     pub fn SSL_CTX_set_tmp_dh_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32523,7 +32523,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_tmp_dh_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_tmp_dh_callback"]
     pub fn SSL_set_tmp_dh_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32536,7 +32536,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_sigalgs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_sigalgs"]
     pub fn SSL_CTX_set1_sigalgs(
         ctx: *mut SSL_CTX,
         values: *const ::std::os::raw::c_int,
@@ -32544,7 +32544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_sigalgs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_sigalgs"]
     pub fn SSL_set1_sigalgs(
         ssl: *mut SSL,
         values: *const ::std::os::raw::c_int,
@@ -32552,25 +32552,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set1_sigalgs_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set1_sigalgs_list"]
     pub fn SSL_CTX_set1_sigalgs_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set1_sigalgs_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set1_sigalgs_list"]
     pub fn SSL_set1_sigalgs_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_get_security_level"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_get_security_level"]
     pub fn SSL_CTX_get_security_level(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_security_level"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_security_level"]
     pub fn SSL_CTX_set_security_level(ctx: *const SSL_CTX, level: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -32650,26 +32650,26 @@ pub type sk_SSL_COMP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_cache_hit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_cache_hit"]
     pub fn SSL_cache_hit(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_default_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_default_timeout"]
     pub fn SSL_get_default_timeout(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_version"]
     pub fn SSL_get_version(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_cipher_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_cipher_list"]
     pub fn SSL_get_cipher_list(
         ssl: *const SSL,
         n: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_client_cert_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_client_cert_cb"]
     pub fn SSL_CTX_set_client_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32682,11 +32682,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_want"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_want"]
     pub fn SSL_want(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_finished"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_finished"]
     pub fn SSL_get_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32694,7 +32694,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_peer_finished"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_peer_finished"]
     pub fn SSL_get_peer_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32702,15 +32702,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_alert_type_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_alert_type_string"]
     pub fn SSL_alert_type_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_alert_desc_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_alert_desc_string"]
     pub fn SSL_alert_desc_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_state_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_state_string"]
     pub fn SSL_state_string(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 #[repr(C)]
@@ -32720,42 +32720,42 @@ pub struct ssl_conf_ctx_st {
 }
 pub type SSL_CONF_CTX = ssl_conf_ctx_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_state"]
     pub fn SSL_state(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_shutdown"]
     pub fn SSL_set_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tmp_ecdh"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tmp_ecdh"]
     pub fn SSL_CTX_set_tmp_ecdh(ctx: *mut SSL_CTX, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_tmp_ecdh"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_tmp_ecdh"]
     pub fn SSL_set_tmp_ecdh(ssl: *mut SSL, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_add_dir_cert_subjects_to_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_add_dir_cert_subjects_to_stack"]
     pub fn SSL_add_dir_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         dir: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_enable_tls_channel_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_enable_tls_channel_id"]
     pub fn SSL_CTX_enable_tls_channel_id(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_enable_tls_channel_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_enable_tls_channel_id"]
     pub fn SSL_enable_tls_channel_id(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_f_ssl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_f_ssl"]
     pub fn BIO_f_ssl() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_BIO_set_ssl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_BIO_set_ssl"]
     pub fn BIO_set_ssl(
         bio: *mut BIO,
         ssl: *mut SSL,
@@ -32763,33 +32763,33 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_session"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_session"]
     pub fn SSL_get_session(ssl: *const SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get1_session"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get1_session"]
     pub fn SSL_get1_session(ssl: *mut SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_OPENSSL_init_ssl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_OPENSSL_init_ssl"]
     pub fn OPENSSL_init_ssl(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_tlsext_status_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_tlsext_status_type"]
     pub fn SSL_set_tlsext_status_type(
         ssl: *mut SSL,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_tlsext_status_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_tlsext_status_type"]
     pub fn SSL_get_tlsext_status_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_set_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_set_tlsext_status_ocsp_resp"]
     pub fn SSL_set_tlsext_status_ocsp_resp(
         ssl: *mut SSL,
         resp: *mut u8,
@@ -32797,11 +32797,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_get_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_get_tlsext_status_ocsp_resp"]
     pub fn SSL_get_tlsext_status_ocsp_resp(ssl: *const SSL, out: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_status_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_status_cb"]
     pub fn SSL_CTX_set_tlsext_status_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -32813,18 +32813,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_status_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_status_arg"]
     pub fn SSL_CTX_set_tlsext_status_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_SSL_CIPHER_get_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_SSL_CIPHER_get_value"]
     pub fn SSL_CIPHER_get_value(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_6_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_7_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,

--- a/aws-lc-fips-sys/src/x86_64_unknown_linux_gnu_crypto.rs
+++ b/aws-lc-fips-sys/src/x86_64_unknown_linux_gnu_crypto.rs
@@ -4536,38 +4536,38 @@ pub type X509_STORE = x509_store_st;
 pub type X509_TRUST = x509_trust_st;
 pub type OPENSSL_BLOCK = *mut ::std::os::raw::c_void;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4576,18 +4576,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4596,18 +4596,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4616,7 +4616,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -4624,11 +4624,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -4639,30 +4639,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -4701,30 +4701,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -4734,15 +4734,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -4806,7 +4806,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4814,7 +4814,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4822,15 +4822,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4842,7 +4842,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4851,7 +4851,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4862,7 +4862,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4873,7 +4873,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4885,7 +4885,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4895,7 +4895,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4905,7 +4905,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4916,7 +4916,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5137,27 +5137,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5165,29 +5165,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5195,7 +5195,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5327,27 +5327,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -5355,11 +5355,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -5367,22 +5367,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -5391,7 +5391,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -5400,35 +5400,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -5438,7 +5438,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -5498,7 +5498,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -5604,19 +5604,19 @@ impl Default for crypto_mutex_st {
 pub type CRYPTO_MUTEX = crypto_mutex_st;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5629,7 +5629,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5643,7 +5643,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5654,29 +5654,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -5732,7 +5732,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5743,7 +5743,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5756,7 +5756,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5768,7 +5768,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -5777,7 +5777,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5788,7 +5788,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -5815,23 +5815,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -5839,7 +5839,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -5847,7 +5847,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5855,7 +5855,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5863,15 +5863,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5880,7 +5880,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5888,7 +5888,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5897,67 +5897,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -5983,7 +5983,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5991,68 +5991,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6060,7 +6060,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6068,7 +6068,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6077,11 +6077,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -6090,15 +6090,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -6106,11 +6106,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -6118,22 +6118,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -6141,30 +6141,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -6172,89 +6172,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -6263,34 +6263,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -6299,13 +6299,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -6314,13 +6314,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -6333,7 +6333,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -6346,7 +6346,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -6359,7 +6359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6371,7 +6371,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -6385,7 +6385,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6398,7 +6398,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -6411,7 +6411,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6423,23 +6423,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -6449,7 +6449,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -6457,37 +6457,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -6499,7 +6499,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6869,193 +6869,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7064,15 +7064,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7082,11 +7082,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -7094,47 +7094,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7142,11 +7142,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7154,43 +7154,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -7199,7 +7199,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7209,7 +7209,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7218,7 +7218,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7228,7 +7228,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7237,7 +7237,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7247,7 +7247,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7256,7 +7256,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7266,7 +7266,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7275,7 +7275,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7284,7 +7284,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7292,7 +7292,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7301,7 +7301,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7310,7 +7310,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7319,11 +7319,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -7331,7 +7331,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -7391,15 +7391,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -7413,7 +7413,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -7421,11 +7421,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7440,7 +7440,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -7450,7 +7450,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -7461,7 +7461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7471,7 +7471,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7480,7 +7480,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7489,7 +7489,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7498,7 +7498,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7508,7 +7508,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7518,23 +7518,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7543,7 +7543,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7552,7 +7552,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7562,7 +7562,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7571,7 +7571,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7581,7 +7581,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7592,7 +7592,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7603,15 +7603,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -7622,7 +7622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -7635,11 +7635,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -7647,7 +7647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -7655,7 +7655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -7803,15 +7803,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -7835,15 +7835,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7852,7 +7852,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -7860,14 +7860,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -7875,7 +7875,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -7883,7 +7883,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -7891,7 +7891,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -7899,14 +7899,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -7914,7 +7914,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7922,22 +7922,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8013,54 +8013,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8068,7 +8068,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8076,79 +8076,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -8156,7 +8156,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -8164,7 +8164,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -8172,7 +8172,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -8180,7 +8180,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -8188,7 +8188,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -8196,7 +8196,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -8204,7 +8204,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -8212,7 +8212,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -8220,117 +8220,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -8338,14 +8338,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8355,7 +8355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8367,7 +8367,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -8377,7 +8377,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -8387,15 +8387,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8403,26 +8403,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8430,23 +8430,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8454,14 +8454,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8469,25 +8469,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -8495,7 +8495,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -8503,14 +8503,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -8539,19 +8539,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -8559,11 +8559,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -8571,54 +8571,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -8626,59 +8626,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -8686,23 +8686,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, t: time_t) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         t: time_t,
@@ -8711,26 +8711,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -8738,29 +8738,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
@@ -8769,22 +8769,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -8792,15 +8792,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -8809,11 +8809,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, t: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         t: time_t,
@@ -8822,41 +8822,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -8864,11 +8864,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8893,7 +8893,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -8903,11 +8903,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8915,11 +8915,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8927,7 +8927,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9261,15 +9261,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -9277,19 +9277,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9297,7 +9297,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9305,12 +9305,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9318,14 +9318,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9333,33 +9333,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -9367,7 +9367,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -9375,19 +9375,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -9395,7 +9395,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -9403,7 +9403,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -9413,7 +9413,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -9423,11 +9423,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -9435,33 +9435,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9469,34 +9469,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -10106,7 +10106,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10131,19 +10131,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -10153,19 +10153,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10175,7 +10175,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10183,11 +10183,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10197,7 +10197,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10205,7 +10205,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -10415,11 +10415,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -10427,11 +10427,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -10486,19 +10486,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10507,7 +10507,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10568,23 +10568,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -10592,82 +10592,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10675,7 +10675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10683,11 +10683,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10695,7 +10695,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10704,7 +10704,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10715,22 +10715,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10739,7 +10739,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10748,7 +10748,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -10757,7 +10757,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -10766,33 +10766,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10800,7 +10800,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10808,7 +10808,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -11115,23 +11115,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11139,40 +11139,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -11180,15 +11180,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11196,55 +11196,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -11252,11 +11252,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -11264,7 +11264,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -11272,11 +11272,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -11284,11 +11284,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -11299,114 +11299,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11417,7 +11417,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11427,7 +11427,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11437,7 +11437,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11447,7 +11447,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11455,7 +11455,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11465,7 +11465,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11473,7 +11473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11483,7 +11483,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11491,47 +11491,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -11540,45 +11540,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -11591,23 +11591,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11617,7 +11617,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11626,7 +11626,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11635,7 +11635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11643,7 +11643,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11651,7 +11651,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11659,7 +11659,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11668,118 +11668,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -12016,7 +12016,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -12026,19 +12026,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12048,15 +12048,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -12151,15 +12151,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -12167,7 +12167,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -12175,14 +12175,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -12190,7 +12190,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -12198,23 +12198,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12222,15 +12222,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12317,11 +12317,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12329,19 +12329,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12349,19 +12349,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -12459,11 +12459,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12471,19 +12471,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12491,15 +12491,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12597,11 +12597,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12609,34 +12609,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -12644,34 +12644,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -12679,7 +12679,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12688,7 +12688,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12697,7 +12697,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12705,7 +12705,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12713,21 +12713,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12735,7 +12735,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12743,7 +12743,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -12751,7 +12751,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -12760,7 +12760,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -12768,11 +12768,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -12799,51 +12799,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -12853,70 +12853,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -12924,15 +12924,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -12941,7 +12941,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -12950,7 +12950,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -12961,7 +12961,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -12971,11 +12971,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -12986,7 +12986,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13059,15 +13059,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13076,7 +13076,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13087,7 +13087,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13098,7 +13098,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13111,7 +13111,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13123,7 +13123,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_decrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13132,7 +13132,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_encrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13141,43 +13141,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13185,7 +13185,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13193,7 +13193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13202,7 +13202,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13211,40 +13211,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13253,11 +13253,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13265,7 +13265,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13276,19 +13276,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13296,19 +13296,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13323,7 +13323,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13331,14 +13331,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13346,114 +13346,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13461,11 +13461,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13473,7 +13473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13481,7 +13481,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13489,7 +13489,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13500,75 +13500,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13576,19 +13576,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -13680,15 +13680,15 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -13696,11 +13696,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -13708,15 +13708,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_METHOD_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_METHOD_unref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -13762,43 +13762,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -13806,7 +13806,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -13815,7 +13815,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -13823,7 +13823,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -13832,7 +13832,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -13844,11 +13844,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13902,28 +13902,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -13932,7 +13932,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13942,7 +13942,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13953,7 +13953,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13964,7 +13964,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13975,47 +13975,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14025,7 +14025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14033,14 +14033,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14048,11 +14048,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14060,11 +14060,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14072,11 +14072,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14084,7 +14084,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14240,19 +14240,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14260,19 +14260,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14280,7 +14280,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14290,53 +14290,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14344,7 +14344,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14353,7 +14353,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14363,7 +14363,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14373,7 +14373,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14383,7 +14383,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14393,7 +14393,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14404,7 +14404,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14414,7 +14414,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14424,7 +14424,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14434,7 +14434,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14444,7 +14444,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14453,7 +14453,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14461,7 +14461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14472,7 +14472,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14481,7 +14481,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14490,7 +14490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14498,11 +14498,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14512,15 +14512,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -14574,92 +14574,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -14667,7 +14667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -14676,15 +14676,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -14692,11 +14692,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -14704,22 +14704,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14729,7 +14729,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14737,7 +14737,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14859,11 +14859,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14871,11 +14871,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14883,11 +14883,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14895,14 +14895,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -14919,7 +14919,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -14928,7 +14928,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14939,7 +14939,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14950,7 +14950,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15004,23 +15004,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15028,7 +15028,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15036,7 +15036,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15044,7 +15044,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15053,19 +15053,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15073,11 +15073,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15087,7 +15087,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15095,83 +15095,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15309,11 +15309,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15322,11 +15322,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15337,11 +15337,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15356,7 +15356,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15371,7 +15371,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15389,7 +15389,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15404,66 +15404,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15474,7 +15474,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15482,7 +15482,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15491,7 +15491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15499,102 +15499,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -15602,40 +15602,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15644,7 +15644,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15653,7 +15653,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15661,7 +15661,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15669,7 +15669,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15679,7 +15679,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15687,7 +15687,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15695,7 +15695,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15705,7 +15705,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15715,7 +15715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15723,7 +15723,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15731,7 +15731,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15741,7 +15741,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15749,11 +15749,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15761,7 +15761,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -15770,7 +15770,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15778,11 +15778,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15790,7 +15790,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15799,7 +15799,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15808,7 +15808,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15817,7 +15817,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15826,7 +15826,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15839,7 +15839,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15851,7 +15851,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15866,31 +15866,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -15900,11 +15900,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -15914,11 +15914,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15928,11 +15928,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15942,11 +15942,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15956,18 +15956,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -15975,18 +15975,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -15996,7 +15996,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16006,102 +16006,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16109,28 +16109,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16138,7 +16138,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16146,7 +16146,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16156,31 +16156,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16194,7 +16194,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16208,15 +16208,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16225,7 +16225,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16233,7 +16233,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16242,22 +16242,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16265,40 +16265,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16306,11 +16306,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16318,11 +16318,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16330,11 +16330,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16342,14 +16342,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -16523,7 +16523,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16537,7 +16537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16549,7 +16549,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -16561,11 +16561,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16573,15 +16573,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -16668,7 +16668,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -16680,27 +16680,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16710,7 +16710,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -16718,7 +16718,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16726,23 +16726,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16751,7 +16751,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -16927,82 +16927,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17011,18 +17011,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17031,7 +17031,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17040,23 +17040,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17072,7 +17072,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17090,7 +17090,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17103,7 +17103,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17116,7 +17116,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17129,7 +17129,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17139,19 +17139,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17410,7 +17410,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17418,7 +17418,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17427,7 +17427,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17436,22 +17436,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17459,15 +17459,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17554,66 +17554,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -17622,7 +17622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -17630,7 +17630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -17638,7 +17638,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -17719,7 +17719,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -17738,7 +17738,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -17746,47 +17746,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18080,51 +18080,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18150,15 +18150,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18166,18 +18166,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18185,79 +18185,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18266,11 +18266,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18279,7 +18279,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18288,12 +18288,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18302,7 +18302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18311,7 +18311,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18319,7 +18319,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18331,7 +18331,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18343,7 +18343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -18353,7 +18353,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -18363,7 +18363,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18374,7 +18374,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18388,7 +18388,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18400,7 +18400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18411,7 +18411,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -18424,7 +18424,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18436,7 +18436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -18446,7 +18446,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -18456,31 +18456,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18491,7 +18491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18502,7 +18502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -18515,7 +18515,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -18526,19 +18526,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18546,19 +18546,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18566,7 +18566,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -18576,7 +18576,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -18584,26 +18584,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -18612,7 +18612,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18620,11 +18620,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18632,11 +18632,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18646,7 +18646,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18656,7 +18656,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -18667,7 +18667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -18675,7 +18675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -19176,27 +19176,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19204,51 +19204,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19261,15 +19261,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19277,7 +19277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19285,7 +19285,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19293,15 +19293,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19309,68 +19309,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19378,7 +19378,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19386,25 +19386,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19412,14 +19412,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -19427,7 +19427,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -19435,7 +19435,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -19443,14 +19443,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -19472,23 +19472,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19496,23 +19496,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -19521,19 +19521,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19541,7 +19541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -19549,7 +19549,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -19557,11 +19557,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19569,55 +19569,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -19625,7 +19625,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -19633,25 +19633,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -19659,19 +19659,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -19679,23 +19679,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19703,33 +19703,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -19737,22 +19737,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -19802,19 +19802,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -19822,15 +19822,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -19838,15 +19838,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19854,7 +19854,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19862,21 +19862,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -19885,7 +19885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19897,7 +19897,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19909,7 +19909,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -19921,19 +19921,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -19941,33 +19941,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -19976,11 +19976,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -19990,7 +19990,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20000,7 +20000,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20010,19 +20010,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20030,18 +20030,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20050,7 +20050,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20059,33 +20059,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20109,11 +20109,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20121,18 +20121,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20140,7 +20140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20148,7 +20148,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20156,21 +20156,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -20199,23 +20199,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -20223,11 +20223,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -20236,7 +20236,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -20245,15 +20245,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -20261,7 +20261,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -20269,7 +20269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20278,7 +20278,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20287,7 +20287,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -20296,7 +20296,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -20305,7 +20305,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -20314,259 +20314,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -20574,11 +20574,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20588,7 +20588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -20596,14 +20596,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20613,7 +20613,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -20621,42 +20621,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20665,7 +20665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -21238,11 +21238,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -21250,7 +21250,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -21258,54 +21258,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21313,23 +21313,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -21337,7 +21337,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -21346,44 +21346,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21391,34 +21391,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21426,26 +21426,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21453,18 +21453,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21472,38 +21472,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21511,25 +21511,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21537,7 +21537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21545,23 +21545,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21569,26 +21569,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21596,26 +21596,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -21623,7 +21623,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -21633,7 +21633,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -21643,7 +21643,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -21653,7 +21653,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21665,7 +21665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21676,15 +21676,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -21692,18 +21692,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21711,7 +21711,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21719,28 +21719,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21750,7 +21750,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21760,7 +21760,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -21770,37 +21770,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -21810,66 +21810,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -21878,19 +21878,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -21899,7 +21899,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -21907,7 +21907,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -21916,7 +21916,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -21925,15 +21925,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -21942,11 +21942,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -21955,7 +21955,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -21965,7 +21965,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21974,7 +21974,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21984,11 +21984,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21996,7 +21996,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -22004,7 +22004,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -22012,21 +22012,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -22034,7 +22034,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22043,7 +22043,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22053,11 +22053,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22065,7 +22065,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22073,28 +22073,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22104,7 +22104,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22114,7 +22114,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22124,7 +22124,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22134,7 +22134,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22144,7 +22144,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22154,14 +22154,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -22170,7 +22170,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -22179,34 +22179,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22214,26 +22214,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -22244,7 +22244,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -22254,11 +22254,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -22266,19 +22266,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -22295,19 +22295,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22394,15 +22394,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22410,14 +22410,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -22536,18 +22536,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22555,7 +22555,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22563,202 +22563,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -22766,15 +22766,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -22783,50 +22783,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -22835,7 +22835,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -22845,7 +22845,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22853,7 +22853,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22861,7 +22861,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22869,19 +22869,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -22890,11 +22890,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -22902,81 +22902,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -22985,11 +22985,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -22997,7 +22997,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23009,105 +23009,105 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23115,7 +23115,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23123,20 +23123,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -23144,7 +23144,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -23152,42 +23152,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -23199,14 +23199,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -23216,7 +23216,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23226,7 +23226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -23236,7 +23236,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -23248,7 +23248,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23259,7 +23259,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23273,7 +23273,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -23282,7 +23282,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23292,7 +23292,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -23302,7 +23302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23313,7 +23313,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23327,7 +23327,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -23336,7 +23336,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -23345,11 +23345,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_proc_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_dek_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -23358,7 +23358,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23367,7 +23367,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23376,15 +23376,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23393,7 +23393,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23402,15 +23402,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -23419,7 +23419,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -23428,23 +23428,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -23453,7 +23453,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -23462,15 +23462,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -23479,7 +23479,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -23488,15 +23488,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -23505,7 +23505,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -23514,15 +23514,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23531,7 +23531,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23540,21 +23540,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23563,7 +23563,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23572,7 +23572,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -23584,7 +23584,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -23596,7 +23596,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23605,7 +23605,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23614,15 +23614,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23631,7 +23631,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23640,15 +23640,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23657,7 +23657,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23666,7 +23666,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -23678,7 +23678,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -23690,7 +23690,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23699,7 +23699,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23708,15 +23708,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23725,7 +23725,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23734,15 +23734,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23751,7 +23751,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23760,7 +23760,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -23772,7 +23772,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -23784,7 +23784,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23793,7 +23793,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23802,15 +23802,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -23819,7 +23819,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -23828,15 +23828,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23845,7 +23845,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23854,7 +23854,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23866,7 +23866,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23878,7 +23878,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23887,7 +23887,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23896,15 +23896,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23916,7 +23916,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -23928,7 +23928,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23940,7 +23940,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23952,7 +23952,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23961,7 +23961,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23973,7 +23973,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23985,7 +23985,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23997,7 +23997,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24006,7 +24006,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24018,7 +24018,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -24031,7 +24031,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -24045,7 +24045,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -24053,7 +24053,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -24061,7 +24061,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -24070,11 +24070,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -24082,27 +24082,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24112,7 +24112,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24120,7 +24120,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -24135,74 +24135,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24303,19 +24303,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24380,11 +24380,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -24471,11 +24471,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -24483,42 +24483,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -24593,15 +24593,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24614,7 +24614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24629,18 +24629,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24649,14 +24649,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24665,7 +24665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24676,7 +24676,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24685,7 +24685,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24697,7 +24697,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -24709,18 +24709,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24728,14 +24728,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24743,7 +24743,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24757,7 +24757,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24772,7 +24772,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24785,7 +24785,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24800,7 +24800,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -26508,15 +26508,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26524,26 +26524,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26551,14 +26551,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -26790,15 +26790,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26806,26 +26806,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26833,26 +26833,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26860,29 +26860,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -26890,19 +26890,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26910,18 +26910,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -26929,7 +26929,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -26937,15 +26937,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26953,26 +26953,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26980,22 +26980,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -27003,14 +27003,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -27018,7 +27018,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -27026,14 +27026,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27041,15 +27041,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27057,33 +27057,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27091,26 +27091,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27118,26 +27118,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27145,26 +27145,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27172,26 +27172,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27199,26 +27199,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27226,26 +27226,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27253,26 +27253,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27280,26 +27280,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27307,38 +27307,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27346,26 +27346,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27373,70 +27373,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27447,7 +27447,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27455,7 +27455,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27465,7 +27465,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -27563,7 +27563,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -27574,11 +27574,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27587,7 +27587,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27596,7 +27596,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -27605,7 +27605,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27614,7 +27614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27623,7 +27623,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27632,7 +27632,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27641,67 +27641,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27710,14 +27710,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -27725,7 +27725,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27735,7 +27735,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -27744,7 +27744,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -27753,7 +27753,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -27762,7 +27762,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -27772,11 +27772,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -27784,70 +27784,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_akid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -27865,43 +27865,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27911,7 +27911,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27920,7 +27920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -27929,7 +27929,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -27937,15 +27937,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,

--- a/aws-lc-fips-sys/src/x86_64_unknown_linux_gnu_crypto_ssl.rs
+++ b/aws-lc-fips-sys/src/x86_64_unknown_linux_gnu_crypto_ssl.rs
@@ -5528,38 +5528,38 @@ pub type X509_STORE = x509_store_st;
 pub type X509_TRUST = x509_trust_st;
 pub type OPENSSL_BLOCK = *mut ::std::os::raw::c_void;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5568,18 +5568,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5588,18 +5588,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5608,7 +5608,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -5616,11 +5616,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -5631,30 +5631,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -5693,30 +5693,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -5726,15 +5726,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -5798,7 +5798,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5806,7 +5806,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5814,15 +5814,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5834,7 +5834,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5843,7 +5843,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5854,7 +5854,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5865,7 +5865,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5877,7 +5877,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5887,7 +5887,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5897,7 +5897,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5908,7 +5908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -6129,27 +6129,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -6157,29 +6157,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -6187,7 +6187,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -6319,27 +6319,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -6347,11 +6347,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6359,22 +6359,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6383,7 +6383,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -6392,35 +6392,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6430,7 +6430,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6490,7 +6490,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6596,19 +6596,19 @@ impl Default for crypto_mutex_st {
 pub type CRYPTO_MUTEX = crypto_mutex_st;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6621,7 +6621,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6635,7 +6635,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6646,29 +6646,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6724,7 +6724,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6735,7 +6735,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6748,7 +6748,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6760,7 +6760,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6769,7 +6769,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6780,7 +6780,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6807,23 +6807,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6831,7 +6831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6839,7 +6839,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6847,7 +6847,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6855,15 +6855,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6872,7 +6872,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6880,7 +6880,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6889,67 +6889,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6975,7 +6975,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6983,68 +6983,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -7052,7 +7052,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -7060,7 +7060,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -7069,11 +7069,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -7082,15 +7082,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -7098,11 +7098,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -7110,22 +7110,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -7133,30 +7133,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -7164,89 +7164,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -7255,34 +7255,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -7291,13 +7291,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -7306,13 +7306,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7325,7 +7325,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7338,7 +7338,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7351,7 +7351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7363,7 +7363,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7377,7 +7377,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7390,7 +7390,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7403,7 +7403,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7415,23 +7415,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7441,7 +7441,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7449,37 +7449,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7491,7 +7491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7861,193 +7861,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8056,15 +8056,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -8074,11 +8074,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -8086,47 +8086,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8134,11 +8134,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8146,43 +8146,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -8191,7 +8191,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8201,7 +8201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8210,7 +8210,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8220,7 +8220,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8229,7 +8229,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8239,7 +8239,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8248,7 +8248,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8258,7 +8258,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8267,7 +8267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8276,7 +8276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8284,7 +8284,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8293,7 +8293,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8302,7 +8302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8311,11 +8311,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8323,7 +8323,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8383,15 +8383,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8405,7 +8405,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8413,11 +8413,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8432,7 +8432,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8442,7 +8442,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8453,7 +8453,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8463,7 +8463,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8472,7 +8472,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8481,7 +8481,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8490,7 +8490,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8500,7 +8500,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8510,23 +8510,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8535,7 +8535,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8544,7 +8544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8554,7 +8554,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8563,7 +8563,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8573,7 +8573,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8584,7 +8584,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8595,15 +8595,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8614,7 +8614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8627,11 +8627,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8639,7 +8639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8647,7 +8647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -8795,15 +8795,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8827,15 +8827,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8844,7 +8844,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8852,14 +8852,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8867,7 +8867,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8875,7 +8875,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8883,7 +8883,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8891,14 +8891,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8906,7 +8906,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8914,22 +8914,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9005,54 +9005,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -9060,7 +9060,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -9068,79 +9068,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -9148,7 +9148,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -9156,7 +9156,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -9164,7 +9164,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -9172,7 +9172,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -9180,7 +9180,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -9188,7 +9188,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -9196,7 +9196,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -9204,7 +9204,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -9212,117 +9212,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9330,14 +9330,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9347,7 +9347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9359,7 +9359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9369,7 +9369,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9379,15 +9379,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9395,26 +9395,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9422,23 +9422,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9446,14 +9446,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9461,25 +9461,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9487,7 +9487,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9495,14 +9495,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9531,19 +9531,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9551,11 +9551,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9563,54 +9563,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9618,59 +9618,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9678,23 +9678,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, t: time_t) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         t: time_t,
@@ -9703,26 +9703,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9730,29 +9730,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
@@ -9761,22 +9761,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9784,15 +9784,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9801,11 +9801,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, t: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         t: time_t,
@@ -9814,41 +9814,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9856,11 +9856,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9885,7 +9885,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9895,11 +9895,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9907,11 +9907,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9919,7 +9919,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10253,15 +10253,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10269,19 +10269,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10289,7 +10289,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10297,12 +10297,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10310,14 +10310,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10325,33 +10325,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10359,7 +10359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10367,19 +10367,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10387,7 +10387,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10395,7 +10395,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10405,7 +10405,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10415,11 +10415,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10427,33 +10427,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10461,34 +10461,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -11098,7 +11098,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -11123,19 +11123,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -11145,19 +11145,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11167,7 +11167,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11175,11 +11175,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11189,7 +11189,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11197,7 +11197,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11407,11 +11407,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11419,11 +11419,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11478,19 +11478,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11499,7 +11499,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11560,23 +11560,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11584,82 +11584,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11667,7 +11667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11675,11 +11675,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11687,7 +11687,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11696,7 +11696,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11707,22 +11707,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11731,7 +11731,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11740,7 +11740,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11749,7 +11749,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11758,33 +11758,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11792,7 +11792,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11800,7 +11800,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -12107,23 +12107,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12131,40 +12131,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -12172,15 +12172,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12188,55 +12188,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -12244,11 +12244,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -12256,7 +12256,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12264,11 +12264,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12276,11 +12276,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12291,114 +12291,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12409,7 +12409,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12419,7 +12419,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12429,7 +12429,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12439,7 +12439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12447,7 +12447,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12457,7 +12457,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12465,7 +12465,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12475,7 +12475,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12483,47 +12483,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12532,45 +12532,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12583,23 +12583,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12609,7 +12609,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12618,7 +12618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12627,7 +12627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12635,7 +12635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12643,7 +12643,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12651,7 +12651,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12660,118 +12660,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -13008,7 +13008,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -13018,19 +13018,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -13040,15 +13040,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -13143,15 +13143,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -13159,7 +13159,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -13167,14 +13167,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -13182,7 +13182,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -13190,23 +13190,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13214,15 +13214,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13309,11 +13309,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13321,19 +13321,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13341,19 +13341,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -13451,11 +13451,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13463,19 +13463,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13483,15 +13483,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13589,11 +13589,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13601,34 +13601,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -13636,34 +13636,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13671,7 +13671,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13680,7 +13680,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13689,7 +13689,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13697,7 +13697,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13705,21 +13705,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13727,7 +13727,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13735,7 +13735,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -13743,7 +13743,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -13752,7 +13752,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -13760,11 +13760,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -13791,51 +13791,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -13845,70 +13845,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13916,15 +13916,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13933,7 +13933,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13942,7 +13942,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13953,7 +13953,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13963,11 +13963,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13978,7 +13978,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -14051,15 +14051,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -14068,7 +14068,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14079,7 +14079,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -14090,7 +14090,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14103,7 +14103,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14115,7 +14115,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_decrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -14124,7 +14124,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_encrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -14133,43 +14133,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -14177,7 +14177,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -14185,7 +14185,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -14194,7 +14194,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -14203,40 +14203,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -14245,11 +14245,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14257,7 +14257,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -14268,19 +14268,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -14288,19 +14288,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -14315,7 +14315,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -14323,14 +14323,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14338,114 +14338,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -14453,11 +14453,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -14465,7 +14465,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14473,7 +14473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14481,7 +14481,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -14492,75 +14492,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -14568,19 +14568,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14672,15 +14672,15 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -14688,11 +14688,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -14700,15 +14700,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_METHOD_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_METHOD_unref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -14754,43 +14754,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14798,7 +14798,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14807,7 +14807,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14815,7 +14815,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14824,7 +14824,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14836,11 +14836,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14894,28 +14894,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14924,7 +14924,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14934,7 +14934,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14945,7 +14945,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14956,7 +14956,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14967,47 +14967,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15017,7 +15017,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -15025,14 +15025,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -15040,11 +15040,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15052,11 +15052,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15064,11 +15064,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15076,7 +15076,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15232,19 +15232,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -15252,19 +15252,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -15272,7 +15272,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -15282,53 +15282,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15336,7 +15336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -15345,7 +15345,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15355,7 +15355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15365,7 +15365,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15375,7 +15375,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15385,7 +15385,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15396,7 +15396,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -15406,7 +15406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15416,7 +15416,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15426,7 +15426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15436,7 +15436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15445,7 +15445,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -15453,7 +15453,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15464,7 +15464,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -15473,7 +15473,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -15482,7 +15482,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -15490,11 +15490,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15504,15 +15504,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -15566,92 +15566,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -15659,7 +15659,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15668,15 +15668,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15684,11 +15684,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15696,22 +15696,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15721,7 +15721,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15729,7 +15729,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15851,11 +15851,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15863,11 +15863,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15875,11 +15875,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15887,14 +15887,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15911,7 +15911,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15920,7 +15920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15931,7 +15931,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15942,7 +15942,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15996,23 +15996,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -16020,7 +16020,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -16028,7 +16028,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -16036,7 +16036,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -16045,19 +16045,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -16065,11 +16065,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -16079,7 +16079,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -16087,83 +16087,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -16301,11 +16301,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -16314,11 +16314,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16329,11 +16329,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16348,7 +16348,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16363,7 +16363,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16381,7 +16381,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16396,66 +16396,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16466,7 +16466,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -16474,7 +16474,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -16483,7 +16483,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -16491,102 +16491,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16594,40 +16594,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16636,7 +16636,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16645,7 +16645,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16653,7 +16653,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16661,7 +16661,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16671,7 +16671,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16679,7 +16679,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16687,7 +16687,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16697,7 +16697,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16707,7 +16707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16715,7 +16715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16723,7 +16723,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16733,7 +16733,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16741,11 +16741,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16753,7 +16753,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16762,7 +16762,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16770,11 +16770,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16782,7 +16782,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16791,7 +16791,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16800,7 +16800,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16809,7 +16809,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16818,7 +16818,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16831,7 +16831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16843,7 +16843,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16858,31 +16858,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16892,11 +16892,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16906,11 +16906,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16920,11 +16920,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16934,11 +16934,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16948,18 +16948,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16967,18 +16967,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16988,7 +16988,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16998,102 +16998,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -17101,28 +17101,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -17130,7 +17130,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -17138,7 +17138,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -17148,31 +17148,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -17186,7 +17186,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -17200,15 +17200,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -17217,7 +17217,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -17225,7 +17225,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -17234,22 +17234,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -17257,40 +17257,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -17298,11 +17298,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -17310,11 +17310,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -17322,11 +17322,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -17334,14 +17334,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -17515,7 +17515,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -17529,7 +17529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -17541,7 +17541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -17553,11 +17553,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17565,15 +17565,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17660,7 +17660,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17672,27 +17672,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17702,7 +17702,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17710,7 +17710,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17718,23 +17718,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17743,7 +17743,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17919,82 +17919,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -18003,18 +18003,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -18023,7 +18023,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -18032,23 +18032,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -18064,7 +18064,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -18082,7 +18082,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -18095,7 +18095,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -18108,7 +18108,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -18121,7 +18121,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -18131,19 +18131,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -18402,7 +18402,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -18410,7 +18410,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -18419,7 +18419,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -18428,22 +18428,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18451,15 +18451,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18546,66 +18546,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -18614,7 +18614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -18622,7 +18622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -18630,7 +18630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -18711,7 +18711,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -18730,7 +18730,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18738,47 +18738,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -19072,51 +19072,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19142,15 +19142,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -19158,18 +19158,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -19177,79 +19177,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -19258,11 +19258,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -19271,7 +19271,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -19280,12 +19280,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -19294,7 +19294,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19303,7 +19303,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19311,7 +19311,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19323,7 +19323,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19335,7 +19335,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19345,7 +19345,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19355,7 +19355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19366,7 +19366,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19380,7 +19380,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19392,7 +19392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19403,7 +19403,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19416,7 +19416,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19428,7 +19428,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19438,7 +19438,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19448,31 +19448,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19483,7 +19483,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19494,7 +19494,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19507,7 +19507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19518,19 +19518,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19538,19 +19538,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19558,7 +19558,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19568,7 +19568,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19576,26 +19576,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19604,7 +19604,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19612,11 +19612,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19624,11 +19624,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19638,7 +19638,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19648,7 +19648,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19659,7 +19659,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19667,7 +19667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -20168,27 +20168,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -20196,51 +20196,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -20253,15 +20253,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -20269,7 +20269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -20277,7 +20277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -20285,15 +20285,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -20301,68 +20301,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -20370,7 +20370,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -20378,25 +20378,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -20404,14 +20404,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -20419,7 +20419,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -20427,7 +20427,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -20435,14 +20435,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -20464,23 +20464,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -20488,23 +20488,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -20513,19 +20513,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20533,7 +20533,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20541,7 +20541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20549,11 +20549,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20561,55 +20561,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20617,7 +20617,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20625,25 +20625,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20651,19 +20651,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20671,23 +20671,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20695,33 +20695,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20729,22 +20729,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20794,19 +20794,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20814,15 +20814,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20830,15 +20830,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20846,7 +20846,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20854,21 +20854,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20877,7 +20877,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20889,7 +20889,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20901,7 +20901,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20913,19 +20913,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20933,33 +20933,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20968,11 +20968,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20982,7 +20982,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20992,7 +20992,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -21002,19 +21002,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -21022,18 +21022,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -21042,7 +21042,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -21051,33 +21051,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -21101,11 +21101,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -21113,18 +21113,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -21132,7 +21132,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -21140,7 +21140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -21148,21 +21148,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21191,23 +21191,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21215,11 +21215,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21228,7 +21228,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21237,15 +21237,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -21253,7 +21253,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -21261,7 +21261,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -21270,7 +21270,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -21279,7 +21279,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -21288,7 +21288,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -21297,7 +21297,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -21306,259 +21306,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -21566,11 +21566,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21580,7 +21580,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -21588,14 +21588,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21605,7 +21605,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -21613,42 +21613,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -21657,7 +21657,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -22230,11 +22230,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22242,7 +22242,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22250,54 +22250,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -22305,23 +22305,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22329,7 +22329,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22338,44 +22338,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22383,34 +22383,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22418,26 +22418,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22445,18 +22445,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -22464,38 +22464,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22503,25 +22503,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22529,7 +22529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22537,23 +22537,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22561,26 +22561,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22588,26 +22588,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22615,7 +22615,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22625,7 +22625,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22635,7 +22635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22645,7 +22645,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22657,7 +22657,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22668,15 +22668,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -22684,18 +22684,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22703,7 +22703,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22711,28 +22711,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22742,7 +22742,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22752,7 +22752,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -22762,37 +22762,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -22802,66 +22802,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -22870,19 +22870,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22891,7 +22891,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22899,7 +22899,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22908,7 +22908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22917,15 +22917,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22934,11 +22934,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -22947,7 +22947,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -22957,7 +22957,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22966,7 +22966,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22976,11 +22976,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22988,7 +22988,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -22996,7 +22996,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -23004,21 +23004,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -23026,7 +23026,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -23035,7 +23035,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -23045,11 +23045,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23057,7 +23057,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23065,28 +23065,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23096,7 +23096,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23106,7 +23106,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -23116,7 +23116,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23126,7 +23126,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23136,7 +23136,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -23146,14 +23146,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -23162,7 +23162,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -23171,34 +23171,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23206,26 +23206,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -23236,7 +23236,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -23246,11 +23246,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -23258,19 +23258,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -23287,19 +23287,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23386,15 +23386,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23402,14 +23402,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -23528,18 +23528,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23547,7 +23547,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23555,202 +23555,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23758,15 +23758,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -23775,50 +23775,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23827,7 +23827,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23837,7 +23837,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23845,7 +23845,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23853,7 +23853,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23861,19 +23861,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -23882,11 +23882,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23894,81 +23894,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -23977,11 +23977,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23989,7 +23989,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -24001,105 +24001,105 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -24107,7 +24107,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -24115,20 +24115,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -24136,7 +24136,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -24144,42 +24144,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -24191,14 +24191,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -24208,7 +24208,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -24218,7 +24218,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -24228,7 +24228,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -24240,7 +24240,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24251,7 +24251,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24265,7 +24265,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -24274,7 +24274,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -24284,7 +24284,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -24294,7 +24294,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24305,7 +24305,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24319,7 +24319,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -24328,7 +24328,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -24337,11 +24337,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_proc_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_dek_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -24350,7 +24350,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24359,7 +24359,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24368,15 +24368,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24385,7 +24385,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24394,15 +24394,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -24411,7 +24411,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -24420,23 +24420,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -24445,7 +24445,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -24454,15 +24454,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -24471,7 +24471,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -24480,15 +24480,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -24497,7 +24497,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -24506,15 +24506,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24523,7 +24523,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24532,21 +24532,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24555,7 +24555,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24564,7 +24564,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -24576,7 +24576,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -24588,7 +24588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24597,7 +24597,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24606,15 +24606,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24623,7 +24623,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24632,15 +24632,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24649,7 +24649,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24658,7 +24658,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -24670,7 +24670,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -24682,7 +24682,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24691,7 +24691,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24700,15 +24700,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24717,7 +24717,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24726,15 +24726,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24743,7 +24743,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24752,7 +24752,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -24764,7 +24764,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -24776,7 +24776,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24785,7 +24785,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24794,15 +24794,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -24811,7 +24811,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -24820,15 +24820,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24837,7 +24837,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24846,7 +24846,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24858,7 +24858,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24870,7 +24870,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24879,7 +24879,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24888,15 +24888,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24908,7 +24908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -24920,7 +24920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24932,7 +24932,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24944,7 +24944,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24953,7 +24953,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24965,7 +24965,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24977,7 +24977,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24989,7 +24989,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24998,7 +24998,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -25010,7 +25010,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -25023,7 +25023,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -25037,7 +25037,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -25045,7 +25045,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -25053,7 +25053,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -25062,11 +25062,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -25074,27 +25074,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -25104,7 +25104,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -25112,7 +25112,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -25127,74 +25127,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25295,19 +25295,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25372,11 +25372,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -25463,11 +25463,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -25475,42 +25475,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -25585,15 +25585,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25606,7 +25606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25621,18 +25621,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25641,14 +25641,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25657,7 +25657,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25668,7 +25668,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25677,7 +25677,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25689,7 +25689,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -25701,18 +25701,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25720,14 +25720,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25735,7 +25735,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25749,7 +25749,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25764,7 +25764,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25777,7 +25777,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25792,7 +25792,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -27500,15 +27500,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27516,26 +27516,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27543,14 +27543,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -27782,15 +27782,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27798,26 +27798,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27825,26 +27825,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27852,29 +27852,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -27882,19 +27882,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27902,18 +27902,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -27921,7 +27921,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27929,15 +27929,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27945,26 +27945,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27972,22 +27972,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -27995,14 +27995,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -28010,7 +28010,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -28018,14 +28018,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -28033,15 +28033,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28049,33 +28049,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28083,26 +28083,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28110,26 +28110,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28137,26 +28137,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28164,26 +28164,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28191,26 +28191,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28218,26 +28218,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28245,26 +28245,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28272,26 +28272,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28299,38 +28299,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28338,26 +28338,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28365,70 +28365,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28439,7 +28439,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -28447,7 +28447,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28457,7 +28457,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -28555,7 +28555,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -28566,11 +28566,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28579,7 +28579,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28588,7 +28588,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -28597,7 +28597,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28606,7 +28606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28615,7 +28615,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28624,7 +28624,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28633,67 +28633,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28702,14 +28702,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -28717,7 +28717,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28727,7 +28727,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -28736,7 +28736,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -28745,7 +28745,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -28754,7 +28754,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -28764,11 +28764,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -28776,70 +28776,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_akid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -28857,43 +28857,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28903,7 +28903,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28912,7 +28912,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -28921,7 +28921,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -28929,11 +28929,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -28999,119 +28999,119 @@ impl static_assertion_at_line_255_error_is_max_overheads_are_inconsistent {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLS_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLS_method"]
     pub fn TLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLS_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLS_method"]
     pub fn DTLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLS_with_buffers_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLS_with_buffers_method"]
     pub fn TLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLS_with_buffers_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLS_with_buffers_method"]
     pub fn DTLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_new"]
     pub fn SSL_CTX_new(method: *const SSL_METHOD) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_up_ref"]
     pub fn SSL_CTX_up_ref(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_free"]
     pub fn SSL_CTX_free(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_new"]
     pub fn SSL_new(ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_free"]
     pub fn SSL_free(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_SSL_CTX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_SSL_CTX"]
     pub fn SSL_get_SSL_CTX(ssl: *const SSL) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_connect_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_connect_state"]
     pub fn SSL_set_connect_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_accept_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_accept_state"]
     pub fn SSL_set_accept_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_is_server"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_is_server"]
     pub fn SSL_is_server(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_is_dtls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_is_dtls"]
     pub fn SSL_is_dtls(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_bio"]
     pub fn SSL_set_bio(ssl: *mut SSL, rbio: *mut BIO, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set0_rbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set0_rbio"]
     pub fn SSL_set0_rbio(ssl: *mut SSL, rbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set0_wbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set0_wbio"]
     pub fn SSL_set0_wbio(ssl: *mut SSL, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_rbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_rbio"]
     pub fn SSL_get_rbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_wbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_wbio"]
     pub fn SSL_get_wbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_fd"]
     pub fn SSL_get_fd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_rfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_rfd"]
     pub fn SSL_get_rfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_wfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_wfd"]
     pub fn SSL_get_wfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_fd"]
     pub fn SSL_set_fd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_rfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_rfd"]
     pub fn SSL_set_rfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_wfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_wfd"]
     pub fn SSL_set_wfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_do_handshake"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_do_handshake"]
     pub fn SSL_do_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_connect"]
     pub fn SSL_connect(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_accept"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_accept"]
     pub fn SSL_accept(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_read"]
     pub fn SSL_read(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -29119,7 +29119,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_peek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_peek"]
     pub fn SSL_peek(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -29127,15 +29127,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_pending"]
     pub fn SSL_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_has_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_has_pending"]
     pub fn SSL_has_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_write"]
     pub fn SSL_write(
         ssl: *mut SSL,
         buf: *const ::std::os::raw::c_void,
@@ -29143,220 +29143,220 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_key_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_key_update"]
     pub fn SSL_key_update(
         ssl: *mut SSL,
         request_type: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_shutdown"]
     pub fn SSL_shutdown(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_quiet_shutdown"]
     pub fn SSL_CTX_set_quiet_shutdown(ctx: *mut SSL_CTX, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_quiet_shutdown"]
     pub fn SSL_CTX_get_quiet_shutdown(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_quiet_shutdown"]
     pub fn SSL_set_quiet_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_quiet_shutdown"]
     pub fn SSL_get_quiet_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_error"]
     pub fn SSL_get_error(ssl: *const SSL, ret_code: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_error_description"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_error_description"]
     pub fn SSL_error_description(err: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_mtu"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_mtu"]
     pub fn SSL_set_mtu(ssl: *mut SSL, mtu: ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_set_initial_timeout_duration"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_set_initial_timeout_duration"]
     pub fn DTLSv1_set_initial_timeout_duration(ssl: *mut SSL, duration_ms: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_get_timeout"]
     pub fn DTLSv1_get_timeout(ssl: *const SSL, out: *mut timeval) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_handle_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_handle_timeout"]
     pub fn DTLSv1_handle_timeout(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_min_proto_version"]
     pub fn SSL_CTX_set_min_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_max_proto_version"]
     pub fn SSL_CTX_set_max_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_min_proto_version"]
     pub fn SSL_CTX_get_min_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_max_proto_version"]
     pub fn SSL_CTX_get_max_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_min_proto_version"]
     pub fn SSL_set_min_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_max_proto_version"]
     pub fn SSL_set_max_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_min_proto_version"]
     pub fn SSL_get_min_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_max_proto_version"]
     pub fn SSL_get_max_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_version"]
     pub fn SSL_version(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_options"]
     pub fn SSL_CTX_set_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_clear_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_clear_options"]
     pub fn SSL_CTX_clear_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_options"]
     pub fn SSL_CTX_get_options(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_options"]
     pub fn SSL_set_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_clear_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_clear_options"]
     pub fn SSL_clear_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_options"]
     pub fn SSL_get_options(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_mode"]
     pub fn SSL_CTX_set_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_clear_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_clear_mode"]
     pub fn SSL_CTX_clear_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_mode"]
     pub fn SSL_CTX_get_mode(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_mode"]
     pub fn SSL_set_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_clear_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_clear_mode"]
     pub fn SSL_clear_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_mode"]
     pub fn SSL_get_mode(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set0_buffer_pool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set0_buffer_pool"]
     pub fn SSL_CTX_set0_buffer_pool(ctx: *mut SSL_CTX, pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_certificate"]
     pub fn SSL_CTX_use_certificate(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_certificate"]
     pub fn SSL_use_certificate(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_PrivateKey"]
     pub fn SSL_CTX_use_PrivateKey(ctx: *mut SSL_CTX, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_PrivateKey"]
     pub fn SSL_use_PrivateKey(ssl: *mut SSL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set0_chain"]
     pub fn SSL_CTX_set0_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_chain"]
     pub fn SSL_CTX_set1_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set0_chain"]
     pub fn SSL_set0_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_chain"]
     pub fn SSL_set1_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add0_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add0_chain_cert"]
     pub fn SSL_CTX_add0_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add1_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add1_chain_cert"]
     pub fn SSL_CTX_add1_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add0_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add0_chain_cert"]
     pub fn SSL_add0_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add_extra_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add_extra_chain_cert"]
     pub fn SSL_CTX_add_extra_chain_cert(
         ctx: *mut SSL_CTX,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add1_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add1_chain_cert"]
     pub fn SSL_add1_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_clear_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_clear_chain_certs"]
     pub fn SSL_CTX_clear_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_clear_extra_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_clear_extra_chain_certs"]
     pub fn SSL_CTX_clear_extra_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_clear_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_clear_chain_certs"]
     pub fn SSL_clear_chain_certs(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_cert_cb"]
     pub fn SSL_CTX_set_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -29369,7 +29369,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_cert_cb"]
     pub fn SSL_set_cert_cb(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -29382,71 +29382,71 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_certificate_types"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_certificate_types"]
     pub fn SSL_get0_certificate_types(ssl: *const SSL, out_types: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_peer_verify_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_peer_verify_algorithms"]
     pub fn SSL_get0_peer_verify_algorithms(ssl: *const SSL, out_sigalgs: *mut *const u16) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_peer_delegation_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_peer_delegation_algorithms"]
     pub fn SSL_get0_peer_delegation_algorithms(
         ssl: *const SSL,
         out_sigalgs: *mut *const u16,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_certs_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_certs_clear"]
     pub fn SSL_certs_clear(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_check_private_key"]
     pub fn SSL_CTX_check_private_key(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_check_private_key"]
     pub fn SSL_check_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get0_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get0_certificate"]
     pub fn SSL_CTX_get0_certificate(ctx: *const SSL_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_certificate"]
     pub fn SSL_get_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get0_privatekey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get0_privatekey"]
     pub fn SSL_CTX_get0_privatekey(ctx: *const SSL_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_privatekey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_privatekey"]
     pub fn SSL_get_privatekey(ssl: *const SSL) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get0_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get0_chain_certs"]
     pub fn SSL_CTX_get0_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_extra_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_extra_chain_certs"]
     pub fn SSL_CTX_get_extra_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_chain_certs"]
     pub fn SSL_get0_chain_certs(
         ssl: *const SSL,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_signed_cert_timestamp_list"]
     pub fn SSL_CTX_set_signed_cert_timestamp_list(
         ctx: *mut SSL_CTX,
         list: *const u8,
@@ -29454,7 +29454,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_signed_cert_timestamp_list"]
     pub fn SSL_set_signed_cert_timestamp_list(
         ctx: *mut SSL,
         list: *const u8,
@@ -29462,7 +29462,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_ocsp_response"]
     pub fn SSL_CTX_set_ocsp_response(
         ctx: *mut SSL_CTX,
         response: *const u8,
@@ -29470,7 +29470,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_ocsp_response"]
     pub fn SSL_set_ocsp_response(
         ssl: *mut SSL,
         response: *const u8,
@@ -29478,26 +29478,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_signature_algorithm_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_signature_algorithm_name"]
     pub fn SSL_get_signature_algorithm_name(
         sigalg: u16,
         include_curve: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_signature_algorithm_key_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_signature_algorithm_key_type"]
     pub fn SSL_get_signature_algorithm_key_type(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_signature_algorithm_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_signature_algorithm_digest"]
     pub fn SSL_get_signature_algorithm_digest(sigalg: u16) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_is_signature_algorithm_rsa_pss"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_is_signature_algorithm_rsa_pss"]
     pub fn SSL_is_signature_algorithm_rsa_pss(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_signing_algorithm_prefs"]
     pub fn SSL_CTX_set_signing_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -29505,7 +29505,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_signing_algorithm_prefs"]
     pub fn SSL_set_signing_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -29513,7 +29513,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_chain_and_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_chain_and_key"]
     pub fn SSL_CTX_set_chain_and_key(
         ctx: *mut SSL_CTX,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29523,7 +29523,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_chain_and_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_chain_and_key"]
     pub fn SSL_set_chain_and_key(
         ssl: *mut SSL,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29533,19 +29533,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get0_chain"]
     pub fn SSL_CTX_get0_chain(ctx: *const SSL_CTX) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_RSAPrivateKey"]
     pub fn SSL_CTX_use_RSAPrivateKey(ctx: *mut SSL_CTX, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_RSAPrivateKey"]
     pub fn SSL_use_RSAPrivateKey(ssl: *mut SSL, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_certificate_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_certificate_ASN1"]
     pub fn SSL_CTX_use_certificate_ASN1(
         ctx: *mut SSL_CTX,
         der_len: usize,
@@ -29553,7 +29553,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_certificate_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_certificate_ASN1"]
     pub fn SSL_use_certificate_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29561,7 +29561,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_PrivateKey_ASN1"]
     pub fn SSL_CTX_use_PrivateKey_ASN1(
         pk: ::std::os::raw::c_int,
         ctx: *mut SSL_CTX,
@@ -29570,7 +29570,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_PrivateKey_ASN1"]
     pub fn SSL_use_PrivateKey_ASN1(
         type_: ::std::os::raw::c_int,
         ssl: *mut SSL,
@@ -29579,7 +29579,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_RSAPrivateKey_ASN1"]
     pub fn SSL_CTX_use_RSAPrivateKey_ASN1(
         ctx: *mut SSL_CTX,
         der: *const u8,
@@ -29587,7 +29587,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_RSAPrivateKey_ASN1"]
     pub fn SSL_use_RSAPrivateKey_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29595,7 +29595,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_RSAPrivateKey_file"]
     pub fn SSL_CTX_use_RSAPrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29603,7 +29603,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_RSAPrivateKey_file"]
     pub fn SSL_use_RSAPrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29611,7 +29611,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_certificate_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_certificate_file"]
     pub fn SSL_CTX_use_certificate_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29619,7 +29619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_certificate_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_certificate_file"]
     pub fn SSL_use_certificate_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29627,7 +29627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_PrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_PrivateKey_file"]
     pub fn SSL_CTX_use_PrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29635,7 +29635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_PrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_PrivateKey_file"]
     pub fn SSL_use_PrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29643,29 +29643,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_certificate_chain_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_certificate_chain_file"]
     pub fn SSL_CTX_use_certificate_chain_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_default_passwd_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_default_passwd_cb"]
     pub fn SSL_CTX_set_default_passwd_cb(ctx: *mut SSL_CTX, cb: pem_password_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_default_passwd_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_default_passwd_cb"]
     pub fn SSL_CTX_get_default_passwd_cb(ctx: *const SSL_CTX) -> pem_password_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_default_passwd_cb_userdata"]
     pub fn SSL_CTX_set_default_passwd_cb_userdata(
         ctx: *mut SSL_CTX,
         data: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_default_passwd_cb_userdata"]
     pub fn SSL_CTX_get_default_passwd_cb_userdata(
         ctx: *const SSL_CTX,
     ) -> *mut ::std::os::raw::c_void;
@@ -29754,18 +29754,18 @@ fn bindgen_test_layout_ssl_private_key_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_private_key_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_private_key_method"]
     pub fn SSL_set_private_key_method(ssl: *mut SSL, key_method: *const SSL_PRIVATE_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_private_key_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_private_key_method"]
     pub fn SSL_CTX_set_private_key_method(
         ctx: *mut SSL_CTX,
         key_method: *const SSL_PRIVATE_KEY_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_can_release_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_can_release_private_key"]
     pub fn SSL_can_release_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -29790,149 +29790,149 @@ pub type sk_SSL_CIPHER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_cipher_by_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_cipher_by_value"]
     pub fn SSL_get_cipher_by_value(value: u16) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_id"]
     pub fn SSL_CIPHER_get_id(cipher: *const SSL_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_protocol_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_protocol_id"]
     pub fn SSL_CIPHER_get_protocol_id(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_is_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_is_aead"]
     pub fn SSL_CIPHER_is_aead(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_is_block_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_is_block_cipher"]
     pub fn SSL_CIPHER_is_block_cipher(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_cipher_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_cipher_nid"]
     pub fn SSL_CIPHER_get_cipher_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_digest_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_digest_nid"]
     pub fn SSL_CIPHER_get_digest_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_kx_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_kx_nid"]
     pub fn SSL_CIPHER_get_kx_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_auth_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_auth_nid"]
     pub fn SSL_CIPHER_get_auth_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_prf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_prf_nid"]
     pub fn SSL_CIPHER_get_prf_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_min_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_min_version"]
     pub fn SSL_CIPHER_get_min_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_max_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_max_version"]
     pub fn SSL_CIPHER_get_max_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_standard_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_standard_name"]
     pub fn SSL_CIPHER_standard_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_name"]
     pub fn SSL_CIPHER_get_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_kx_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_kx_name"]
     pub fn SSL_CIPHER_get_kx_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_bits"]
     pub fn SSL_CIPHER_get_bits(
         cipher: *const SSL_CIPHER,
         out_alg_bits: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_strict_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_strict_cipher_list"]
     pub fn SSL_CTX_set_strict_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_cipher_list"]
     pub fn SSL_CTX_set_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_strict_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_strict_cipher_list"]
     pub fn SSL_set_strict_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_ciphersuites"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_ciphersuites"]
     pub fn SSL_CTX_set_ciphersuites(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_cipher_list"]
     pub fn SSL_set_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_ciphers"]
     pub fn SSL_CTX_get_ciphers(ctx: *const SSL_CTX) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_cipher_in_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_cipher_in_group"]
     pub fn SSL_CTX_cipher_in_group(ctx: *const SSL_CTX, i: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ciphers"]
     pub fn SSL_get_ciphers(ssl: *const SSL) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_is_init_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_is_init_finished"]
     pub fn SSL_is_init_finished(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_in_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_in_init"]
     pub fn SSL_in_init(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_in_false_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_in_false_start"]
     pub fn SSL_in_false_start(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_certificate"]
     pub fn SSL_get_peer_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_cert_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_cert_chain"]
     pub fn SSL_get_peer_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_full_cert_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_full_cert_chain"]
     pub fn SSL_get_peer_full_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_peer_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_peer_certificates"]
     pub fn SSL_get0_peer_certificates(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_signed_cert_timestamp_list"]
     pub fn SSL_get0_signed_cert_timestamp_list(
         ssl: *const SSL,
         out: *mut *const u8,
@@ -29940,11 +29940,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_ocsp_response"]
     pub fn SSL_get0_ocsp_response(ssl: *const SSL, out: *mut *const u8, out_len: *mut usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_tls_unique"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_tls_unique"]
     pub fn SSL_get_tls_unique(
         ssl: *const SSL,
         out: *mut u8,
@@ -29953,23 +29953,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_extms_support"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_extms_support"]
     pub fn SSL_get_extms_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_current_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_current_cipher"]
     pub fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_session_reused"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_session_reused"]
     pub fn SSL_session_reused(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_secure_renegotiation_support"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_secure_renegotiation_support"]
     pub fn SSL_get_secure_renegotiation_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_export_keying_material"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_export_keying_material"]
     pub fn SSL_export_keying_material(
         ssl: *mut SSL,
         out: *mut u8,
@@ -29982,7 +29982,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_SSL_SESSION"]
     pub fn PEM_read_bio_SSL_SESSION(
         bp: *mut BIO,
         x: *mut *mut SSL_SESSION,
@@ -29991,7 +29991,7 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_SSL_SESSION"]
     pub fn PEM_read_SSL_SESSION(
         fp: *mut FILE,
         x: *mut *mut SSL_SESSION,
@@ -30000,27 +30000,27 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_SSL_SESSION"]
     pub fn PEM_write_bio_SSL_SESSION(bp: *mut BIO, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_SSL_SESSION"]
     pub fn PEM_write_SSL_SESSION(fp: *mut FILE, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_new"]
     pub fn SSL_SESSION_new(ctx: *const SSL_CTX) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_up_ref"]
     pub fn SSL_SESSION_up_ref(session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_free"]
     pub fn SSL_SESSION_free(session: *mut SSL_SESSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_to_bytes"]
     pub fn SSL_SESSION_to_bytes(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -30028,7 +30028,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_to_bytes_for_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_to_bytes_for_ticket"]
     pub fn SSL_SESSION_to_bytes_for_ticket(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -30036,7 +30036,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_from_bytes"]
     pub fn SSL_SESSION_from_bytes(
         in_: *const u8,
         in_len: usize,
@@ -30044,29 +30044,29 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_version"]
     pub fn SSL_SESSION_get_version(session: *const SSL_SESSION) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_protocol_version"]
     pub fn SSL_SESSION_get_protocol_version(session: *const SSL_SESSION) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set_protocol_version"]
     pub fn SSL_SESSION_set_protocol_version(
         session: *mut SSL_SESSION,
         version: u16,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_id"]
     pub fn SSL_SESSION_get_id(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set1_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set1_id"]
     pub fn SSL_SESSION_set1_id(
         session: *mut SSL_SESSION,
         sid: *const u8,
@@ -30074,25 +30074,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_time"]
     pub fn SSL_SESSION_get_time(session: *const SSL_SESSION) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_timeout"]
     pub fn SSL_SESSION_get_timeout(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_peer"]
     pub fn SSL_SESSION_get0_peer(session: *const SSL_SESSION) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_peer_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_peer_certificates"]
     pub fn SSL_SESSION_get0_peer_certificates(
         session: *const SSL_SESSION,
     ) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_signed_cert_timestamp_list"]
     pub fn SSL_SESSION_get0_signed_cert_timestamp_list(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -30100,7 +30100,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_ocsp_response"]
     pub fn SSL_SESSION_get0_ocsp_response(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -30108,7 +30108,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_master_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_master_key"]
     pub fn SSL_SESSION_get_master_key(
         session: *const SSL_SESSION,
         out: *mut u8,
@@ -30116,22 +30116,22 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set_time"]
     pub fn SSL_SESSION_set_time(session: *mut SSL_SESSION, time: u64) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set_timeout"]
     pub fn SSL_SESSION_set_timeout(session: *mut SSL_SESSION, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_id_context"]
     pub fn SSL_SESSION_get0_id_context(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set1_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set1_id_context"]
     pub fn SSL_SESSION_set1_id_context(
         session: *mut SSL_SESSION,
         sid_ctx: *const u8,
@@ -30139,19 +30139,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_should_be_single_use"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_should_be_single_use"]
     pub fn SSL_SESSION_should_be_single_use(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_is_resumable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_is_resumable"]
     pub fn SSL_SESSION_is_resumable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_has_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_has_ticket"]
     pub fn SSL_SESSION_has_ticket(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_ticket"]
     pub fn SSL_SESSION_get0_ticket(
         session: *const SSL_SESSION,
         out_ticket: *mut *const u8,
@@ -30159,7 +30159,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set_ticket"]
     pub fn SSL_SESSION_set_ticket(
         session: *mut SSL_SESSION,
         ticket: *const u8,
@@ -30167,19 +30167,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_ticket_lifetime_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_ticket_lifetime_hint"]
     pub fn SSL_SESSION_get_ticket_lifetime_hint(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_cipher"]
     pub fn SSL_SESSION_get0_cipher(session: *const SSL_SESSION) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_has_peer_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_has_peer_sha256"]
     pub fn SSL_SESSION_has_peer_sha256(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_peer_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_peer_sha256"]
     pub fn SSL_SESSION_get0_peer_sha256(
         session: *const SSL_SESSION,
         out_ptr: *mut *const u8,
@@ -30187,34 +30187,34 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_session_cache_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_session_cache_mode"]
     pub fn SSL_CTX_set_session_cache_mode(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_session_cache_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_session_cache_mode"]
     pub fn SSL_CTX_get_session_cache_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_session"]
     pub fn SSL_set_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_timeout"]
     pub fn SSL_CTX_set_timeout(ctx: *mut SSL_CTX, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_session_psk_dhe_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_session_psk_dhe_timeout"]
     pub fn SSL_CTX_set_session_psk_dhe_timeout(ctx: *mut SSL_CTX, timeout: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_timeout"]
     pub fn SSL_CTX_get_timeout(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_session_id_context"]
     pub fn SSL_CTX_set_session_id_context(
         ctx: *mut SSL_CTX,
         sid_ctx: *const u8,
@@ -30222,7 +30222,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_session_id_context"]
     pub fn SSL_set_session_id_context(
         ssl: *mut SSL,
         sid_ctx: *const u8,
@@ -30230,44 +30230,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_session_id_context"]
     pub fn SSL_get0_session_id_context(ssl: *const SSL, out_len: *mut usize) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_set_cache_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_set_cache_size"]
     pub fn SSL_CTX_sess_set_cache_size(
         ctx: *mut SSL_CTX,
         size: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_get_cache_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_get_cache_size"]
     pub fn SSL_CTX_sess_get_cache_size(ctx: *const SSL_CTX) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_number"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_number"]
     pub fn SSL_CTX_sess_number(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add_session"]
     pub fn SSL_CTX_add_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_remove_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_remove_session"]
     pub fn SSL_CTX_remove_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_flush_sessions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_flush_sessions"]
     pub fn SSL_CTX_flush_sessions(ctx: *mut SSL_CTX, time: u64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_set_new_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_set_new_cb"]
     pub fn SSL_CTX_sess_set_new_cb(
         ctx: *mut SSL_CTX,
         new_session_cb: ::std::option::Option<
@@ -30276,7 +30276,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_get_new_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_get_new_cb"]
     pub fn SSL_CTX_sess_get_new_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30284,7 +30284,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_set_remove_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_set_remove_cb"]
     pub fn SSL_CTX_sess_set_remove_cb(
         ctx: *mut SSL_CTX,
         remove_session_cb: ::std::option::Option<
@@ -30293,13 +30293,13 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_get_remove_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_get_remove_cb"]
     pub fn SSL_CTX_sess_get_remove_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<unsafe extern "C" fn(ctx: *mut SSL_CTX, arg1: *mut SSL_SESSION)>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_set_get_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_set_get_cb"]
     pub fn SSL_CTX_sess_set_get_cb(
         ctx: *mut SSL_CTX,
         get_session_cb: ::std::option::Option<
@@ -30313,7 +30313,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_get_get_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_get_get_cb"]
     pub fn SSL_CTX_sess_get_get_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30326,11 +30326,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_magic_pending_session_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_magic_pending_session_ptr"]
     pub fn SSL_magic_pending_session_ptr() -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_tlsext_ticket_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_tlsext_ticket_keys"]
     pub fn SSL_CTX_get_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         out: *mut ::std::os::raw::c_void,
@@ -30338,7 +30338,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_ticket_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_ticket_keys"]
     pub fn SSL_CTX_set_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         in_: *const ::std::os::raw::c_void,
@@ -30346,7 +30346,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_ticket_key_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_ticket_key_cb"]
     pub fn SSL_CTX_set_tlsext_ticket_key_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30438,14 +30438,14 @@ fn bindgen_test_layout_ssl_ticket_aead_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_ticket_aead_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_ticket_aead_method"]
     pub fn SSL_CTX_set_ticket_aead_method(
         ctx: *mut SSL_CTX,
         aead_method: *const SSL_TICKET_AEAD_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_process_tls13_new_session_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_process_tls13_new_session_ticket"]
     pub fn SSL_process_tls13_new_session_ticket(
         ssl: *mut SSL,
         buf: *const u8,
@@ -30453,15 +30453,15 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_num_tickets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_num_tickets"]
     pub fn SSL_CTX_set_num_tickets(ctx: *mut SSL_CTX, num_tickets: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_num_tickets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_num_tickets"]
     pub fn SSL_CTX_get_num_tickets(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_curves"]
     pub fn SSL_CTX_set1_curves(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_int,
@@ -30469,7 +30469,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_curves"]
     pub fn SSL_set1_curves(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_int,
@@ -30477,29 +30477,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_curves_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_curves_list"]
     pub fn SSL_CTX_set1_curves_list(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_curves_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_curves_list"]
     pub fn SSL_set1_curves_list(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_curve_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_curve_id"]
     pub fn SSL_get_curve_id(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_curve_name"]
     pub fn SSL_get_curve_name(curve_id: u16) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_to_bytes"]
     pub fn SSL_to_bytes(
         in_: *const SSL,
         out_data: *mut *mut u8,
@@ -30507,11 +30507,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_from_bytes"]
     pub fn SSL_from_bytes(in_: *const u8, in_len: usize, ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_groups"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_groups"]
     pub fn SSL_CTX_set1_groups(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_int,
@@ -30519,7 +30519,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_groups"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_groups"]
     pub fn SSL_set1_groups(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_int,
@@ -30527,21 +30527,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_groups_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_groups_list"]
     pub fn SSL_CTX_set1_groups_list(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_groups_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_groups_list"]
     pub fn SSL_set1_groups_list(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_verify"]
     pub fn SSL_CTX_set_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30554,7 +30554,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_verify"]
     pub fn SSL_set_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30571,7 +30571,7 @@ pub const ssl_verify_result_t_ssl_verify_invalid: ssl_verify_result_t = 1;
 pub const ssl_verify_result_t_ssl_verify_retry: ssl_verify_result_t = 2;
 pub type ssl_verify_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_custom_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_custom_verify"]
     pub fn SSL_CTX_set_custom_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30581,7 +30581,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_custom_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_custom_verify"]
     pub fn SSL_set_custom_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30591,15 +30591,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_verify_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_verify_mode"]
     pub fn SSL_CTX_get_verify_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_verify_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_verify_mode"]
     pub fn SSL_get_verify_mode(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_verify_callback"]
     pub fn SSL_CTX_get_verify_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -30610,7 +30610,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_verify_callback"]
     pub fn SSL_get_verify_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -30621,83 +30621,83 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_host"]
     pub fn SSL_set1_host(
         ssl: *mut SSL,
         hostname: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_verify_depth"]
     pub fn SSL_CTX_set_verify_depth(ctx: *mut SSL_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_verify_depth"]
     pub fn SSL_set_verify_depth(ssl: *mut SSL, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_verify_depth"]
     pub fn SSL_CTX_get_verify_depth(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_verify_depth"]
     pub fn SSL_get_verify_depth(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_param"]
     pub fn SSL_CTX_set1_param(
         ctx: *mut SSL_CTX,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_param"]
     pub fn SSL_set1_param(ssl: *mut SSL, param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get0_param"]
     pub fn SSL_CTX_get0_param(ctx: *mut SSL_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_param"]
     pub fn SSL_get0_param(ssl: *mut SSL) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_purpose"]
     pub fn SSL_CTX_set_purpose(
         ctx: *mut SSL_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_purpose"]
     pub fn SSL_set_purpose(ssl: *mut SSL, purpose: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_trust"]
     pub fn SSL_CTX_set_trust(
         ctx: *mut SSL_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_trust"]
     pub fn SSL_set_trust(ssl: *mut SSL, trust: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_cert_store"]
     pub fn SSL_CTX_set_cert_store(ctx: *mut SSL_CTX, store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_cert_store"]
     pub fn SSL_CTX_get_cert_store(ctx: *const SSL_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_default_verify_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_default_verify_paths"]
     pub fn SSL_CTX_set_default_verify_paths(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_load_verify_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_load_verify_locations"]
     pub fn SSL_CTX_load_verify_locations(
         ctx: *mut SSL_CTX,
         ca_file: *const ::std::os::raw::c_char,
@@ -30705,19 +30705,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_verify_result"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_verify_result"]
     pub fn SSL_get_verify_result(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_alert_from_verify_result"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_alert_from_verify_result"]
     pub fn SSL_alert_from_verify_result(result: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ex_data_X509_STORE_CTX_idx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ex_data_X509_STORE_CTX_idx"]
     pub fn SSL_get_ex_data_X509_STORE_CTX_idx() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_cert_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_cert_verify_callback"]
     pub fn SSL_CTX_set_cert_verify_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30730,51 +30730,51 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_enable_signed_cert_timestamps"]
     pub fn SSL_enable_signed_cert_timestamps(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_enable_signed_cert_timestamps"]
     pub fn SSL_CTX_enable_signed_cert_timestamps(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_enable_ocsp_stapling"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_enable_ocsp_stapling"]
     pub fn SSL_enable_ocsp_stapling(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_enable_ocsp_stapling"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_enable_ocsp_stapling"]
     pub fn SSL_CTX_enable_ocsp_stapling(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set0_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set0_verify_cert_store"]
     pub fn SSL_CTX_set0_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_verify_cert_store"]
     pub fn SSL_CTX_set1_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set0_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set0_verify_cert_store"]
     pub fn SSL_set0_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_verify_cert_store"]
     pub fn SSL_set1_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_verify_algorithm_prefs"]
     pub fn SSL_CTX_set_verify_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -30782,7 +30782,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_verify_algorithm_prefs"]
     pub fn SSL_set_verify_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -30790,87 +30790,87 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_hostflags"]
     pub fn SSL_set_hostflags(ssl: *mut SSL, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_client_CA_list"]
     pub fn SSL_set_client_CA_list(ssl: *mut SSL, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_client_CA_list"]
     pub fn SSL_CTX_set_client_CA_list(ctx: *mut SSL_CTX, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set0_client_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set0_client_CAs"]
     pub fn SSL_set0_client_CAs(ssl: *mut SSL, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set0_client_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set0_client_CAs"]
     pub fn SSL_CTX_set0_client_CAs(ctx: *mut SSL_CTX, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_client_CA_list"]
     pub fn SSL_get_client_CA_list(ssl: *const SSL) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_server_requested_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_server_requested_CAs"]
     pub fn SSL_get0_server_requested_CAs(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_client_CA_list"]
     pub fn SSL_CTX_get_client_CA_list(ctx: *const SSL_CTX) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add_client_CA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add_client_CA"]
     pub fn SSL_add_client_CA(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add_client_CA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add_client_CA"]
     pub fn SSL_CTX_add_client_CA(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_load_client_CA_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_load_client_CA_file"]
     pub fn SSL_load_client_CA_file(file: *const ::std::os::raw::c_char) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_dup_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_dup_CA_list"]
     pub fn SSL_dup_CA_list(list: *mut stack_st_X509_NAME) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add_file_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add_file_cert_subjects_to_stack"]
     pub fn SSL_add_file_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add_bio_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add_bio_cert_subjects_to_stack"]
     pub fn SSL_add_bio_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tlsext_host_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tlsext_host_name"]
     pub fn SSL_set_tlsext_host_name(
         ssl: *mut SSL,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_servername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_servername"]
     pub fn SSL_get_servername(
         ssl: *const SSL,
         type_: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_servername_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_servername_type"]
     pub fn SSL_get_servername_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_servername_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_servername_callback"]
     pub fn SSL_CTX_set_tlsext_servername_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30883,18 +30883,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_servername_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_servername_arg"]
     pub fn SSL_CTX_set_tlsext_servername_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_SSL_CTX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_SSL_CTX"]
     pub fn SSL_set_SSL_CTX(ssl: *mut SSL, ctx: *mut SSL_CTX) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_alpn_protos"]
     pub fn SSL_CTX_set_alpn_protos(
         ctx: *mut SSL_CTX,
         protos: *const u8,
@@ -30902,7 +30902,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_alpn_protos"]
     pub fn SSL_set_alpn_protos(
         ssl: *mut SSL,
         protos: *const u8,
@@ -30910,7 +30910,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_alpn_select_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_alpn_select_cb"]
     pub fn SSL_CTX_set_alpn_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30927,7 +30927,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_alpn_selected"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_alpn_selected"]
     pub fn SSL_get0_alpn_selected(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30935,11 +30935,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_allow_unknown_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_allow_unknown_alpn_protos"]
     pub fn SSL_CTX_set_allow_unknown_alpn_protos(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add_application_settings"]
     pub fn SSL_add_application_settings(
         ssl: *mut SSL,
         proto: *const u8,
@@ -30949,7 +30949,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_peer_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_peer_application_settings"]
     pub fn SSL_get0_peer_application_settings(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30957,7 +30957,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_has_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_has_application_settings"]
     pub fn SSL_has_application_settings(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub type ssl_cert_compression_func_t = ::std::option::Option<
@@ -30978,7 +30978,7 @@ pub type ssl_cert_decompression_func_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add_cert_compression_alg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add_cert_compression_alg"]
     pub fn SSL_CTX_add_cert_compression_alg(
         ctx: *mut SSL_CTX,
         alg_id: u16,
@@ -30987,7 +30987,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_next_protos_advertised_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_next_protos_advertised_cb"]
     pub fn SSL_CTX_set_next_protos_advertised_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31002,7 +31002,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_next_proto_select_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_next_proto_select_cb"]
     pub fn SSL_CTX_set_next_proto_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31019,7 +31019,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_next_proto_negotiated"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_next_proto_negotiated"]
     pub fn SSL_get0_next_proto_negotiated(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -31027,7 +31027,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_select_next_proto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_select_next_proto"]
     pub fn SSL_select_next_proto(
         out: *mut *mut u8,
         out_len: *mut u8,
@@ -31038,29 +31038,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tls_channel_id_enabled"]
     pub fn SSL_CTX_set_tls_channel_id_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tls_channel_id_enabled"]
     pub fn SSL_set_tls_channel_id_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_tls_channel_id"]
     pub fn SSL_CTX_set1_tls_channel_id(
         ctx: *mut SSL_CTX,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_tls_channel_id"]
     pub fn SSL_set1_tls_channel_id(
         ssl: *mut SSL,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_tls_channel_id"]
     pub fn SSL_get_tls_channel_id(ssl: *mut SSL, out: *mut u8, max_out: usize) -> usize;
 }
 #[repr(C)]
@@ -31137,29 +31137,29 @@ pub type sk_SRTP_PROTECTION_PROFILE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_srtp_profiles"]
     pub fn SSL_CTX_set_srtp_profiles(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_srtp_profiles"]
     pub fn SSL_set_srtp_profiles(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_srtp_profiles"]
     pub fn SSL_get_srtp_profiles(ssl: *const SSL) -> *const stack_st_SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_selected_srtp_profile"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_selected_srtp_profile"]
     pub fn SSL_get_selected_srtp_profile(ssl: *mut SSL) -> *const SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_psk_client_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_psk_client_callback"]
     pub fn SSL_CTX_set_psk_client_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31175,7 +31175,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_psk_client_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_psk_client_callback"]
     pub fn SSL_set_psk_client_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31191,7 +31191,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_psk_server_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_psk_server_callback"]
     pub fn SSL_CTX_set_psk_server_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31205,7 +31205,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_psk_server_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_psk_server_callback"]
     pub fn SSL_set_psk_server_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31219,29 +31219,29 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_psk_identity_hint"]
     pub fn SSL_CTX_use_psk_identity_hint(
         ctx: *mut SSL_CTX,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_psk_identity_hint"]
     pub fn SSL_use_psk_identity_hint(
         ssl: *mut SSL,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_psk_identity_hint"]
     pub fn SSL_get_psk_identity_hint(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_psk_identity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_psk_identity"]
     pub fn SSL_get_psk_identity(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_delegated_credential"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_delegated_credential"]
     pub fn SSL_set1_delegated_credential(
         ssl: *mut SSL,
         dc: *mut CRYPTO_BUFFER,
@@ -31250,7 +31250,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_delegated_credential_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_delegated_credential_used"]
     pub fn SSL_delegated_credential_used(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub const ssl_encryption_level_t_ssl_encryption_initial: ssl_encryption_level_t = 0;
@@ -31363,22 +31363,22 @@ fn bindgen_test_layout_ssl_quic_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_quic_max_handshake_flight_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_quic_max_handshake_flight_len"]
     pub fn SSL_quic_max_handshake_flight_len(
         ssl: *const SSL,
         level: ssl_encryption_level_t,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_quic_read_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_quic_read_level"]
     pub fn SSL_quic_read_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_quic_write_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_quic_write_level"]
     pub fn SSL_quic_write_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_provide_quic_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_provide_quic_data"]
     pub fn SSL_provide_quic_data(
         ssl: *mut SSL,
         level: ssl_encryption_level_t,
@@ -31387,25 +31387,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_process_quic_post_handshake"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_process_quic_post_handshake"]
     pub fn SSL_process_quic_post_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_quic_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_quic_method"]
     pub fn SSL_CTX_set_quic_method(
         ctx: *mut SSL_CTX,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_quic_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_quic_method"]
     pub fn SSL_set_quic_method(
         ssl: *mut SSL,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_quic_transport_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_quic_transport_params"]
     pub fn SSL_set_quic_transport_params(
         ssl: *mut SSL,
         params: *const u8,
@@ -31413,7 +31413,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_quic_transport_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_quic_transport_params"]
     pub fn SSL_get_peer_quic_transport_params(
         ssl: *const SSL,
         out_params: *mut *const u8,
@@ -31421,11 +31421,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_quic_use_legacy_codepoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_quic_use_legacy_codepoint"]
     pub fn SSL_set_quic_use_legacy_codepoint(ssl: *mut SSL, use_legacy: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_quic_early_data_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_quic_early_data_context"]
     pub fn SSL_set_quic_early_data_context(
         ssl: *mut SSL,
         context: *const u8,
@@ -31433,35 +31433,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_early_data_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_early_data_enabled"]
     pub fn SSL_CTX_set_early_data_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_early_data_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_early_data_enabled"]
     pub fn SSL_set_early_data_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_in_early_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_in_early_data"]
     pub fn SSL_in_early_data(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_early_data_capable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_early_data_capable"]
     pub fn SSL_SESSION_early_data_capable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_copy_without_early_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_copy_without_early_data"]
     pub fn SSL_SESSION_copy_without_early_data(session: *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_early_data_accepted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_early_data_accepted"]
     pub fn SSL_early_data_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_reset_early_data_reject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_reset_early_data_reject"]
     pub fn SSL_reset_early_data_reject(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ticket_age_skew"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ticket_age_skew"]
     pub fn SSL_get_ticket_age_skew(ssl: *const SSL) -> i32;
 }
 pub const ssl_early_data_reason_t_ssl_early_data_unknown: ssl_early_data_reason_t = 0;
@@ -31483,21 +31483,21 @@ pub const ssl_early_data_reason_t_ssl_early_data_alps_mismatch: ssl_early_data_r
 pub const ssl_early_data_reason_t_ssl_early_data_reason_max_value: ssl_early_data_reason_t = 14;
 pub type ssl_early_data_reason_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_early_data_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_early_data_reason"]
     pub fn SSL_get_early_data_reason(ssl: *const SSL) -> ssl_early_data_reason_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_early_data_reason_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_early_data_reason_string"]
     pub fn SSL_early_data_reason_string(
         reason: ssl_early_data_reason_t,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_enable_ech_grease"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_enable_ech_grease"]
     pub fn SSL_set_enable_ech_grease(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_ech_config_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_ech_config_list"]
     pub fn SSL_set1_ech_config_list(
         ssl: *mut SSL,
         ech_config_list: *const u8,
@@ -31505,7 +31505,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_ech_name_override"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_ech_name_override"]
     pub fn SSL_get0_ech_name_override(
         ssl: *const SSL,
         out_name: *mut *const ::std::os::raw::c_char,
@@ -31513,7 +31513,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_ech_retry_configs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_ech_retry_configs"]
     pub fn SSL_get0_ech_retry_configs(
         ssl: *const SSL,
         out_retry_configs: *mut *const u8,
@@ -31521,7 +31521,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_marshal_ech_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_marshal_ech_config"]
     pub fn SSL_marshal_ech_config(
         out: *mut *mut u8,
         out_len: *mut usize,
@@ -31532,19 +31532,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_new"]
     pub fn SSL_ECH_KEYS_new() -> *mut SSL_ECH_KEYS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_up_ref"]
     pub fn SSL_ECH_KEYS_up_ref(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_free"]
     pub fn SSL_ECH_KEYS_free(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_add"]
     pub fn SSL_ECH_KEYS_add(
         keys: *mut SSL_ECH_KEYS,
         is_retry_config: ::std::os::raw::c_int,
@@ -31554,12 +31554,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_has_duplicate_config_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_has_duplicate_config_id"]
     pub fn SSL_ECH_KEYS_has_duplicate_config_id(keys: *const SSL_ECH_KEYS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_marshal_retry_configs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_marshal_retry_configs"]
     pub fn SSL_ECH_KEYS_marshal_retry_configs(
         keys: *const SSL_ECH_KEYS,
         out: *mut *mut u8,
@@ -31567,34 +31567,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_ech_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_ech_keys"]
     pub fn SSL_CTX_set1_ech_keys(
         ctx: *mut SSL_CTX,
         keys: *mut SSL_ECH_KEYS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ech_accepted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ech_accepted"]
     pub fn SSL_ech_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_alert_type_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_alert_type_string_long"]
     pub fn SSL_alert_type_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_alert_desc_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_alert_desc_string_long"]
     pub fn SSL_alert_desc_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_send_fatal_alert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_send_fatal_alert"]
     pub fn SSL_send_fatal_alert(ssl: *mut SSL, alert: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_ex_data"]
     pub fn SSL_set_ex_data(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -31602,14 +31602,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ex_data"]
     pub fn SSL_get_ex_data(
         ssl: *const SSL,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ex_new_index"]
     pub fn SSL_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31619,7 +31619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set_ex_data"]
     pub fn SSL_SESSION_set_ex_data(
         session: *mut SSL_SESSION,
         idx: ::std::os::raw::c_int,
@@ -31627,14 +31627,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_ex_data"]
     pub fn SSL_SESSION_get_ex_data(
         session: *const SSL_SESSION,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_ex_new_index"]
     pub fn SSL_SESSION_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31644,7 +31644,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_ex_data"]
     pub fn SSL_CTX_set_ex_data(
         ctx: *mut SSL_CTX,
         idx: ::std::os::raw::c_int,
@@ -31652,14 +31652,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_ex_data"]
     pub fn SSL_CTX_get_ex_data(
         ctx: *const SSL_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_ex_new_index"]
     pub fn SSL_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31669,7 +31669,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ivs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ivs"]
     pub fn SSL_get_ivs(
         ssl: *const SSL,
         out_read_iv: *mut *const u8,
@@ -31678,11 +31678,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_key_block_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_key_block_len"]
     pub fn SSL_get_key_block_len(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_generate_key_block"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_generate_key_block"]
     pub fn SSL_generate_key_block(
         ssl: *const SSL,
         out: *mut u8,
@@ -31690,26 +31690,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_read_sequence"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_read_sequence"]
     pub fn SSL_get_read_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_write_sequence"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_write_sequence"]
     pub fn SSL_get_write_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_record_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_record_protocol_version"]
     pub fn SSL_CTX_set_record_protocol_version(
         ctx: *mut SSL_CTX,
         version: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_serialize_capabilities"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_serialize_capabilities"]
     pub fn SSL_serialize_capabilities(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_request_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_request_handshake_hints"]
     pub fn SSL_request_handshake_hints(
         ssl: *mut SSL,
         client_hello: *const u8,
@@ -31719,11 +31719,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_serialize_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_serialize_handshake_hints"]
     pub fn SSL_serialize_handshake_hints(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_handshake_hints"]
     pub fn SSL_set_handshake_hints(
         ssl: *mut SSL,
         hints: *const u8,
@@ -31731,7 +31731,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_msg_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_msg_callback"]
     pub fn SSL_CTX_set_msg_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31748,11 +31748,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_msg_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_msg_callback_arg"]
     pub fn SSL_CTX_set_msg_callback_arg(ctx: *mut SSL_CTX, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_msg_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_msg_callback"]
     pub fn SSL_set_msg_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31769,11 +31769,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_msg_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_msg_callback_arg"]
     pub fn SSL_set_msg_callback_arg(ssl: *mut SSL, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_keylog_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_keylog_callback"]
     pub fn SSL_CTX_set_keylog_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31782,7 +31782,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_keylog_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_keylog_callback"]
     pub fn SSL_CTX_get_keylog_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -31790,14 +31790,14 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_current_time_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_current_time_cb"]
     pub fn SSL_CTX_set_current_time_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<unsafe extern "C" fn(ssl: *const SSL, out_clock: *mut timeval)>,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_shed_handshake_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_shed_handshake_config"]
     pub fn SSL_set_shed_handshake_config(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_never: ssl_renegotiate_mode_t = 0;
@@ -31807,46 +31807,46 @@ pub const ssl_renegotiate_mode_t_ssl_renegotiate_ignore: ssl_renegotiate_mode_t 
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_explicit: ssl_renegotiate_mode_t = 4;
 pub type ssl_renegotiate_mode_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_renegotiate_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_renegotiate_mode"]
     pub fn SSL_set_renegotiate_mode(ssl: *mut SSL, mode: ssl_renegotiate_mode_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_renegotiate"]
     pub fn SSL_renegotiate(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_renegotiate_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_renegotiate_pending"]
     pub fn SSL_renegotiate_pending(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_total_renegotiations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_total_renegotiations"]
     pub fn SSL_total_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_max_cert_list"]
     pub fn SSL_CTX_get_max_cert_list(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_max_cert_list"]
     pub fn SSL_CTX_set_max_cert_list(ctx: *mut SSL_CTX, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_max_cert_list"]
     pub fn SSL_get_max_cert_list(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_max_cert_list"]
     pub fn SSL_set_max_cert_list(ssl: *mut SSL, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_max_send_fragment"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_max_send_fragment"]
     pub fn SSL_CTX_set_max_send_fragment(
         ctx: *mut SSL_CTX,
         max_send_fragment: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_max_send_fragment"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_max_send_fragment"]
     pub fn SSL_set_max_send_fragment(
         ssl: *mut SSL,
         max_send_fragment: usize,
@@ -32040,7 +32040,7 @@ pub const ssl_select_cert_result_t_ssl_select_cert_retry: ssl_select_cert_result
 pub const ssl_select_cert_result_t_ssl_select_cert_error: ssl_select_cert_result_t = -1;
 pub type ssl_select_cert_result_t = ::std::os::raw::c_int;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_early_callback_ctx_extension_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_early_callback_ctx_extension_get"]
     pub fn SSL_early_callback_ctx_extension_get(
         client_hello: *const SSL_CLIENT_HELLO,
         extension_type: u16,
@@ -32049,7 +32049,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_select_certificate_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_select_certificate_cb"]
     pub fn SSL_CTX_set_select_certificate_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32058,7 +32058,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_dos_protection_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_dos_protection_cb"]
     pub fn SSL_CTX_set_dos_protection_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32067,19 +32067,19 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_reverify_on_resume"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_reverify_on_resume"]
     pub fn SSL_CTX_set_reverify_on_resume(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_enforce_rsa_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_enforce_rsa_key_usage"]
     pub fn SSL_set_enforce_rsa_key_usage(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_was_key_usage_invalid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_was_key_usage_invalid"]
     pub fn SSL_was_key_usage_invalid(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_info_callback"]
     pub fn SSL_CTX_set_info_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32092,7 +32092,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_info_callback"]
     pub fn SSL_CTX_get_info_callback(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -32104,7 +32104,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_info_callback"]
     pub fn SSL_set_info_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32117,7 +32117,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_info_callback"]
     pub fn SSL_get_info_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -32129,77 +32129,77 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_state_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_state_string_long"]
     pub fn SSL_state_string_long(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_shutdown"]
     pub fn SSL_get_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_signature_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_signature_algorithm"]
     pub fn SSL_get_peer_signature_algorithm(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_client_random"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_client_random"]
     pub fn SSL_get_client_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_server_random"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_server_random"]
     pub fn SSL_get_server_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_pending_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_pending_cipher"]
     pub fn SSL_get_pending_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_set_retain_only_sha256_of_client_certs(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_CTX_set_retain_only_sha256_of_client_certs(
         ctx: *mut SSL_CTX,
         enable: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_grease_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_grease_enabled"]
     pub fn SSL_CTX_set_grease_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_permute_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_permute_extensions"]
     pub fn SSL_CTX_set_permute_extensions(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_permute_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_permute_extensions"]
     pub fn SSL_set_permute_extensions(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_max_seal_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_max_seal_overhead"]
     pub fn SSL_max_seal_overhead(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_false_start_allowed_without_alpn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_false_start_allowed_without_alpn"]
     pub fn SSL_CTX_set_false_start_allowed_without_alpn(
         ctx: *mut SSL_CTX,
         allowed: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_used_hello_retry_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_used_hello_retry_request"]
     pub fn SSL_used_hello_retry_request(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_jdk11_workaround"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_jdk11_workaround"]
     pub fn SSL_set_jdk11_workaround(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_library_init"]
     pub fn SSL_library_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_description"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_description"]
     pub fn SSL_CIPHER_description(
         cipher: *const SSL_CIPHER,
         buf: *mut ::std::os::raw::c_char,
@@ -32207,11 +32207,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_version"]
     pub fn SSL_CIPHER_get_version(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_rfc_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_rfc_name"]
     pub fn SSL_CIPHER_get_rfc_name(cipher: *const SSL_CIPHER) -> *mut ::std::os::raw::c_char;
 }
 pub type COMP_METHOD = ::std::os::raw::c_void;
@@ -32222,126 +32222,126 @@ pub struct stack_st_SSL_COMP {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_get_compression_methods"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_get_compression_methods"]
     pub fn SSL_COMP_get_compression_methods() -> *mut stack_st_SSL_COMP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_add_compression_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_add_compression_method"]
     pub fn SSL_COMP_add_compression_method(
         id: ::std::os::raw::c_int,
         cm: *mut COMP_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_get_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_get_name"]
     pub fn SSL_COMP_get_name(comp: *const COMP_METHOD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_get0_name"]
     pub fn SSL_COMP_get0_name(comp: *const SSL_COMP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_get_id"]
     pub fn SSL_COMP_get_id(comp: *const SSL_COMP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_free_compression_methods"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_free_compression_methods"]
     pub fn SSL_COMP_free_compression_methods();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLv23_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLv23_method"]
     pub fn SSLv23_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_method"]
     pub fn TLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_1_method"]
     pub fn TLSv1_1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_2_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_2_method"]
     pub fn TLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_method"]
     pub fn DTLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_2_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_2_method"]
     pub fn DTLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLS_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLS_server_method"]
     pub fn TLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLS_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLS_client_method"]
     pub fn TLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLv23_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLv23_server_method"]
     pub fn SSLv23_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLv23_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLv23_client_method"]
     pub fn SSLv23_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_server_method"]
     pub fn TLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_client_method"]
     pub fn TLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_1_server_method"]
     pub fn TLSv1_1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_1_client_method"]
     pub fn TLSv1_1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_2_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_2_server_method"]
     pub fn TLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_2_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_2_client_method"]
     pub fn TLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLS_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLS_server_method"]
     pub fn DTLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLS_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLS_client_method"]
     pub fn DTLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_server_method"]
     pub fn DTLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_client_method"]
     pub fn DTLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_2_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_2_server_method"]
     pub fn DTLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_2_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_2_client_method"]
     pub fn DTLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_clear"]
     pub fn SSL_clear(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tmp_rsa_callback"]
     pub fn SSL_CTX_set_tmp_rsa_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32354,7 +32354,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tmp_rsa_callback"]
     pub fn SSL_set_tmp_rsa_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32367,98 +32367,98 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_connect"]
     pub fn SSL_CTX_sess_connect(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_connect_good"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_connect_good"]
     pub fn SSL_CTX_sess_connect_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_connect_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_connect_renegotiate"]
     pub fn SSL_CTX_sess_connect_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_accept"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_accept"]
     pub fn SSL_CTX_sess_accept(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_accept_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_accept_renegotiate"]
     pub fn SSL_CTX_sess_accept_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_accept_good"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_accept_good"]
     pub fn SSL_CTX_sess_accept_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_hits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_hits"]
     pub fn SSL_CTX_sess_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_cb_hits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_cb_hits"]
     pub fn SSL_CTX_sess_cb_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_misses"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_misses"]
     pub fn SSL_CTX_sess_misses(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_timeouts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_timeouts"]
     pub fn SSL_CTX_sess_timeouts(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_cache_full"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_cache_full"]
     pub fn SSL_CTX_sess_cache_full(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_cutthrough_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_cutthrough_complete"]
     pub fn SSL_cutthrough_complete(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_num_renegotiations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_num_renegotiations"]
     pub fn SSL_num_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_need_tmp_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_need_tmp_RSA"]
     pub fn SSL_CTX_need_tmp_RSA(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_need_tmp_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_need_tmp_RSA"]
     pub fn SSL_need_tmp_RSA(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tmp_rsa"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tmp_rsa"]
     pub fn SSL_CTX_set_tmp_rsa(ctx: *mut SSL_CTX, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tmp_rsa"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tmp_rsa"]
     pub fn SSL_set_tmp_rsa(ssl: *mut SSL, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_read_ahead"]
     pub fn SSL_CTX_get_read_ahead(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_read_ahead"]
     pub fn SSL_CTX_set_read_ahead(
         ctx: *mut SSL_CTX,
         yes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_read_ahead"]
     pub fn SSL_get_read_ahead(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_read_ahead"]
     pub fn SSL_set_read_ahead(ssl: *mut SSL, yes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_state"]
     pub fn SSL_set_state(ssl: *mut SSL, state: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_shared_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_shared_ciphers"]
     pub fn SSL_get_shared_ciphers(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_char,
@@ -32466,7 +32466,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_shared_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_shared_sigalgs"]
     pub fn SSL_get_shared_sigalgs(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -32478,11 +32478,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_SSL_SESSION"]
     pub fn i2d_SSL_SESSION(in_: *mut SSL_SESSION, pp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_SSL_SESSION"]
     pub fn d2i_SSL_SESSION(
         a: *mut *mut SSL_SESSION,
         pp: *mut *const u8,
@@ -32490,61 +32490,61 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_SSL_SESSION_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_SSL_SESSION_bio"]
     pub fn i2d_SSL_SESSION_bio(bio: *mut BIO, session: *const SSL_SESSION)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_SSL_SESSION_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_SSL_SESSION_bio"]
     pub fn d2i_SSL_SESSION_bio(bio: *mut BIO, out: *mut *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_SSL_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_SSL_strings"]
     pub fn ERR_load_SSL_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_load_error_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_load_error_strings"]
     pub fn SSL_load_error_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_use_srtp"]
     pub fn SSL_CTX_set_tlsext_use_srtp(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tlsext_use_srtp"]
     pub fn SSL_set_tlsext_use_srtp(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_current_compression"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_current_compression"]
     pub fn SSL_get_current_compression(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_current_expansion"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_current_expansion"]
     pub fn SSL_get_current_expansion(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_server_tmp_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_server_tmp_key"]
     pub fn SSL_get_server_tmp_key(
         ssl: *mut SSL,
         out_key: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tmp_dh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tmp_dh"]
     pub fn SSL_CTX_set_tmp_dh(ctx: *mut SSL_CTX, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tmp_dh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tmp_dh"]
     pub fn SSL_set_tmp_dh(ssl: *mut SSL, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tmp_dh_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tmp_dh_callback"]
     pub fn SSL_CTX_set_tmp_dh_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32557,7 +32557,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tmp_dh_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tmp_dh_callback"]
     pub fn SSL_set_tmp_dh_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32570,7 +32570,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_sigalgs"]
     pub fn SSL_CTX_set1_sigalgs(
         ctx: *mut SSL_CTX,
         values: *const ::std::os::raw::c_int,
@@ -32578,7 +32578,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_sigalgs"]
     pub fn SSL_set1_sigalgs(
         ssl: *mut SSL,
         values: *const ::std::os::raw::c_int,
@@ -32586,25 +32586,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_sigalgs_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_sigalgs_list"]
     pub fn SSL_CTX_set1_sigalgs_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_sigalgs_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_sigalgs_list"]
     pub fn SSL_set1_sigalgs_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_security_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_security_level"]
     pub fn SSL_CTX_get_security_level(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_security_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_security_level"]
     pub fn SSL_CTX_set_security_level(ctx: *const SSL_CTX, level: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -32684,26 +32684,26 @@ pub type sk_SSL_COMP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_cache_hit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_cache_hit"]
     pub fn SSL_cache_hit(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_default_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_default_timeout"]
     pub fn SSL_get_default_timeout(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_version"]
     pub fn SSL_get_version(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_cipher_list"]
     pub fn SSL_get_cipher_list(
         ssl: *const SSL,
         n: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_client_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_client_cert_cb"]
     pub fn SSL_CTX_set_client_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32716,11 +32716,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_want"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_want"]
     pub fn SSL_want(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_finished"]
     pub fn SSL_get_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32728,7 +32728,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_finished"]
     pub fn SSL_get_peer_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32736,15 +32736,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_alert_type_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_alert_type_string"]
     pub fn SSL_alert_type_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_alert_desc_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_alert_desc_string"]
     pub fn SSL_alert_desc_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_state_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_state_string"]
     pub fn SSL_state_string(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 #[repr(C)]
@@ -32754,42 +32754,42 @@ pub struct ssl_conf_ctx_st {
 }
 pub type SSL_CONF_CTX = ssl_conf_ctx_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_state"]
     pub fn SSL_state(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_shutdown"]
     pub fn SSL_set_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tmp_ecdh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tmp_ecdh"]
     pub fn SSL_CTX_set_tmp_ecdh(ctx: *mut SSL_CTX, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tmp_ecdh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tmp_ecdh"]
     pub fn SSL_set_tmp_ecdh(ssl: *mut SSL, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add_dir_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add_dir_cert_subjects_to_stack"]
     pub fn SSL_add_dir_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         dir: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_enable_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_enable_tls_channel_id"]
     pub fn SSL_CTX_enable_tls_channel_id(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_enable_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_enable_tls_channel_id"]
     pub fn SSL_enable_tls_channel_id(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_f_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_f_ssl"]
     pub fn BIO_f_ssl() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_ssl"]
     pub fn BIO_set_ssl(
         bio: *mut BIO,
         ssl: *mut SSL,
@@ -32797,33 +32797,33 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_session"]
     pub fn SSL_get_session(ssl: *const SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get1_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get1_session"]
     pub fn SSL_get1_session(ssl: *mut SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_init_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_init_ssl"]
     pub fn OPENSSL_init_ssl(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tlsext_status_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tlsext_status_type"]
     pub fn SSL_set_tlsext_status_type(
         ssl: *mut SSL,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_tlsext_status_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_tlsext_status_type"]
     pub fn SSL_get_tlsext_status_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tlsext_status_ocsp_resp"]
     pub fn SSL_set_tlsext_status_ocsp_resp(
         ssl: *mut SSL,
         resp: *mut u8,
@@ -32831,11 +32831,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_tlsext_status_ocsp_resp"]
     pub fn SSL_get_tlsext_status_ocsp_resp(ssl: *const SSL, out: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_status_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_status_cb"]
     pub fn SSL_CTX_set_tlsext_status_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -32847,18 +32847,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_status_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_status_arg"]
     pub fn SSL_CTX_set_tlsext_status_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_value"]
     pub fn SSL_CIPHER_get_value(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,

--- a/aws-lc-fips-sys/src/x86_64_unknown_linux_musl_crypto.rs
+++ b/aws-lc-fips-sys/src/x86_64_unknown_linux_musl_crypto.rs
@@ -4276,38 +4276,38 @@ pub type X509_STORE = x509_store_st;
 pub type X509_TRUST = x509_trust_st;
 pub type OPENSSL_BLOCK = *mut ::std::os::raw::c_void;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4316,18 +4316,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4336,18 +4336,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4356,7 +4356,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -4364,11 +4364,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -4379,30 +4379,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -4441,30 +4441,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -4474,15 +4474,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -4546,7 +4546,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4554,7 +4554,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4562,15 +4562,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4582,7 +4582,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4591,7 +4591,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4602,7 +4602,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4613,7 +4613,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4625,7 +4625,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4635,7 +4635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4645,7 +4645,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4656,7 +4656,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4877,27 +4877,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -4905,29 +4905,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -4935,7 +4935,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5067,27 +5067,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -5095,11 +5095,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -5107,22 +5107,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -5131,7 +5131,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -5140,35 +5140,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -5178,7 +5178,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -5238,7 +5238,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -5294,19 +5294,19 @@ impl Default for crypto_ex_data_st {
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5319,7 +5319,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5333,7 +5333,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5344,29 +5344,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -5422,7 +5422,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5433,7 +5433,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5446,7 +5446,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5458,7 +5458,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -5467,7 +5467,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5478,7 +5478,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -5505,23 +5505,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -5529,7 +5529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -5537,7 +5537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5545,7 +5545,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5553,15 +5553,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5570,7 +5570,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5578,7 +5578,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5587,67 +5587,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -5673,7 +5673,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5681,68 +5681,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -5750,7 +5750,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -5758,7 +5758,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -5767,11 +5767,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -5780,15 +5780,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -5796,11 +5796,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -5808,22 +5808,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -5831,30 +5831,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -5862,89 +5862,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -5953,34 +5953,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -5989,13 +5989,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -6004,13 +6004,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -6023,7 +6023,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -6036,7 +6036,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -6049,7 +6049,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6061,7 +6061,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -6075,7 +6075,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6088,7 +6088,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -6101,7 +6101,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6113,23 +6113,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -6139,7 +6139,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -6147,37 +6147,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -6189,7 +6189,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6559,193 +6559,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6754,15 +6754,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -6772,11 +6772,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -6784,47 +6784,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6832,11 +6832,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6844,43 +6844,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -6889,7 +6889,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6899,7 +6899,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6908,7 +6908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6918,7 +6918,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6927,7 +6927,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6937,7 +6937,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6946,7 +6946,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6956,7 +6956,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6965,7 +6965,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6974,7 +6974,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6982,7 +6982,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6991,7 +6991,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7000,7 +7000,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7009,11 +7009,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -7021,7 +7021,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -7081,15 +7081,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -7103,7 +7103,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -7111,11 +7111,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7130,7 +7130,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -7140,7 +7140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -7151,7 +7151,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7161,7 +7161,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7170,7 +7170,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7179,7 +7179,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7188,7 +7188,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7198,7 +7198,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7208,23 +7208,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7233,7 +7233,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7242,7 +7242,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7252,7 +7252,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7261,7 +7261,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7271,7 +7271,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7282,7 +7282,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7293,15 +7293,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -7312,7 +7312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -7325,11 +7325,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -7337,7 +7337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -7345,7 +7345,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -7493,15 +7493,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -7525,15 +7525,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7542,7 +7542,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -7550,14 +7550,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -7565,7 +7565,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -7573,7 +7573,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -7581,7 +7581,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -7589,14 +7589,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -7604,7 +7604,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7612,22 +7612,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -7703,54 +7703,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -7758,7 +7758,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -7766,79 +7766,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -7846,7 +7846,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -7854,7 +7854,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -7862,7 +7862,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -7870,7 +7870,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -7878,7 +7878,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -7886,7 +7886,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -7894,7 +7894,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -7902,7 +7902,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -7910,117 +7910,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -8028,14 +8028,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8045,7 +8045,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8057,7 +8057,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -8067,7 +8067,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -8077,15 +8077,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8093,26 +8093,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8120,23 +8120,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8144,14 +8144,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8159,25 +8159,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -8185,7 +8185,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -8193,14 +8193,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -8229,19 +8229,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -8249,11 +8249,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -8261,54 +8261,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -8316,59 +8316,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -8376,23 +8376,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, t: time_t) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         t: time_t,
@@ -8401,26 +8401,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -8428,29 +8428,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
@@ -8459,22 +8459,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -8482,15 +8482,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -8499,11 +8499,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, t: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         t: time_t,
@@ -8512,41 +8512,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -8554,11 +8554,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8583,7 +8583,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -8593,11 +8593,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8605,11 +8605,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8617,7 +8617,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8951,15 +8951,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -8967,19 +8967,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -8987,7 +8987,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -8995,12 +8995,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9008,14 +9008,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9023,33 +9023,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -9057,7 +9057,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -9065,19 +9065,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -9085,7 +9085,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -9093,7 +9093,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -9103,7 +9103,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -9113,11 +9113,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -9125,33 +9125,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9159,34 +9159,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -9796,7 +9796,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9821,19 +9821,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -9843,19 +9843,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -9865,7 +9865,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -9873,11 +9873,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -9887,7 +9887,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -9895,7 +9895,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -10105,11 +10105,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -10117,11 +10117,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -10176,19 +10176,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10197,7 +10197,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10258,23 +10258,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -10282,82 +10282,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10365,7 +10365,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10373,11 +10373,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10385,7 +10385,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10394,7 +10394,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10405,22 +10405,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10429,7 +10429,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10438,7 +10438,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -10447,7 +10447,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -10456,33 +10456,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10490,7 +10490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10498,7 +10498,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -10805,23 +10805,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -10829,40 +10829,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -10870,15 +10870,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -10886,55 +10886,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -10942,11 +10942,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -10954,7 +10954,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -10962,11 +10962,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -10974,11 +10974,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -10989,114 +10989,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11107,7 +11107,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11117,7 +11117,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11127,7 +11127,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11137,7 +11137,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11145,7 +11145,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11155,7 +11155,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11163,7 +11163,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11173,7 +11173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11181,47 +11181,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -11230,45 +11230,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -11281,23 +11281,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11307,7 +11307,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11316,7 +11316,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11325,7 +11325,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11333,7 +11333,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11341,7 +11341,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11349,7 +11349,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11358,118 +11358,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -11706,7 +11706,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -11716,19 +11716,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -11738,15 +11738,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -11841,15 +11841,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -11857,7 +11857,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -11865,14 +11865,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -11880,7 +11880,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -11888,23 +11888,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11912,15 +11912,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12007,11 +12007,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12019,19 +12019,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12039,19 +12039,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -12149,11 +12149,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12161,19 +12161,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12181,15 +12181,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12287,11 +12287,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12299,34 +12299,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -12334,34 +12334,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -12369,7 +12369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12378,7 +12378,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12387,7 +12387,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12395,7 +12395,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12403,21 +12403,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12425,7 +12425,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12433,7 +12433,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -12441,7 +12441,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -12450,7 +12450,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -12458,11 +12458,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -12489,51 +12489,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -12543,70 +12543,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -12614,15 +12614,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -12631,7 +12631,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -12640,7 +12640,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -12651,7 +12651,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -12661,11 +12661,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -12676,7 +12676,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -12749,15 +12749,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -12766,7 +12766,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -12777,7 +12777,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -12788,7 +12788,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -12801,7 +12801,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -12813,7 +12813,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_decrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -12822,7 +12822,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_encrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -12831,43 +12831,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -12875,7 +12875,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -12883,7 +12883,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -12892,7 +12892,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -12901,40 +12901,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -12943,11 +12943,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -12955,7 +12955,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -12966,19 +12966,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -12986,19 +12986,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13013,7 +13013,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13021,14 +13021,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13036,114 +13036,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13151,11 +13151,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13163,7 +13163,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13171,7 +13171,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13179,7 +13179,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13190,75 +13190,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13266,19 +13266,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -13370,15 +13370,15 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -13386,11 +13386,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -13398,15 +13398,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_METHOD_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_METHOD_unref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -13452,43 +13452,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -13496,7 +13496,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -13505,7 +13505,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -13513,7 +13513,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -13522,7 +13522,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -13534,11 +13534,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13592,28 +13592,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -13622,7 +13622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13632,7 +13632,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13643,7 +13643,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13654,7 +13654,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13665,47 +13665,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -13715,7 +13715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -13723,14 +13723,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -13738,11 +13738,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -13750,11 +13750,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -13762,11 +13762,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -13774,7 +13774,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13930,19 +13930,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -13950,19 +13950,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -13970,7 +13970,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -13980,53 +13980,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14034,7 +14034,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14043,7 +14043,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14053,7 +14053,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14063,7 +14063,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14073,7 +14073,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14083,7 +14083,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14094,7 +14094,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14104,7 +14104,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14114,7 +14114,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14124,7 +14124,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14134,7 +14134,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14143,7 +14143,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14151,7 +14151,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14162,7 +14162,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14171,7 +14171,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14180,7 +14180,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14188,11 +14188,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14202,15 +14202,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -14264,92 +14264,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -14357,7 +14357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -14366,15 +14366,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -14382,11 +14382,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -14394,22 +14394,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14419,7 +14419,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14427,7 +14427,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14549,11 +14549,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14561,11 +14561,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14573,11 +14573,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14585,14 +14585,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -14609,7 +14609,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -14618,7 +14618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14629,7 +14629,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14640,7 +14640,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -14694,23 +14694,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -14718,7 +14718,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -14726,7 +14726,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -14734,7 +14734,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14743,19 +14743,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -14763,11 +14763,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -14777,7 +14777,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -14785,83 +14785,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -14999,11 +14999,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15012,11 +15012,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15027,11 +15027,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15046,7 +15046,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15061,7 +15061,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15079,7 +15079,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15094,66 +15094,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15164,7 +15164,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15172,7 +15172,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15181,7 +15181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15189,102 +15189,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -15292,40 +15292,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15334,7 +15334,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15343,7 +15343,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15351,7 +15351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15359,7 +15359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15369,7 +15369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15377,7 +15377,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15385,7 +15385,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15395,7 +15395,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15405,7 +15405,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15413,7 +15413,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15421,7 +15421,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15431,7 +15431,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15439,11 +15439,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15451,7 +15451,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -15460,7 +15460,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15468,11 +15468,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15480,7 +15480,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15489,7 +15489,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15498,7 +15498,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15507,7 +15507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15516,7 +15516,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15529,7 +15529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15541,7 +15541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15556,31 +15556,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -15590,11 +15590,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -15604,11 +15604,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15618,11 +15618,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15632,11 +15632,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15646,18 +15646,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -15665,18 +15665,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -15686,7 +15686,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -15696,102 +15696,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -15799,28 +15799,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -15828,7 +15828,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -15836,7 +15836,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -15846,31 +15846,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -15884,7 +15884,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -15898,15 +15898,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -15915,7 +15915,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -15923,7 +15923,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -15932,22 +15932,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -15955,40 +15955,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -15996,11 +15996,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16008,11 +16008,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16020,11 +16020,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16032,14 +16032,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -16213,7 +16213,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16227,7 +16227,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16239,7 +16239,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -16251,11 +16251,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16263,15 +16263,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -16358,7 +16358,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -16370,27 +16370,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16400,7 +16400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -16408,7 +16408,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16416,23 +16416,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16441,7 +16441,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -16617,82 +16617,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -16701,18 +16701,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -16721,7 +16721,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -16730,23 +16730,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -16762,7 +16762,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -16780,7 +16780,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -16793,7 +16793,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -16806,7 +16806,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -16819,7 +16819,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -16829,19 +16829,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17100,7 +17100,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17108,7 +17108,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17117,7 +17117,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17126,22 +17126,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17149,15 +17149,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17244,66 +17244,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -17312,7 +17312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -17320,7 +17320,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -17328,7 +17328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -17409,7 +17409,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -17428,7 +17428,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -17436,47 +17436,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -17770,51 +17770,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -17840,15 +17840,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -17856,18 +17856,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -17875,79 +17875,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -17956,11 +17956,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -17969,7 +17969,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -17978,12 +17978,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -17992,7 +17992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18001,7 +18001,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18009,7 +18009,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18021,7 +18021,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18033,7 +18033,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -18043,7 +18043,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -18053,7 +18053,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18064,7 +18064,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18078,7 +18078,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18090,7 +18090,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18101,7 +18101,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -18114,7 +18114,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18126,7 +18126,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -18136,7 +18136,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -18146,31 +18146,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18181,7 +18181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18192,7 +18192,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -18205,7 +18205,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -18216,19 +18216,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18236,19 +18236,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18256,7 +18256,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -18266,7 +18266,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -18274,26 +18274,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -18302,7 +18302,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18310,11 +18310,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18322,11 +18322,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18336,7 +18336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18346,7 +18346,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -18357,7 +18357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -18365,7 +18365,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -18866,27 +18866,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -18894,51 +18894,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -18951,15 +18951,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -18967,7 +18967,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -18975,7 +18975,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -18983,15 +18983,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -18999,68 +18999,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19068,7 +19068,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19076,25 +19076,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19102,14 +19102,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -19117,7 +19117,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -19125,7 +19125,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -19133,14 +19133,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -19162,23 +19162,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19186,23 +19186,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -19211,19 +19211,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19231,7 +19231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -19239,7 +19239,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -19247,11 +19247,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19259,55 +19259,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -19315,7 +19315,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -19323,25 +19323,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -19349,19 +19349,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -19369,23 +19369,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19393,33 +19393,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -19427,22 +19427,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -19492,19 +19492,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -19512,15 +19512,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -19528,15 +19528,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19544,7 +19544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19552,21 +19552,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -19575,7 +19575,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19587,7 +19587,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19599,7 +19599,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -19611,19 +19611,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -19631,33 +19631,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -19666,11 +19666,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -19680,7 +19680,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -19690,7 +19690,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -19700,19 +19700,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -19720,18 +19720,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -19740,7 +19740,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -19749,33 +19749,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -19799,11 +19799,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -19811,18 +19811,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -19830,7 +19830,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -19838,7 +19838,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -19846,21 +19846,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -19889,23 +19889,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -19913,11 +19913,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -19926,7 +19926,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -19935,15 +19935,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -19951,7 +19951,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -19959,7 +19959,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -19968,7 +19968,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -19977,7 +19977,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -19986,7 +19986,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -19995,7 +19995,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -20004,259 +20004,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -20264,11 +20264,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20278,7 +20278,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -20286,14 +20286,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20303,7 +20303,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -20311,42 +20311,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20355,7 +20355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20928,11 +20928,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -20940,7 +20940,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -20948,54 +20948,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21003,23 +21003,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -21027,7 +21027,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -21036,44 +21036,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21081,34 +21081,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21116,26 +21116,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21143,18 +21143,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21162,38 +21162,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21201,25 +21201,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21227,7 +21227,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21235,23 +21235,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21259,26 +21259,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21286,26 +21286,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -21313,7 +21313,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -21323,7 +21323,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -21333,7 +21333,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -21343,7 +21343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21355,7 +21355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21366,15 +21366,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -21382,18 +21382,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21401,7 +21401,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21409,28 +21409,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21440,7 +21440,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21450,7 +21450,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -21460,37 +21460,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -21500,66 +21500,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -21568,19 +21568,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -21589,7 +21589,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -21597,7 +21597,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -21606,7 +21606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -21615,15 +21615,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -21632,11 +21632,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -21645,7 +21645,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -21655,7 +21655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21664,7 +21664,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21674,11 +21674,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21686,7 +21686,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -21694,7 +21694,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -21702,21 +21702,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -21724,7 +21724,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21733,7 +21733,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21743,11 +21743,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21755,7 +21755,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21763,28 +21763,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21794,7 +21794,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21804,7 +21804,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -21814,7 +21814,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21824,7 +21824,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21834,7 +21834,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -21844,14 +21844,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -21860,7 +21860,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -21869,34 +21869,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21904,26 +21904,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -21934,7 +21934,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -21944,11 +21944,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -21956,19 +21956,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -21985,19 +21985,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22084,15 +22084,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22100,14 +22100,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -22226,18 +22226,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22245,7 +22245,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22253,202 +22253,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -22456,15 +22456,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -22473,50 +22473,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -22525,7 +22525,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -22535,7 +22535,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22543,7 +22543,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22551,7 +22551,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22559,19 +22559,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -22580,11 +22580,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -22592,81 +22592,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -22675,11 +22675,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -22687,7 +22687,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -22699,105 +22699,105 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -22805,7 +22805,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -22813,20 +22813,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -22834,7 +22834,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -22842,42 +22842,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -22889,14 +22889,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -22906,7 +22906,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -22916,7 +22916,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -22926,7 +22926,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -22938,7 +22938,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -22949,7 +22949,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -22963,7 +22963,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -22972,7 +22972,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -22982,7 +22982,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -22992,7 +22992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23003,7 +23003,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23017,7 +23017,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -23026,7 +23026,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -23035,11 +23035,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_proc_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_dek_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -23048,7 +23048,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23057,7 +23057,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23066,15 +23066,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23083,7 +23083,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23092,15 +23092,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -23109,7 +23109,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -23118,23 +23118,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -23143,7 +23143,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -23152,15 +23152,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -23169,7 +23169,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -23178,15 +23178,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -23195,7 +23195,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -23204,15 +23204,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23221,7 +23221,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23230,21 +23230,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23253,7 +23253,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23262,7 +23262,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -23274,7 +23274,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -23286,7 +23286,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23295,7 +23295,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23304,15 +23304,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23321,7 +23321,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23330,15 +23330,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23347,7 +23347,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23356,7 +23356,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -23368,7 +23368,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -23380,7 +23380,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23389,7 +23389,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23398,15 +23398,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23415,7 +23415,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23424,15 +23424,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23441,7 +23441,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23450,7 +23450,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -23462,7 +23462,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -23474,7 +23474,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23483,7 +23483,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23492,15 +23492,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -23509,7 +23509,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -23518,15 +23518,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23535,7 +23535,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23544,7 +23544,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23556,7 +23556,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23568,7 +23568,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23577,7 +23577,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23586,15 +23586,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23606,7 +23606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -23618,7 +23618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23630,7 +23630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23642,7 +23642,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23651,7 +23651,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23663,7 +23663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23675,7 +23675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23687,7 +23687,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23696,7 +23696,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23708,7 +23708,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -23721,7 +23721,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -23735,7 +23735,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -23743,7 +23743,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -23751,7 +23751,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -23760,11 +23760,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -23772,27 +23772,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -23802,7 +23802,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -23810,7 +23810,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -23825,74 +23825,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23993,19 +23993,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24070,11 +24070,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -24161,11 +24161,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -24173,42 +24173,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -24283,15 +24283,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24304,7 +24304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24319,18 +24319,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24339,14 +24339,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24355,7 +24355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24366,7 +24366,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24375,7 +24375,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24387,7 +24387,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -24399,18 +24399,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24418,14 +24418,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24433,7 +24433,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24447,7 +24447,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24462,7 +24462,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24475,7 +24475,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24490,7 +24490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -26198,15 +26198,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26214,26 +26214,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26241,14 +26241,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -26480,15 +26480,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26496,26 +26496,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26523,26 +26523,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26550,29 +26550,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -26580,19 +26580,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26600,18 +26600,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -26619,7 +26619,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -26627,15 +26627,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26643,26 +26643,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26670,22 +26670,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -26693,14 +26693,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -26708,7 +26708,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -26716,14 +26716,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -26731,15 +26731,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26747,33 +26747,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26781,26 +26781,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26808,26 +26808,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26835,26 +26835,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26862,26 +26862,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26889,26 +26889,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26916,26 +26916,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26943,26 +26943,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26970,26 +26970,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26997,38 +26997,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27036,26 +27036,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27063,70 +27063,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27137,7 +27137,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27145,7 +27145,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27155,7 +27155,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -27253,7 +27253,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -27264,11 +27264,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27277,7 +27277,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27286,7 +27286,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -27295,7 +27295,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27304,7 +27304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27313,7 +27313,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27322,7 +27322,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27331,67 +27331,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27400,14 +27400,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -27415,7 +27415,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27425,7 +27425,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -27434,7 +27434,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -27443,7 +27443,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -27452,7 +27452,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -27462,11 +27462,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -27474,70 +27474,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_akid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -27555,43 +27555,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27601,7 +27601,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27610,7 +27610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -27619,7 +27619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -27627,15 +27627,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,

--- a/aws-lc-fips-sys/src/x86_64_unknown_linux_musl_crypto_ssl.rs
+++ b/aws-lc-fips-sys/src/x86_64_unknown_linux_musl_crypto_ssl.rs
@@ -5268,38 +5268,38 @@ pub type X509_STORE = x509_store_st;
 pub type X509_TRUST = x509_trust_st;
 pub type OPENSSL_BLOCK = *mut ::std::os::raw::c_void;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5308,18 +5308,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5328,18 +5328,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5348,7 +5348,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -5356,11 +5356,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -5371,30 +5371,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -5433,30 +5433,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -5466,15 +5466,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -5538,7 +5538,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5546,7 +5546,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5554,15 +5554,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5574,7 +5574,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5583,7 +5583,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5594,7 +5594,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5605,7 +5605,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5617,7 +5617,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5627,7 +5627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5637,7 +5637,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5648,7 +5648,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5869,27 +5869,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5897,29 +5897,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5927,7 +5927,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -6059,27 +6059,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -6087,11 +6087,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6099,22 +6099,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6123,7 +6123,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -6132,35 +6132,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6170,7 +6170,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6230,7 +6230,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6286,19 +6286,19 @@ impl Default for crypto_ex_data_st {
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6311,7 +6311,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6325,7 +6325,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6336,29 +6336,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6414,7 +6414,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6425,7 +6425,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6438,7 +6438,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6450,7 +6450,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6459,7 +6459,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6470,7 +6470,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6497,23 +6497,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6521,7 +6521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6529,7 +6529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6537,7 +6537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6545,15 +6545,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6562,7 +6562,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6570,7 +6570,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6579,67 +6579,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6665,7 +6665,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6673,68 +6673,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6742,7 +6742,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6750,7 +6750,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6759,11 +6759,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -6772,15 +6772,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -6788,11 +6788,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -6800,22 +6800,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -6823,30 +6823,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -6854,89 +6854,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -6945,34 +6945,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -6981,13 +6981,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -6996,13 +6996,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7015,7 +7015,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7028,7 +7028,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7041,7 +7041,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7053,7 +7053,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7067,7 +7067,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7080,7 +7080,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7093,7 +7093,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7105,23 +7105,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7131,7 +7131,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7139,37 +7139,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7181,7 +7181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7551,193 +7551,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7746,15 +7746,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7764,11 +7764,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -7776,47 +7776,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7824,11 +7824,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7836,43 +7836,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -7881,7 +7881,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7891,7 +7891,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7900,7 +7900,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7910,7 +7910,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7919,7 +7919,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7929,7 +7929,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7938,7 +7938,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7948,7 +7948,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7957,7 +7957,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7966,7 +7966,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7974,7 +7974,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7983,7 +7983,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7992,7 +7992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8001,11 +8001,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8013,7 +8013,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8073,15 +8073,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8095,7 +8095,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8103,11 +8103,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8122,7 +8122,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8132,7 +8132,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8143,7 +8143,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8153,7 +8153,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8162,7 +8162,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8171,7 +8171,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8180,7 +8180,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8190,7 +8190,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8200,23 +8200,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8225,7 +8225,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8234,7 +8234,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8244,7 +8244,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8253,7 +8253,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8263,7 +8263,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8274,7 +8274,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8285,15 +8285,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8304,7 +8304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8317,11 +8317,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8329,7 +8329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8337,7 +8337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -8485,15 +8485,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8517,15 +8517,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8534,7 +8534,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8542,14 +8542,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8557,7 +8557,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8565,7 +8565,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8573,7 +8573,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8581,14 +8581,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8596,7 +8596,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8604,22 +8604,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8695,54 +8695,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8750,7 +8750,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8758,79 +8758,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -8838,7 +8838,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -8846,7 +8846,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -8854,7 +8854,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -8862,7 +8862,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -8870,7 +8870,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -8878,7 +8878,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -8886,7 +8886,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -8894,7 +8894,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -8902,117 +8902,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9020,14 +9020,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9037,7 +9037,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9049,7 +9049,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9059,7 +9059,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9069,15 +9069,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9085,26 +9085,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9112,23 +9112,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9136,14 +9136,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9151,25 +9151,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9177,7 +9177,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9185,14 +9185,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9221,19 +9221,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9241,11 +9241,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9253,54 +9253,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9308,59 +9308,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9368,23 +9368,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, t: time_t) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         t: time_t,
@@ -9393,26 +9393,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9420,29 +9420,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         t: time_t,
@@ -9451,22 +9451,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9474,15 +9474,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9491,11 +9491,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, t: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         t: time_t,
@@ -9504,41 +9504,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9546,11 +9546,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9575,7 +9575,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9585,11 +9585,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9597,11 +9597,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9609,7 +9609,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9943,15 +9943,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -9959,19 +9959,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9979,7 +9979,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9987,12 +9987,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10000,14 +10000,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10015,33 +10015,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10049,7 +10049,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10057,19 +10057,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10077,7 +10077,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10085,7 +10085,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10095,7 +10095,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10105,11 +10105,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10117,33 +10117,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10151,34 +10151,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -10788,7 +10788,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10813,19 +10813,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -10835,19 +10835,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10857,7 +10857,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10865,11 +10865,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10879,7 +10879,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10887,7 +10887,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11097,11 +11097,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11109,11 +11109,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11168,19 +11168,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11189,7 +11189,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11250,23 +11250,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11274,82 +11274,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11357,7 +11357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11365,11 +11365,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11377,7 +11377,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11386,7 +11386,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11397,22 +11397,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11421,7 +11421,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11430,7 +11430,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11439,7 +11439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11448,33 +11448,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11482,7 +11482,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11490,7 +11490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -11797,23 +11797,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11821,40 +11821,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -11862,15 +11862,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11878,55 +11878,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -11934,11 +11934,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -11946,7 +11946,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -11954,11 +11954,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -11966,11 +11966,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -11981,114 +11981,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12099,7 +12099,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12109,7 +12109,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12119,7 +12119,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12129,7 +12129,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12137,7 +12137,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12147,7 +12147,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12155,7 +12155,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12165,7 +12165,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12173,47 +12173,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12222,45 +12222,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12273,23 +12273,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12299,7 +12299,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12308,7 +12308,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12317,7 +12317,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12325,7 +12325,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12333,7 +12333,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12341,7 +12341,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12350,118 +12350,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -12698,7 +12698,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -12708,19 +12708,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12730,15 +12730,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -12833,15 +12833,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -12849,7 +12849,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -12857,14 +12857,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -12872,7 +12872,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -12880,23 +12880,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12904,15 +12904,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12999,11 +12999,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13011,19 +13011,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13031,19 +13031,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -13141,11 +13141,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13153,19 +13153,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13173,15 +13173,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13279,11 +13279,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13291,34 +13291,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -13326,34 +13326,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13361,7 +13361,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13370,7 +13370,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13379,7 +13379,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13387,7 +13387,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13395,21 +13395,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13417,7 +13417,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13425,7 +13425,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -13433,7 +13433,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -13442,7 +13442,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -13450,11 +13450,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -13481,51 +13481,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -13535,70 +13535,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13606,15 +13606,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13623,7 +13623,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13632,7 +13632,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13643,7 +13643,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13653,11 +13653,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13668,7 +13668,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13741,15 +13741,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13758,7 +13758,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13769,7 +13769,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13780,7 +13780,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13793,7 +13793,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13805,7 +13805,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_decrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13814,7 +13814,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DES_encrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13823,43 +13823,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13867,7 +13867,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13875,7 +13875,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13884,7 +13884,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13893,40 +13893,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13935,11 +13935,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13947,7 +13947,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13958,19 +13958,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13978,19 +13978,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -14005,7 +14005,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -14013,14 +14013,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14028,114 +14028,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -14143,11 +14143,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -14155,7 +14155,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14163,7 +14163,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14171,7 +14171,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -14182,75 +14182,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -14258,19 +14258,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14362,15 +14362,15 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -14378,11 +14378,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -14390,15 +14390,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_METHOD_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_METHOD_unref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -14444,43 +14444,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14488,7 +14488,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14497,7 +14497,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14505,7 +14505,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14514,7 +14514,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14526,11 +14526,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14584,28 +14584,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14614,7 +14614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14624,7 +14624,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14635,7 +14635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14646,7 +14646,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14657,47 +14657,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14707,7 +14707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14715,14 +14715,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14730,11 +14730,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14742,11 +14742,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14754,11 +14754,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14766,7 +14766,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14922,19 +14922,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14942,19 +14942,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14962,7 +14962,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14972,53 +14972,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15026,7 +15026,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -15035,7 +15035,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15045,7 +15045,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15055,7 +15055,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15065,7 +15065,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15075,7 +15075,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15086,7 +15086,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -15096,7 +15096,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15106,7 +15106,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15116,7 +15116,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15126,7 +15126,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15135,7 +15135,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -15143,7 +15143,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15154,7 +15154,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -15163,7 +15163,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -15172,7 +15172,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -15180,11 +15180,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15194,15 +15194,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -15256,92 +15256,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -15349,7 +15349,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15358,15 +15358,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15374,11 +15374,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15386,22 +15386,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15411,7 +15411,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15419,7 +15419,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15541,11 +15541,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15553,11 +15553,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15565,11 +15565,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15577,14 +15577,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15601,7 +15601,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15610,7 +15610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15621,7 +15621,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15632,7 +15632,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15686,23 +15686,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15710,7 +15710,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15718,7 +15718,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15726,7 +15726,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15735,19 +15735,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15755,11 +15755,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15769,7 +15769,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15777,83 +15777,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15991,11 +15991,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -16004,11 +16004,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16019,11 +16019,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16038,7 +16038,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16053,7 +16053,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16071,7 +16071,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16086,66 +16086,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16156,7 +16156,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -16164,7 +16164,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -16173,7 +16173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -16181,102 +16181,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16284,40 +16284,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16326,7 +16326,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16335,7 +16335,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16343,7 +16343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16351,7 +16351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16361,7 +16361,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16369,7 +16369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16377,7 +16377,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16387,7 +16387,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16397,7 +16397,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16405,7 +16405,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16413,7 +16413,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16423,7 +16423,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16431,11 +16431,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16443,7 +16443,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16452,7 +16452,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16460,11 +16460,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16472,7 +16472,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16481,7 +16481,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16490,7 +16490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16499,7 +16499,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16508,7 +16508,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16521,7 +16521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16533,7 +16533,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16548,31 +16548,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16582,11 +16582,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16596,11 +16596,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16610,11 +16610,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16624,11 +16624,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16638,18 +16638,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16657,18 +16657,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16678,7 +16678,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16688,102 +16688,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16791,28 +16791,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16820,7 +16820,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16828,7 +16828,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16838,31 +16838,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16876,7 +16876,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16890,15 +16890,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16907,7 +16907,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16915,7 +16915,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16924,22 +16924,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16947,40 +16947,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16988,11 +16988,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -17000,11 +17000,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -17012,11 +17012,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -17024,14 +17024,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -17205,7 +17205,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -17219,7 +17219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -17231,7 +17231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -17243,11 +17243,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17255,15 +17255,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17350,7 +17350,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17362,27 +17362,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17392,7 +17392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17400,7 +17400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17408,23 +17408,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17433,7 +17433,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17609,82 +17609,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17693,18 +17693,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17713,7 +17713,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17722,23 +17722,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17754,7 +17754,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17772,7 +17772,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17785,7 +17785,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17798,7 +17798,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17811,7 +17811,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17821,19 +17821,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -18092,7 +18092,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -18100,7 +18100,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -18109,7 +18109,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -18118,22 +18118,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18141,15 +18141,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18236,66 +18236,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -18304,7 +18304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -18312,7 +18312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -18320,7 +18320,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -18401,7 +18401,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -18420,7 +18420,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18428,47 +18428,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18762,51 +18762,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18832,15 +18832,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18848,18 +18848,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18867,79 +18867,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18948,11 +18948,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18961,7 +18961,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18970,12 +18970,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18984,7 +18984,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18993,7 +18993,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19001,7 +19001,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19013,7 +19013,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19025,7 +19025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19035,7 +19035,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19045,7 +19045,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19056,7 +19056,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19070,7 +19070,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19082,7 +19082,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19093,7 +19093,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19106,7 +19106,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19118,7 +19118,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19128,7 +19128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19138,31 +19138,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19173,7 +19173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19184,7 +19184,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19197,7 +19197,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19208,19 +19208,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19228,19 +19228,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19248,7 +19248,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19258,7 +19258,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19266,26 +19266,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19294,7 +19294,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19302,11 +19302,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19314,11 +19314,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19328,7 +19328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19338,7 +19338,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19349,7 +19349,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19357,7 +19357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -19858,27 +19858,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19886,51 +19886,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19943,15 +19943,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19959,7 +19959,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19967,7 +19967,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19975,15 +19975,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19991,68 +19991,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -20060,7 +20060,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -20068,25 +20068,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -20094,14 +20094,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -20109,7 +20109,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -20117,7 +20117,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -20125,14 +20125,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -20154,23 +20154,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -20178,23 +20178,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -20203,19 +20203,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20223,7 +20223,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20231,7 +20231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20239,11 +20239,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20251,55 +20251,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20307,7 +20307,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20315,25 +20315,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20341,19 +20341,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20361,23 +20361,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20385,33 +20385,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20419,22 +20419,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20484,19 +20484,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20504,15 +20504,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20520,15 +20520,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20536,7 +20536,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20544,21 +20544,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20567,7 +20567,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20579,7 +20579,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20591,7 +20591,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20603,19 +20603,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20623,33 +20623,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20658,11 +20658,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20672,7 +20672,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20682,7 +20682,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20692,19 +20692,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20712,18 +20712,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20732,7 +20732,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20741,33 +20741,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20791,11 +20791,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20803,18 +20803,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20822,7 +20822,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20830,7 +20830,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20838,21 +20838,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -20881,23 +20881,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -20905,11 +20905,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -20918,7 +20918,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -20927,15 +20927,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -20943,7 +20943,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -20951,7 +20951,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20960,7 +20960,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20969,7 +20969,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -20978,7 +20978,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -20987,7 +20987,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -20996,259 +20996,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -21256,11 +21256,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21270,7 +21270,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -21278,14 +21278,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21295,7 +21295,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -21303,42 +21303,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -21347,7 +21347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -21920,11 +21920,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -21932,7 +21932,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -21940,54 +21940,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21995,23 +21995,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22019,7 +22019,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22028,44 +22028,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22073,34 +22073,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22108,26 +22108,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22135,18 +22135,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -22154,38 +22154,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22193,25 +22193,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22219,7 +22219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22227,23 +22227,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22251,26 +22251,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22278,26 +22278,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22305,7 +22305,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22315,7 +22315,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22325,7 +22325,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22335,7 +22335,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22347,7 +22347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22358,15 +22358,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -22374,18 +22374,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22393,7 +22393,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22401,28 +22401,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22432,7 +22432,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22442,7 +22442,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -22452,37 +22452,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -22492,66 +22492,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -22560,19 +22560,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22581,7 +22581,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22589,7 +22589,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22598,7 +22598,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22607,15 +22607,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22624,11 +22624,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -22637,7 +22637,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -22647,7 +22647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22656,7 +22656,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22666,11 +22666,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22678,7 +22678,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -22686,7 +22686,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -22694,21 +22694,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -22716,7 +22716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22725,7 +22725,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22735,11 +22735,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22747,7 +22747,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22755,28 +22755,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22786,7 +22786,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22796,7 +22796,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22806,7 +22806,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22816,7 +22816,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22826,7 +22826,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22836,14 +22836,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -22852,7 +22852,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -22861,34 +22861,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22896,26 +22896,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -22926,7 +22926,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -22936,11 +22936,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -22948,19 +22948,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -22977,19 +22977,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23076,15 +23076,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23092,14 +23092,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -23218,18 +23218,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23237,7 +23237,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23245,202 +23245,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23448,15 +23448,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -23465,50 +23465,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23517,7 +23517,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23527,7 +23527,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23535,7 +23535,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23543,7 +23543,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23551,19 +23551,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -23572,11 +23572,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23584,81 +23584,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -23667,11 +23667,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23679,7 +23679,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23691,105 +23691,105 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23797,7 +23797,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23805,20 +23805,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -23826,7 +23826,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -23834,42 +23834,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -23881,14 +23881,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -23898,7 +23898,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23908,7 +23908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -23918,7 +23918,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -23930,7 +23930,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23941,7 +23941,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23955,7 +23955,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -23964,7 +23964,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23974,7 +23974,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -23984,7 +23984,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23995,7 +23995,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24009,7 +24009,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -24018,7 +24018,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -24027,11 +24027,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_proc_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_dek_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -24040,7 +24040,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24049,7 +24049,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24058,15 +24058,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24075,7 +24075,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24084,15 +24084,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -24101,7 +24101,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -24110,23 +24110,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -24135,7 +24135,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -24144,15 +24144,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -24161,7 +24161,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -24170,15 +24170,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -24187,7 +24187,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -24196,15 +24196,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24213,7 +24213,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24222,21 +24222,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24245,7 +24245,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24254,7 +24254,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -24266,7 +24266,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -24278,7 +24278,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24287,7 +24287,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24296,15 +24296,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24313,7 +24313,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24322,15 +24322,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24339,7 +24339,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24348,7 +24348,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -24360,7 +24360,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -24372,7 +24372,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24381,7 +24381,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24390,15 +24390,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24407,7 +24407,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24416,15 +24416,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24433,7 +24433,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24442,7 +24442,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -24454,7 +24454,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -24466,7 +24466,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24475,7 +24475,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24484,15 +24484,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -24501,7 +24501,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -24510,15 +24510,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24527,7 +24527,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24536,7 +24536,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24548,7 +24548,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24560,7 +24560,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24569,7 +24569,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24578,15 +24578,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24598,7 +24598,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -24610,7 +24610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24622,7 +24622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24634,7 +24634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24643,7 +24643,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24655,7 +24655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24667,7 +24667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24679,7 +24679,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24688,7 +24688,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24700,7 +24700,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -24713,7 +24713,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -24727,7 +24727,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -24735,7 +24735,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -24743,7 +24743,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -24752,11 +24752,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -24764,27 +24764,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24794,7 +24794,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24802,7 +24802,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -24817,74 +24817,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24985,19 +24985,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25062,11 +25062,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -25153,11 +25153,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -25165,42 +25165,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -25275,15 +25275,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25296,7 +25296,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25311,18 +25311,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25331,14 +25331,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25347,7 +25347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25358,7 +25358,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25367,7 +25367,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25379,7 +25379,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -25391,18 +25391,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25410,14 +25410,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25425,7 +25425,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25439,7 +25439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25454,7 +25454,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25467,7 +25467,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25482,7 +25482,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -27190,15 +27190,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27206,26 +27206,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_POLICY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27233,14 +27233,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -27472,15 +27472,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27488,26 +27488,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27515,26 +27515,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27542,29 +27542,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -27572,19 +27572,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27592,18 +27592,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -27611,7 +27611,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27619,15 +27619,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27635,26 +27635,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27662,22 +27662,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OTHERNAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -27685,14 +27685,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -27700,7 +27700,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -27708,14 +27708,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27723,15 +27723,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27739,33 +27739,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27773,26 +27773,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27800,26 +27800,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27827,26 +27827,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27854,26 +27854,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27881,26 +27881,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27908,26 +27908,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27935,26 +27935,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27962,26 +27962,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27989,38 +27989,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28028,26 +28028,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28055,70 +28055,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28129,7 +28129,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -28137,7 +28137,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28147,7 +28147,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -28245,7 +28245,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -28256,11 +28256,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28269,7 +28269,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28278,7 +28278,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -28287,7 +28287,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28296,7 +28296,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28305,7 +28305,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28314,7 +28314,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28323,67 +28323,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28392,14 +28392,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -28407,7 +28407,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28417,7 +28417,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -28426,7 +28426,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -28435,7 +28435,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -28444,7 +28444,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -28454,11 +28454,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -28466,70 +28466,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_akid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -28547,43 +28547,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28593,7 +28593,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28602,7 +28602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -28611,7 +28611,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -28619,11 +28619,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -28689,119 +28689,119 @@ impl static_assertion_at_line_255_error_is_max_overheads_are_inconsistent {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLS_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLS_method"]
     pub fn TLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLS_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLS_method"]
     pub fn DTLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLS_with_buffers_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLS_with_buffers_method"]
     pub fn TLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLS_with_buffers_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLS_with_buffers_method"]
     pub fn DTLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_new"]
     pub fn SSL_CTX_new(method: *const SSL_METHOD) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_up_ref"]
     pub fn SSL_CTX_up_ref(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_free"]
     pub fn SSL_CTX_free(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_new"]
     pub fn SSL_new(ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_free"]
     pub fn SSL_free(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_SSL_CTX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_SSL_CTX"]
     pub fn SSL_get_SSL_CTX(ssl: *const SSL) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_connect_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_connect_state"]
     pub fn SSL_set_connect_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_accept_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_accept_state"]
     pub fn SSL_set_accept_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_is_server"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_is_server"]
     pub fn SSL_is_server(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_is_dtls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_is_dtls"]
     pub fn SSL_is_dtls(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_bio"]
     pub fn SSL_set_bio(ssl: *mut SSL, rbio: *mut BIO, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set0_rbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set0_rbio"]
     pub fn SSL_set0_rbio(ssl: *mut SSL, rbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set0_wbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set0_wbio"]
     pub fn SSL_set0_wbio(ssl: *mut SSL, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_rbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_rbio"]
     pub fn SSL_get_rbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_wbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_wbio"]
     pub fn SSL_get_wbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_fd"]
     pub fn SSL_get_fd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_rfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_rfd"]
     pub fn SSL_get_rfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_wfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_wfd"]
     pub fn SSL_get_wfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_fd"]
     pub fn SSL_set_fd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_rfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_rfd"]
     pub fn SSL_set_rfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_wfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_wfd"]
     pub fn SSL_set_wfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_do_handshake"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_do_handshake"]
     pub fn SSL_do_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_connect"]
     pub fn SSL_connect(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_accept"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_accept"]
     pub fn SSL_accept(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_read"]
     pub fn SSL_read(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -28809,7 +28809,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_peek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_peek"]
     pub fn SSL_peek(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -28817,15 +28817,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_pending"]
     pub fn SSL_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_has_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_has_pending"]
     pub fn SSL_has_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_write"]
     pub fn SSL_write(
         ssl: *mut SSL,
         buf: *const ::std::os::raw::c_void,
@@ -28833,220 +28833,220 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_key_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_key_update"]
     pub fn SSL_key_update(
         ssl: *mut SSL,
         request_type: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_shutdown"]
     pub fn SSL_shutdown(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_quiet_shutdown"]
     pub fn SSL_CTX_set_quiet_shutdown(ctx: *mut SSL_CTX, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_quiet_shutdown"]
     pub fn SSL_CTX_get_quiet_shutdown(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_quiet_shutdown"]
     pub fn SSL_set_quiet_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_quiet_shutdown"]
     pub fn SSL_get_quiet_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_error"]
     pub fn SSL_get_error(ssl: *const SSL, ret_code: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_error_description"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_error_description"]
     pub fn SSL_error_description(err: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_mtu"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_mtu"]
     pub fn SSL_set_mtu(ssl: *mut SSL, mtu: ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_set_initial_timeout_duration"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_set_initial_timeout_duration"]
     pub fn DTLSv1_set_initial_timeout_duration(ssl: *mut SSL, duration_ms: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_get_timeout"]
     pub fn DTLSv1_get_timeout(ssl: *const SSL, out: *mut timeval) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_handle_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_handle_timeout"]
     pub fn DTLSv1_handle_timeout(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_min_proto_version"]
     pub fn SSL_CTX_set_min_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_max_proto_version"]
     pub fn SSL_CTX_set_max_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_min_proto_version"]
     pub fn SSL_CTX_get_min_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_max_proto_version"]
     pub fn SSL_CTX_get_max_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_min_proto_version"]
     pub fn SSL_set_min_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_max_proto_version"]
     pub fn SSL_set_max_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_min_proto_version"]
     pub fn SSL_get_min_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_max_proto_version"]
     pub fn SSL_get_max_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_version"]
     pub fn SSL_version(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_options"]
     pub fn SSL_CTX_set_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_clear_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_clear_options"]
     pub fn SSL_CTX_clear_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_options"]
     pub fn SSL_CTX_get_options(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_options"]
     pub fn SSL_set_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_clear_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_clear_options"]
     pub fn SSL_clear_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_options"]
     pub fn SSL_get_options(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_mode"]
     pub fn SSL_CTX_set_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_clear_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_clear_mode"]
     pub fn SSL_CTX_clear_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_mode"]
     pub fn SSL_CTX_get_mode(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_mode"]
     pub fn SSL_set_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_clear_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_clear_mode"]
     pub fn SSL_clear_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_mode"]
     pub fn SSL_get_mode(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set0_buffer_pool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set0_buffer_pool"]
     pub fn SSL_CTX_set0_buffer_pool(ctx: *mut SSL_CTX, pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_certificate"]
     pub fn SSL_CTX_use_certificate(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_certificate"]
     pub fn SSL_use_certificate(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_PrivateKey"]
     pub fn SSL_CTX_use_PrivateKey(ctx: *mut SSL_CTX, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_PrivateKey"]
     pub fn SSL_use_PrivateKey(ssl: *mut SSL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set0_chain"]
     pub fn SSL_CTX_set0_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_chain"]
     pub fn SSL_CTX_set1_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set0_chain"]
     pub fn SSL_set0_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_chain"]
     pub fn SSL_set1_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add0_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add0_chain_cert"]
     pub fn SSL_CTX_add0_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add1_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add1_chain_cert"]
     pub fn SSL_CTX_add1_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add0_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add0_chain_cert"]
     pub fn SSL_add0_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add_extra_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add_extra_chain_cert"]
     pub fn SSL_CTX_add_extra_chain_cert(
         ctx: *mut SSL_CTX,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add1_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add1_chain_cert"]
     pub fn SSL_add1_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_clear_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_clear_chain_certs"]
     pub fn SSL_CTX_clear_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_clear_extra_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_clear_extra_chain_certs"]
     pub fn SSL_CTX_clear_extra_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_clear_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_clear_chain_certs"]
     pub fn SSL_clear_chain_certs(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_cert_cb"]
     pub fn SSL_CTX_set_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -29059,7 +29059,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_cert_cb"]
     pub fn SSL_set_cert_cb(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -29072,71 +29072,71 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_certificate_types"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_certificate_types"]
     pub fn SSL_get0_certificate_types(ssl: *const SSL, out_types: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_peer_verify_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_peer_verify_algorithms"]
     pub fn SSL_get0_peer_verify_algorithms(ssl: *const SSL, out_sigalgs: *mut *const u16) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_peer_delegation_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_peer_delegation_algorithms"]
     pub fn SSL_get0_peer_delegation_algorithms(
         ssl: *const SSL,
         out_sigalgs: *mut *const u16,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_certs_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_certs_clear"]
     pub fn SSL_certs_clear(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_check_private_key"]
     pub fn SSL_CTX_check_private_key(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_check_private_key"]
     pub fn SSL_check_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get0_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get0_certificate"]
     pub fn SSL_CTX_get0_certificate(ctx: *const SSL_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_certificate"]
     pub fn SSL_get_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get0_privatekey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get0_privatekey"]
     pub fn SSL_CTX_get0_privatekey(ctx: *const SSL_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_privatekey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_privatekey"]
     pub fn SSL_get_privatekey(ssl: *const SSL) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get0_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get0_chain_certs"]
     pub fn SSL_CTX_get0_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_extra_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_extra_chain_certs"]
     pub fn SSL_CTX_get_extra_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_chain_certs"]
     pub fn SSL_get0_chain_certs(
         ssl: *const SSL,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_signed_cert_timestamp_list"]
     pub fn SSL_CTX_set_signed_cert_timestamp_list(
         ctx: *mut SSL_CTX,
         list: *const u8,
@@ -29144,7 +29144,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_signed_cert_timestamp_list"]
     pub fn SSL_set_signed_cert_timestamp_list(
         ctx: *mut SSL,
         list: *const u8,
@@ -29152,7 +29152,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_ocsp_response"]
     pub fn SSL_CTX_set_ocsp_response(
         ctx: *mut SSL_CTX,
         response: *const u8,
@@ -29160,7 +29160,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_ocsp_response"]
     pub fn SSL_set_ocsp_response(
         ssl: *mut SSL,
         response: *const u8,
@@ -29168,26 +29168,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_signature_algorithm_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_signature_algorithm_name"]
     pub fn SSL_get_signature_algorithm_name(
         sigalg: u16,
         include_curve: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_signature_algorithm_key_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_signature_algorithm_key_type"]
     pub fn SSL_get_signature_algorithm_key_type(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_signature_algorithm_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_signature_algorithm_digest"]
     pub fn SSL_get_signature_algorithm_digest(sigalg: u16) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_is_signature_algorithm_rsa_pss"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_is_signature_algorithm_rsa_pss"]
     pub fn SSL_is_signature_algorithm_rsa_pss(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_signing_algorithm_prefs"]
     pub fn SSL_CTX_set_signing_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -29195,7 +29195,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_signing_algorithm_prefs"]
     pub fn SSL_set_signing_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -29203,7 +29203,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_chain_and_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_chain_and_key"]
     pub fn SSL_CTX_set_chain_and_key(
         ctx: *mut SSL_CTX,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29213,7 +29213,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_chain_and_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_chain_and_key"]
     pub fn SSL_set_chain_and_key(
         ssl: *mut SSL,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29223,19 +29223,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get0_chain"]
     pub fn SSL_CTX_get0_chain(ctx: *const SSL_CTX) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_RSAPrivateKey"]
     pub fn SSL_CTX_use_RSAPrivateKey(ctx: *mut SSL_CTX, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_RSAPrivateKey"]
     pub fn SSL_use_RSAPrivateKey(ssl: *mut SSL, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_certificate_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_certificate_ASN1"]
     pub fn SSL_CTX_use_certificate_ASN1(
         ctx: *mut SSL_CTX,
         der_len: usize,
@@ -29243,7 +29243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_certificate_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_certificate_ASN1"]
     pub fn SSL_use_certificate_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29251,7 +29251,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_PrivateKey_ASN1"]
     pub fn SSL_CTX_use_PrivateKey_ASN1(
         pk: ::std::os::raw::c_int,
         ctx: *mut SSL_CTX,
@@ -29260,7 +29260,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_PrivateKey_ASN1"]
     pub fn SSL_use_PrivateKey_ASN1(
         type_: ::std::os::raw::c_int,
         ssl: *mut SSL,
@@ -29269,7 +29269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_RSAPrivateKey_ASN1"]
     pub fn SSL_CTX_use_RSAPrivateKey_ASN1(
         ctx: *mut SSL_CTX,
         der: *const u8,
@@ -29277,7 +29277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_RSAPrivateKey_ASN1"]
     pub fn SSL_use_RSAPrivateKey_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29285,7 +29285,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_RSAPrivateKey_file"]
     pub fn SSL_CTX_use_RSAPrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29293,7 +29293,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_RSAPrivateKey_file"]
     pub fn SSL_use_RSAPrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29301,7 +29301,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_certificate_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_certificate_file"]
     pub fn SSL_CTX_use_certificate_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29309,7 +29309,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_certificate_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_certificate_file"]
     pub fn SSL_use_certificate_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29317,7 +29317,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_PrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_PrivateKey_file"]
     pub fn SSL_CTX_use_PrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29325,7 +29325,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_PrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_PrivateKey_file"]
     pub fn SSL_use_PrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29333,29 +29333,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_certificate_chain_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_certificate_chain_file"]
     pub fn SSL_CTX_use_certificate_chain_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_default_passwd_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_default_passwd_cb"]
     pub fn SSL_CTX_set_default_passwd_cb(ctx: *mut SSL_CTX, cb: pem_password_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_default_passwd_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_default_passwd_cb"]
     pub fn SSL_CTX_get_default_passwd_cb(ctx: *const SSL_CTX) -> pem_password_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_default_passwd_cb_userdata"]
     pub fn SSL_CTX_set_default_passwd_cb_userdata(
         ctx: *mut SSL_CTX,
         data: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_default_passwd_cb_userdata"]
     pub fn SSL_CTX_get_default_passwd_cb_userdata(
         ctx: *const SSL_CTX,
     ) -> *mut ::std::os::raw::c_void;
@@ -29444,18 +29444,18 @@ fn bindgen_test_layout_ssl_private_key_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_private_key_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_private_key_method"]
     pub fn SSL_set_private_key_method(ssl: *mut SSL, key_method: *const SSL_PRIVATE_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_private_key_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_private_key_method"]
     pub fn SSL_CTX_set_private_key_method(
         ctx: *mut SSL_CTX,
         key_method: *const SSL_PRIVATE_KEY_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_can_release_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_can_release_private_key"]
     pub fn SSL_can_release_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -29480,149 +29480,149 @@ pub type sk_SSL_CIPHER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_cipher_by_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_cipher_by_value"]
     pub fn SSL_get_cipher_by_value(value: u16) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_id"]
     pub fn SSL_CIPHER_get_id(cipher: *const SSL_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_protocol_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_protocol_id"]
     pub fn SSL_CIPHER_get_protocol_id(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_is_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_is_aead"]
     pub fn SSL_CIPHER_is_aead(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_is_block_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_is_block_cipher"]
     pub fn SSL_CIPHER_is_block_cipher(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_cipher_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_cipher_nid"]
     pub fn SSL_CIPHER_get_cipher_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_digest_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_digest_nid"]
     pub fn SSL_CIPHER_get_digest_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_kx_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_kx_nid"]
     pub fn SSL_CIPHER_get_kx_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_auth_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_auth_nid"]
     pub fn SSL_CIPHER_get_auth_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_prf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_prf_nid"]
     pub fn SSL_CIPHER_get_prf_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_min_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_min_version"]
     pub fn SSL_CIPHER_get_min_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_max_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_max_version"]
     pub fn SSL_CIPHER_get_max_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_standard_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_standard_name"]
     pub fn SSL_CIPHER_standard_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_name"]
     pub fn SSL_CIPHER_get_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_kx_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_kx_name"]
     pub fn SSL_CIPHER_get_kx_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_bits"]
     pub fn SSL_CIPHER_get_bits(
         cipher: *const SSL_CIPHER,
         out_alg_bits: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_strict_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_strict_cipher_list"]
     pub fn SSL_CTX_set_strict_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_cipher_list"]
     pub fn SSL_CTX_set_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_strict_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_strict_cipher_list"]
     pub fn SSL_set_strict_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_ciphersuites"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_ciphersuites"]
     pub fn SSL_CTX_set_ciphersuites(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_cipher_list"]
     pub fn SSL_set_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_ciphers"]
     pub fn SSL_CTX_get_ciphers(ctx: *const SSL_CTX) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_cipher_in_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_cipher_in_group"]
     pub fn SSL_CTX_cipher_in_group(ctx: *const SSL_CTX, i: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ciphers"]
     pub fn SSL_get_ciphers(ssl: *const SSL) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_is_init_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_is_init_finished"]
     pub fn SSL_is_init_finished(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_in_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_in_init"]
     pub fn SSL_in_init(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_in_false_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_in_false_start"]
     pub fn SSL_in_false_start(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_certificate"]
     pub fn SSL_get_peer_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_cert_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_cert_chain"]
     pub fn SSL_get_peer_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_full_cert_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_full_cert_chain"]
     pub fn SSL_get_peer_full_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_peer_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_peer_certificates"]
     pub fn SSL_get0_peer_certificates(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_signed_cert_timestamp_list"]
     pub fn SSL_get0_signed_cert_timestamp_list(
         ssl: *const SSL,
         out: *mut *const u8,
@@ -29630,11 +29630,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_ocsp_response"]
     pub fn SSL_get0_ocsp_response(ssl: *const SSL, out: *mut *const u8, out_len: *mut usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_tls_unique"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_tls_unique"]
     pub fn SSL_get_tls_unique(
         ssl: *const SSL,
         out: *mut u8,
@@ -29643,23 +29643,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_extms_support"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_extms_support"]
     pub fn SSL_get_extms_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_current_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_current_cipher"]
     pub fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_session_reused"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_session_reused"]
     pub fn SSL_session_reused(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_secure_renegotiation_support"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_secure_renegotiation_support"]
     pub fn SSL_get_secure_renegotiation_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_export_keying_material"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_export_keying_material"]
     pub fn SSL_export_keying_material(
         ssl: *mut SSL,
         out: *mut u8,
@@ -29672,7 +29672,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_bio_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_bio_SSL_SESSION"]
     pub fn PEM_read_bio_SSL_SESSION(
         bp: *mut BIO,
         x: *mut *mut SSL_SESSION,
@@ -29681,7 +29681,7 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_read_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_read_SSL_SESSION"]
     pub fn PEM_read_SSL_SESSION(
         fp: *mut FILE,
         x: *mut *mut SSL_SESSION,
@@ -29690,27 +29690,27 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_bio_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_bio_SSL_SESSION"]
     pub fn PEM_write_bio_SSL_SESSION(bp: *mut BIO, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_PEM_write_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_PEM_write_SSL_SESSION"]
     pub fn PEM_write_SSL_SESSION(fp: *mut FILE, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_new"]
     pub fn SSL_SESSION_new(ctx: *const SSL_CTX) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_up_ref"]
     pub fn SSL_SESSION_up_ref(session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_free"]
     pub fn SSL_SESSION_free(session: *mut SSL_SESSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_to_bytes"]
     pub fn SSL_SESSION_to_bytes(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -29718,7 +29718,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_to_bytes_for_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_to_bytes_for_ticket"]
     pub fn SSL_SESSION_to_bytes_for_ticket(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -29726,7 +29726,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_from_bytes"]
     pub fn SSL_SESSION_from_bytes(
         in_: *const u8,
         in_len: usize,
@@ -29734,29 +29734,29 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_version"]
     pub fn SSL_SESSION_get_version(session: *const SSL_SESSION) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_protocol_version"]
     pub fn SSL_SESSION_get_protocol_version(session: *const SSL_SESSION) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set_protocol_version"]
     pub fn SSL_SESSION_set_protocol_version(
         session: *mut SSL_SESSION,
         version: u16,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_id"]
     pub fn SSL_SESSION_get_id(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set1_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set1_id"]
     pub fn SSL_SESSION_set1_id(
         session: *mut SSL_SESSION,
         sid: *const u8,
@@ -29764,25 +29764,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_time"]
     pub fn SSL_SESSION_get_time(session: *const SSL_SESSION) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_timeout"]
     pub fn SSL_SESSION_get_timeout(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_peer"]
     pub fn SSL_SESSION_get0_peer(session: *const SSL_SESSION) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_peer_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_peer_certificates"]
     pub fn SSL_SESSION_get0_peer_certificates(
         session: *const SSL_SESSION,
     ) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_signed_cert_timestamp_list"]
     pub fn SSL_SESSION_get0_signed_cert_timestamp_list(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -29790,7 +29790,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_ocsp_response"]
     pub fn SSL_SESSION_get0_ocsp_response(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -29798,7 +29798,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_master_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_master_key"]
     pub fn SSL_SESSION_get_master_key(
         session: *const SSL_SESSION,
         out: *mut u8,
@@ -29806,22 +29806,22 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set_time"]
     pub fn SSL_SESSION_set_time(session: *mut SSL_SESSION, time: u64) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set_timeout"]
     pub fn SSL_SESSION_set_timeout(session: *mut SSL_SESSION, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_id_context"]
     pub fn SSL_SESSION_get0_id_context(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set1_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set1_id_context"]
     pub fn SSL_SESSION_set1_id_context(
         session: *mut SSL_SESSION,
         sid_ctx: *const u8,
@@ -29829,19 +29829,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_should_be_single_use"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_should_be_single_use"]
     pub fn SSL_SESSION_should_be_single_use(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_is_resumable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_is_resumable"]
     pub fn SSL_SESSION_is_resumable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_has_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_has_ticket"]
     pub fn SSL_SESSION_has_ticket(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_ticket"]
     pub fn SSL_SESSION_get0_ticket(
         session: *const SSL_SESSION,
         out_ticket: *mut *const u8,
@@ -29849,7 +29849,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set_ticket"]
     pub fn SSL_SESSION_set_ticket(
         session: *mut SSL_SESSION,
         ticket: *const u8,
@@ -29857,19 +29857,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_ticket_lifetime_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_ticket_lifetime_hint"]
     pub fn SSL_SESSION_get_ticket_lifetime_hint(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_cipher"]
     pub fn SSL_SESSION_get0_cipher(session: *const SSL_SESSION) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_has_peer_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_has_peer_sha256"]
     pub fn SSL_SESSION_has_peer_sha256(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get0_peer_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get0_peer_sha256"]
     pub fn SSL_SESSION_get0_peer_sha256(
         session: *const SSL_SESSION,
         out_ptr: *mut *const u8,
@@ -29877,34 +29877,34 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_session_cache_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_session_cache_mode"]
     pub fn SSL_CTX_set_session_cache_mode(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_session_cache_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_session_cache_mode"]
     pub fn SSL_CTX_get_session_cache_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_session"]
     pub fn SSL_set_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_timeout"]
     pub fn SSL_CTX_set_timeout(ctx: *mut SSL_CTX, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_session_psk_dhe_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_session_psk_dhe_timeout"]
     pub fn SSL_CTX_set_session_psk_dhe_timeout(ctx: *mut SSL_CTX, timeout: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_timeout"]
     pub fn SSL_CTX_get_timeout(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_session_id_context"]
     pub fn SSL_CTX_set_session_id_context(
         ctx: *mut SSL_CTX,
         sid_ctx: *const u8,
@@ -29912,7 +29912,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_session_id_context"]
     pub fn SSL_set_session_id_context(
         ssl: *mut SSL,
         sid_ctx: *const u8,
@@ -29920,44 +29920,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_session_id_context"]
     pub fn SSL_get0_session_id_context(ssl: *const SSL, out_len: *mut usize) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_set_cache_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_set_cache_size"]
     pub fn SSL_CTX_sess_set_cache_size(
         ctx: *mut SSL_CTX,
         size: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_get_cache_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_get_cache_size"]
     pub fn SSL_CTX_sess_get_cache_size(ctx: *const SSL_CTX) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_number"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_number"]
     pub fn SSL_CTX_sess_number(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add_session"]
     pub fn SSL_CTX_add_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_remove_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_remove_session"]
     pub fn SSL_CTX_remove_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_flush_sessions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_flush_sessions"]
     pub fn SSL_CTX_flush_sessions(ctx: *mut SSL_CTX, time: u64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_set_new_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_set_new_cb"]
     pub fn SSL_CTX_sess_set_new_cb(
         ctx: *mut SSL_CTX,
         new_session_cb: ::std::option::Option<
@@ -29966,7 +29966,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_get_new_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_get_new_cb"]
     pub fn SSL_CTX_sess_get_new_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -29974,7 +29974,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_set_remove_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_set_remove_cb"]
     pub fn SSL_CTX_sess_set_remove_cb(
         ctx: *mut SSL_CTX,
         remove_session_cb: ::std::option::Option<
@@ -29983,13 +29983,13 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_get_remove_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_get_remove_cb"]
     pub fn SSL_CTX_sess_get_remove_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<unsafe extern "C" fn(ctx: *mut SSL_CTX, arg1: *mut SSL_SESSION)>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_set_get_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_set_get_cb"]
     pub fn SSL_CTX_sess_set_get_cb(
         ctx: *mut SSL_CTX,
         get_session_cb: ::std::option::Option<
@@ -30003,7 +30003,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_get_get_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_get_get_cb"]
     pub fn SSL_CTX_sess_get_get_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30016,11 +30016,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_magic_pending_session_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_magic_pending_session_ptr"]
     pub fn SSL_magic_pending_session_ptr() -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_tlsext_ticket_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_tlsext_ticket_keys"]
     pub fn SSL_CTX_get_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         out: *mut ::std::os::raw::c_void,
@@ -30028,7 +30028,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_ticket_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_ticket_keys"]
     pub fn SSL_CTX_set_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         in_: *const ::std::os::raw::c_void,
@@ -30036,7 +30036,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_ticket_key_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_ticket_key_cb"]
     pub fn SSL_CTX_set_tlsext_ticket_key_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30128,14 +30128,14 @@ fn bindgen_test_layout_ssl_ticket_aead_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_ticket_aead_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_ticket_aead_method"]
     pub fn SSL_CTX_set_ticket_aead_method(
         ctx: *mut SSL_CTX,
         aead_method: *const SSL_TICKET_AEAD_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_process_tls13_new_session_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_process_tls13_new_session_ticket"]
     pub fn SSL_process_tls13_new_session_ticket(
         ssl: *mut SSL,
         buf: *const u8,
@@ -30143,15 +30143,15 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_num_tickets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_num_tickets"]
     pub fn SSL_CTX_set_num_tickets(ctx: *mut SSL_CTX, num_tickets: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_num_tickets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_num_tickets"]
     pub fn SSL_CTX_get_num_tickets(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_curves"]
     pub fn SSL_CTX_set1_curves(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_int,
@@ -30159,7 +30159,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_curves"]
     pub fn SSL_set1_curves(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_int,
@@ -30167,29 +30167,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_curves_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_curves_list"]
     pub fn SSL_CTX_set1_curves_list(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_curves_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_curves_list"]
     pub fn SSL_set1_curves_list(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_curve_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_curve_id"]
     pub fn SSL_get_curve_id(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_curve_name"]
     pub fn SSL_get_curve_name(curve_id: u16) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_to_bytes"]
     pub fn SSL_to_bytes(
         in_: *const SSL,
         out_data: *mut *mut u8,
@@ -30197,11 +30197,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_from_bytes"]
     pub fn SSL_from_bytes(in_: *const u8, in_len: usize, ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_groups"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_groups"]
     pub fn SSL_CTX_set1_groups(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_int,
@@ -30209,7 +30209,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_groups"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_groups"]
     pub fn SSL_set1_groups(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_int,
@@ -30217,21 +30217,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_groups_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_groups_list"]
     pub fn SSL_CTX_set1_groups_list(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_groups_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_groups_list"]
     pub fn SSL_set1_groups_list(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_verify"]
     pub fn SSL_CTX_set_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30244,7 +30244,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_verify"]
     pub fn SSL_set_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30261,7 +30261,7 @@ pub const ssl_verify_result_t_ssl_verify_invalid: ssl_verify_result_t = 1;
 pub const ssl_verify_result_t_ssl_verify_retry: ssl_verify_result_t = 2;
 pub type ssl_verify_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_custom_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_custom_verify"]
     pub fn SSL_CTX_set_custom_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30271,7 +30271,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_custom_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_custom_verify"]
     pub fn SSL_set_custom_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30281,15 +30281,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_verify_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_verify_mode"]
     pub fn SSL_CTX_get_verify_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_verify_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_verify_mode"]
     pub fn SSL_get_verify_mode(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_verify_callback"]
     pub fn SSL_CTX_get_verify_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -30300,7 +30300,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_verify_callback"]
     pub fn SSL_get_verify_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -30311,83 +30311,83 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_host"]
     pub fn SSL_set1_host(
         ssl: *mut SSL,
         hostname: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_verify_depth"]
     pub fn SSL_CTX_set_verify_depth(ctx: *mut SSL_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_verify_depth"]
     pub fn SSL_set_verify_depth(ssl: *mut SSL, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_verify_depth"]
     pub fn SSL_CTX_get_verify_depth(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_verify_depth"]
     pub fn SSL_get_verify_depth(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_param"]
     pub fn SSL_CTX_set1_param(
         ctx: *mut SSL_CTX,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_param"]
     pub fn SSL_set1_param(ssl: *mut SSL, param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get0_param"]
     pub fn SSL_CTX_get0_param(ctx: *mut SSL_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_param"]
     pub fn SSL_get0_param(ssl: *mut SSL) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_purpose"]
     pub fn SSL_CTX_set_purpose(
         ctx: *mut SSL_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_purpose"]
     pub fn SSL_set_purpose(ssl: *mut SSL, purpose: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_trust"]
     pub fn SSL_CTX_set_trust(
         ctx: *mut SSL_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_trust"]
     pub fn SSL_set_trust(ssl: *mut SSL, trust: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_cert_store"]
     pub fn SSL_CTX_set_cert_store(ctx: *mut SSL_CTX, store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_cert_store"]
     pub fn SSL_CTX_get_cert_store(ctx: *const SSL_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_default_verify_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_default_verify_paths"]
     pub fn SSL_CTX_set_default_verify_paths(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_load_verify_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_load_verify_locations"]
     pub fn SSL_CTX_load_verify_locations(
         ctx: *mut SSL_CTX,
         ca_file: *const ::std::os::raw::c_char,
@@ -30395,19 +30395,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_verify_result"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_verify_result"]
     pub fn SSL_get_verify_result(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_alert_from_verify_result"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_alert_from_verify_result"]
     pub fn SSL_alert_from_verify_result(result: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ex_data_X509_STORE_CTX_idx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ex_data_X509_STORE_CTX_idx"]
     pub fn SSL_get_ex_data_X509_STORE_CTX_idx() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_cert_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_cert_verify_callback"]
     pub fn SSL_CTX_set_cert_verify_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30420,51 +30420,51 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_enable_signed_cert_timestamps"]
     pub fn SSL_enable_signed_cert_timestamps(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_enable_signed_cert_timestamps"]
     pub fn SSL_CTX_enable_signed_cert_timestamps(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_enable_ocsp_stapling"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_enable_ocsp_stapling"]
     pub fn SSL_enable_ocsp_stapling(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_enable_ocsp_stapling"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_enable_ocsp_stapling"]
     pub fn SSL_CTX_enable_ocsp_stapling(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set0_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set0_verify_cert_store"]
     pub fn SSL_CTX_set0_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_verify_cert_store"]
     pub fn SSL_CTX_set1_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set0_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set0_verify_cert_store"]
     pub fn SSL_set0_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_verify_cert_store"]
     pub fn SSL_set1_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_verify_algorithm_prefs"]
     pub fn SSL_CTX_set_verify_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -30472,7 +30472,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_verify_algorithm_prefs"]
     pub fn SSL_set_verify_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -30480,87 +30480,87 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_hostflags"]
     pub fn SSL_set_hostflags(ssl: *mut SSL, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_client_CA_list"]
     pub fn SSL_set_client_CA_list(ssl: *mut SSL, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_client_CA_list"]
     pub fn SSL_CTX_set_client_CA_list(ctx: *mut SSL_CTX, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set0_client_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set0_client_CAs"]
     pub fn SSL_set0_client_CAs(ssl: *mut SSL, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set0_client_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set0_client_CAs"]
     pub fn SSL_CTX_set0_client_CAs(ctx: *mut SSL_CTX, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_client_CA_list"]
     pub fn SSL_get_client_CA_list(ssl: *const SSL) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_server_requested_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_server_requested_CAs"]
     pub fn SSL_get0_server_requested_CAs(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_client_CA_list"]
     pub fn SSL_CTX_get_client_CA_list(ctx: *const SSL_CTX) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add_client_CA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add_client_CA"]
     pub fn SSL_add_client_CA(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add_client_CA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add_client_CA"]
     pub fn SSL_CTX_add_client_CA(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_load_client_CA_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_load_client_CA_file"]
     pub fn SSL_load_client_CA_file(file: *const ::std::os::raw::c_char) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_dup_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_dup_CA_list"]
     pub fn SSL_dup_CA_list(list: *mut stack_st_X509_NAME) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add_file_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add_file_cert_subjects_to_stack"]
     pub fn SSL_add_file_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add_bio_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add_bio_cert_subjects_to_stack"]
     pub fn SSL_add_bio_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tlsext_host_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tlsext_host_name"]
     pub fn SSL_set_tlsext_host_name(
         ssl: *mut SSL,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_servername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_servername"]
     pub fn SSL_get_servername(
         ssl: *const SSL,
         type_: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_servername_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_servername_type"]
     pub fn SSL_get_servername_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_servername_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_servername_callback"]
     pub fn SSL_CTX_set_tlsext_servername_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30573,18 +30573,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_servername_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_servername_arg"]
     pub fn SSL_CTX_set_tlsext_servername_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_SSL_CTX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_SSL_CTX"]
     pub fn SSL_set_SSL_CTX(ssl: *mut SSL, ctx: *mut SSL_CTX) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_alpn_protos"]
     pub fn SSL_CTX_set_alpn_protos(
         ctx: *mut SSL_CTX,
         protos: *const u8,
@@ -30592,7 +30592,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_alpn_protos"]
     pub fn SSL_set_alpn_protos(
         ssl: *mut SSL,
         protos: *const u8,
@@ -30600,7 +30600,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_alpn_select_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_alpn_select_cb"]
     pub fn SSL_CTX_set_alpn_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30617,7 +30617,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_alpn_selected"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_alpn_selected"]
     pub fn SSL_get0_alpn_selected(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30625,11 +30625,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_allow_unknown_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_allow_unknown_alpn_protos"]
     pub fn SSL_CTX_set_allow_unknown_alpn_protos(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add_application_settings"]
     pub fn SSL_add_application_settings(
         ssl: *mut SSL,
         proto: *const u8,
@@ -30639,7 +30639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_peer_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_peer_application_settings"]
     pub fn SSL_get0_peer_application_settings(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30647,7 +30647,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_has_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_has_application_settings"]
     pub fn SSL_has_application_settings(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub type ssl_cert_compression_func_t = ::std::option::Option<
@@ -30668,7 +30668,7 @@ pub type ssl_cert_decompression_func_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_add_cert_compression_alg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_add_cert_compression_alg"]
     pub fn SSL_CTX_add_cert_compression_alg(
         ctx: *mut SSL_CTX,
         alg_id: u16,
@@ -30677,7 +30677,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_next_protos_advertised_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_next_protos_advertised_cb"]
     pub fn SSL_CTX_set_next_protos_advertised_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30692,7 +30692,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_next_proto_select_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_next_proto_select_cb"]
     pub fn SSL_CTX_set_next_proto_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30709,7 +30709,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_next_proto_negotiated"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_next_proto_negotiated"]
     pub fn SSL_get0_next_proto_negotiated(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30717,7 +30717,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_select_next_proto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_select_next_proto"]
     pub fn SSL_select_next_proto(
         out: *mut *mut u8,
         out_len: *mut u8,
@@ -30728,29 +30728,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tls_channel_id_enabled"]
     pub fn SSL_CTX_set_tls_channel_id_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tls_channel_id_enabled"]
     pub fn SSL_set_tls_channel_id_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_tls_channel_id"]
     pub fn SSL_CTX_set1_tls_channel_id(
         ctx: *mut SSL_CTX,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_tls_channel_id"]
     pub fn SSL_set1_tls_channel_id(
         ssl: *mut SSL,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_tls_channel_id"]
     pub fn SSL_get_tls_channel_id(ssl: *mut SSL, out: *mut u8, max_out: usize) -> usize;
 }
 #[repr(C)]
@@ -30827,29 +30827,29 @@ pub type sk_SRTP_PROTECTION_PROFILE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_srtp_profiles"]
     pub fn SSL_CTX_set_srtp_profiles(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_srtp_profiles"]
     pub fn SSL_set_srtp_profiles(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_srtp_profiles"]
     pub fn SSL_get_srtp_profiles(ssl: *const SSL) -> *const stack_st_SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_selected_srtp_profile"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_selected_srtp_profile"]
     pub fn SSL_get_selected_srtp_profile(ssl: *mut SSL) -> *const SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_psk_client_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_psk_client_callback"]
     pub fn SSL_CTX_set_psk_client_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30865,7 +30865,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_psk_client_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_psk_client_callback"]
     pub fn SSL_set_psk_client_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -30881,7 +30881,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_psk_server_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_psk_server_callback"]
     pub fn SSL_CTX_set_psk_server_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30895,7 +30895,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_psk_server_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_psk_server_callback"]
     pub fn SSL_set_psk_server_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -30909,29 +30909,29 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_use_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_use_psk_identity_hint"]
     pub fn SSL_CTX_use_psk_identity_hint(
         ctx: *mut SSL_CTX,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_use_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_use_psk_identity_hint"]
     pub fn SSL_use_psk_identity_hint(
         ssl: *mut SSL,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_psk_identity_hint"]
     pub fn SSL_get_psk_identity_hint(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_psk_identity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_psk_identity"]
     pub fn SSL_get_psk_identity(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_delegated_credential"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_delegated_credential"]
     pub fn SSL_set1_delegated_credential(
         ssl: *mut SSL,
         dc: *mut CRYPTO_BUFFER,
@@ -30940,7 +30940,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_delegated_credential_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_delegated_credential_used"]
     pub fn SSL_delegated_credential_used(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub const ssl_encryption_level_t_ssl_encryption_initial: ssl_encryption_level_t = 0;
@@ -31053,22 +31053,22 @@ fn bindgen_test_layout_ssl_quic_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_quic_max_handshake_flight_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_quic_max_handshake_flight_len"]
     pub fn SSL_quic_max_handshake_flight_len(
         ssl: *const SSL,
         level: ssl_encryption_level_t,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_quic_read_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_quic_read_level"]
     pub fn SSL_quic_read_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_quic_write_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_quic_write_level"]
     pub fn SSL_quic_write_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_provide_quic_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_provide_quic_data"]
     pub fn SSL_provide_quic_data(
         ssl: *mut SSL,
         level: ssl_encryption_level_t,
@@ -31077,25 +31077,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_process_quic_post_handshake"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_process_quic_post_handshake"]
     pub fn SSL_process_quic_post_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_quic_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_quic_method"]
     pub fn SSL_CTX_set_quic_method(
         ctx: *mut SSL_CTX,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_quic_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_quic_method"]
     pub fn SSL_set_quic_method(
         ssl: *mut SSL,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_quic_transport_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_quic_transport_params"]
     pub fn SSL_set_quic_transport_params(
         ssl: *mut SSL,
         params: *const u8,
@@ -31103,7 +31103,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_quic_transport_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_quic_transport_params"]
     pub fn SSL_get_peer_quic_transport_params(
         ssl: *const SSL,
         out_params: *mut *const u8,
@@ -31111,11 +31111,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_quic_use_legacy_codepoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_quic_use_legacy_codepoint"]
     pub fn SSL_set_quic_use_legacy_codepoint(ssl: *mut SSL, use_legacy: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_quic_early_data_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_quic_early_data_context"]
     pub fn SSL_set_quic_early_data_context(
         ssl: *mut SSL,
         context: *const u8,
@@ -31123,35 +31123,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_early_data_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_early_data_enabled"]
     pub fn SSL_CTX_set_early_data_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_early_data_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_early_data_enabled"]
     pub fn SSL_set_early_data_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_in_early_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_in_early_data"]
     pub fn SSL_in_early_data(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_early_data_capable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_early_data_capable"]
     pub fn SSL_SESSION_early_data_capable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_copy_without_early_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_copy_without_early_data"]
     pub fn SSL_SESSION_copy_without_early_data(session: *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_early_data_accepted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_early_data_accepted"]
     pub fn SSL_early_data_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_reset_early_data_reject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_reset_early_data_reject"]
     pub fn SSL_reset_early_data_reject(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ticket_age_skew"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ticket_age_skew"]
     pub fn SSL_get_ticket_age_skew(ssl: *const SSL) -> i32;
 }
 pub const ssl_early_data_reason_t_ssl_early_data_unknown: ssl_early_data_reason_t = 0;
@@ -31173,21 +31173,21 @@ pub const ssl_early_data_reason_t_ssl_early_data_alps_mismatch: ssl_early_data_r
 pub const ssl_early_data_reason_t_ssl_early_data_reason_max_value: ssl_early_data_reason_t = 14;
 pub type ssl_early_data_reason_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_early_data_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_early_data_reason"]
     pub fn SSL_get_early_data_reason(ssl: *const SSL) -> ssl_early_data_reason_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_early_data_reason_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_early_data_reason_string"]
     pub fn SSL_early_data_reason_string(
         reason: ssl_early_data_reason_t,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_enable_ech_grease"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_enable_ech_grease"]
     pub fn SSL_set_enable_ech_grease(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_ech_config_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_ech_config_list"]
     pub fn SSL_set1_ech_config_list(
         ssl: *mut SSL,
         ech_config_list: *const u8,
@@ -31195,7 +31195,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_ech_name_override"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_ech_name_override"]
     pub fn SSL_get0_ech_name_override(
         ssl: *const SSL,
         out_name: *mut *const ::std::os::raw::c_char,
@@ -31203,7 +31203,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get0_ech_retry_configs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get0_ech_retry_configs"]
     pub fn SSL_get0_ech_retry_configs(
         ssl: *const SSL,
         out_retry_configs: *mut *const u8,
@@ -31211,7 +31211,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_marshal_ech_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_marshal_ech_config"]
     pub fn SSL_marshal_ech_config(
         out: *mut *mut u8,
         out_len: *mut usize,
@@ -31222,19 +31222,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_new"]
     pub fn SSL_ECH_KEYS_new() -> *mut SSL_ECH_KEYS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_up_ref"]
     pub fn SSL_ECH_KEYS_up_ref(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_free"]
     pub fn SSL_ECH_KEYS_free(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_add"]
     pub fn SSL_ECH_KEYS_add(
         keys: *mut SSL_ECH_KEYS,
         is_retry_config: ::std::os::raw::c_int,
@@ -31244,12 +31244,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_has_duplicate_config_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_has_duplicate_config_id"]
     pub fn SSL_ECH_KEYS_has_duplicate_config_id(keys: *const SSL_ECH_KEYS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ECH_KEYS_marshal_retry_configs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ECH_KEYS_marshal_retry_configs"]
     pub fn SSL_ECH_KEYS_marshal_retry_configs(
         keys: *const SSL_ECH_KEYS,
         out: *mut *mut u8,
@@ -31257,34 +31257,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_ech_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_ech_keys"]
     pub fn SSL_CTX_set1_ech_keys(
         ctx: *mut SSL_CTX,
         keys: *mut SSL_ECH_KEYS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_ech_accepted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_ech_accepted"]
     pub fn SSL_ech_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_alert_type_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_alert_type_string_long"]
     pub fn SSL_alert_type_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_alert_desc_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_alert_desc_string_long"]
     pub fn SSL_alert_desc_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_send_fatal_alert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_send_fatal_alert"]
     pub fn SSL_send_fatal_alert(ssl: *mut SSL, alert: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_ex_data"]
     pub fn SSL_set_ex_data(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -31292,14 +31292,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ex_data"]
     pub fn SSL_get_ex_data(
         ssl: *const SSL,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ex_new_index"]
     pub fn SSL_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31309,7 +31309,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_set_ex_data"]
     pub fn SSL_SESSION_set_ex_data(
         session: *mut SSL_SESSION,
         idx: ::std::os::raw::c_int,
@@ -31317,14 +31317,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_ex_data"]
     pub fn SSL_SESSION_get_ex_data(
         session: *const SSL_SESSION,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_SESSION_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_SESSION_get_ex_new_index"]
     pub fn SSL_SESSION_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31334,7 +31334,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_ex_data"]
     pub fn SSL_CTX_set_ex_data(
         ctx: *mut SSL_CTX,
         idx: ::std::os::raw::c_int,
@@ -31342,14 +31342,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_ex_data"]
     pub fn SSL_CTX_get_ex_data(
         ctx: *const SSL_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_ex_new_index"]
     pub fn SSL_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31359,7 +31359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_ivs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_ivs"]
     pub fn SSL_get_ivs(
         ssl: *const SSL,
         out_read_iv: *mut *const u8,
@@ -31368,11 +31368,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_key_block_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_key_block_len"]
     pub fn SSL_get_key_block_len(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_generate_key_block"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_generate_key_block"]
     pub fn SSL_generate_key_block(
         ssl: *const SSL,
         out: *mut u8,
@@ -31380,26 +31380,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_read_sequence"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_read_sequence"]
     pub fn SSL_get_read_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_write_sequence"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_write_sequence"]
     pub fn SSL_get_write_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_record_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_record_protocol_version"]
     pub fn SSL_CTX_set_record_protocol_version(
         ctx: *mut SSL_CTX,
         version: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_serialize_capabilities"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_serialize_capabilities"]
     pub fn SSL_serialize_capabilities(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_request_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_request_handshake_hints"]
     pub fn SSL_request_handshake_hints(
         ssl: *mut SSL,
         client_hello: *const u8,
@@ -31409,11 +31409,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_serialize_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_serialize_handshake_hints"]
     pub fn SSL_serialize_handshake_hints(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_handshake_hints"]
     pub fn SSL_set_handshake_hints(
         ssl: *mut SSL,
         hints: *const u8,
@@ -31421,7 +31421,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_msg_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_msg_callback"]
     pub fn SSL_CTX_set_msg_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31438,11 +31438,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_msg_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_msg_callback_arg"]
     pub fn SSL_CTX_set_msg_callback_arg(ctx: *mut SSL_CTX, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_msg_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_msg_callback"]
     pub fn SSL_set_msg_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31459,11 +31459,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_msg_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_msg_callback_arg"]
     pub fn SSL_set_msg_callback_arg(ssl: *mut SSL, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_keylog_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_keylog_callback"]
     pub fn SSL_CTX_set_keylog_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31472,7 +31472,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_keylog_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_keylog_callback"]
     pub fn SSL_CTX_get_keylog_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -31480,14 +31480,14 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_current_time_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_current_time_cb"]
     pub fn SSL_CTX_set_current_time_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<unsafe extern "C" fn(ssl: *const SSL, out_clock: *mut timeval)>,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_shed_handshake_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_shed_handshake_config"]
     pub fn SSL_set_shed_handshake_config(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_never: ssl_renegotiate_mode_t = 0;
@@ -31497,46 +31497,46 @@ pub const ssl_renegotiate_mode_t_ssl_renegotiate_ignore: ssl_renegotiate_mode_t 
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_explicit: ssl_renegotiate_mode_t = 4;
 pub type ssl_renegotiate_mode_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_renegotiate_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_renegotiate_mode"]
     pub fn SSL_set_renegotiate_mode(ssl: *mut SSL, mode: ssl_renegotiate_mode_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_renegotiate"]
     pub fn SSL_renegotiate(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_renegotiate_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_renegotiate_pending"]
     pub fn SSL_renegotiate_pending(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_total_renegotiations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_total_renegotiations"]
     pub fn SSL_total_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_max_cert_list"]
     pub fn SSL_CTX_get_max_cert_list(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_max_cert_list"]
     pub fn SSL_CTX_set_max_cert_list(ctx: *mut SSL_CTX, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_max_cert_list"]
     pub fn SSL_get_max_cert_list(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_max_cert_list"]
     pub fn SSL_set_max_cert_list(ssl: *mut SSL, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_max_send_fragment"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_max_send_fragment"]
     pub fn SSL_CTX_set_max_send_fragment(
         ctx: *mut SSL_CTX,
         max_send_fragment: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_max_send_fragment"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_max_send_fragment"]
     pub fn SSL_set_max_send_fragment(
         ssl: *mut SSL,
         max_send_fragment: usize,
@@ -31730,7 +31730,7 @@ pub const ssl_select_cert_result_t_ssl_select_cert_retry: ssl_select_cert_result
 pub const ssl_select_cert_result_t_ssl_select_cert_error: ssl_select_cert_result_t = -1;
 pub type ssl_select_cert_result_t = ::std::os::raw::c_int;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_early_callback_ctx_extension_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_early_callback_ctx_extension_get"]
     pub fn SSL_early_callback_ctx_extension_get(
         client_hello: *const SSL_CLIENT_HELLO,
         extension_type: u16,
@@ -31739,7 +31739,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_select_certificate_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_select_certificate_cb"]
     pub fn SSL_CTX_set_select_certificate_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31748,7 +31748,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_dos_protection_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_dos_protection_cb"]
     pub fn SSL_CTX_set_dos_protection_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31757,19 +31757,19 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_reverify_on_resume"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_reverify_on_resume"]
     pub fn SSL_CTX_set_reverify_on_resume(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_enforce_rsa_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_enforce_rsa_key_usage"]
     pub fn SSL_set_enforce_rsa_key_usage(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_was_key_usage_invalid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_was_key_usage_invalid"]
     pub fn SSL_was_key_usage_invalid(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_info_callback"]
     pub fn SSL_CTX_set_info_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31782,7 +31782,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_info_callback"]
     pub fn SSL_CTX_get_info_callback(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -31794,7 +31794,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_info_callback"]
     pub fn SSL_set_info_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31807,7 +31807,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_info_callback"]
     pub fn SSL_get_info_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -31819,77 +31819,77 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_state_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_state_string_long"]
     pub fn SSL_state_string_long(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_shutdown"]
     pub fn SSL_get_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_signature_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_signature_algorithm"]
     pub fn SSL_get_peer_signature_algorithm(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_client_random"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_client_random"]
     pub fn SSL_get_client_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_server_random"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_server_random"]
     pub fn SSL_get_server_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_pending_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_pending_cipher"]
     pub fn SSL_get_pending_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_set_retain_only_sha256_of_client_certs(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_CTX_set_retain_only_sha256_of_client_certs(
         ctx: *mut SSL_CTX,
         enable: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_grease_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_grease_enabled"]
     pub fn SSL_CTX_set_grease_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_permute_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_permute_extensions"]
     pub fn SSL_CTX_set_permute_extensions(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_permute_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_permute_extensions"]
     pub fn SSL_set_permute_extensions(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_max_seal_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_max_seal_overhead"]
     pub fn SSL_max_seal_overhead(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_false_start_allowed_without_alpn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_false_start_allowed_without_alpn"]
     pub fn SSL_CTX_set_false_start_allowed_without_alpn(
         ctx: *mut SSL_CTX,
         allowed: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_used_hello_retry_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_used_hello_retry_request"]
     pub fn SSL_used_hello_retry_request(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_jdk11_workaround"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_jdk11_workaround"]
     pub fn SSL_set_jdk11_workaround(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_library_init"]
     pub fn SSL_library_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_description"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_description"]
     pub fn SSL_CIPHER_description(
         cipher: *const SSL_CIPHER,
         buf: *mut ::std::os::raw::c_char,
@@ -31897,11 +31897,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_version"]
     pub fn SSL_CIPHER_get_version(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_rfc_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_rfc_name"]
     pub fn SSL_CIPHER_get_rfc_name(cipher: *const SSL_CIPHER) -> *mut ::std::os::raw::c_char;
 }
 pub type COMP_METHOD = ::std::os::raw::c_void;
@@ -31912,126 +31912,126 @@ pub struct stack_st_SSL_COMP {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_get_compression_methods"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_get_compression_methods"]
     pub fn SSL_COMP_get_compression_methods() -> *mut stack_st_SSL_COMP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_add_compression_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_add_compression_method"]
     pub fn SSL_COMP_add_compression_method(
         id: ::std::os::raw::c_int,
         cm: *mut COMP_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_get_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_get_name"]
     pub fn SSL_COMP_get_name(comp: *const COMP_METHOD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_get0_name"]
     pub fn SSL_COMP_get0_name(comp: *const SSL_COMP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_get_id"]
     pub fn SSL_COMP_get_id(comp: *const SSL_COMP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_COMP_free_compression_methods"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_COMP_free_compression_methods"]
     pub fn SSL_COMP_free_compression_methods();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLv23_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLv23_method"]
     pub fn SSLv23_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_method"]
     pub fn TLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_1_method"]
     pub fn TLSv1_1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_2_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_2_method"]
     pub fn TLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_method"]
     pub fn DTLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_2_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_2_method"]
     pub fn DTLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLS_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLS_server_method"]
     pub fn TLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLS_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLS_client_method"]
     pub fn TLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLv23_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLv23_server_method"]
     pub fn SSLv23_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSLv23_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSLv23_client_method"]
     pub fn SSLv23_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_server_method"]
     pub fn TLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_client_method"]
     pub fn TLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_1_server_method"]
     pub fn TLSv1_1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_1_client_method"]
     pub fn TLSv1_1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_2_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_2_server_method"]
     pub fn TLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_TLSv1_2_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_TLSv1_2_client_method"]
     pub fn TLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLS_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLS_server_method"]
     pub fn DTLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLS_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLS_client_method"]
     pub fn DTLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_server_method"]
     pub fn DTLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_client_method"]
     pub fn DTLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_2_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_2_server_method"]
     pub fn DTLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_DTLSv1_2_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_DTLSv1_2_client_method"]
     pub fn DTLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_clear"]
     pub fn SSL_clear(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tmp_rsa_callback"]
     pub fn SSL_CTX_set_tmp_rsa_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32044,7 +32044,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tmp_rsa_callback"]
     pub fn SSL_set_tmp_rsa_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32057,98 +32057,98 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_connect"]
     pub fn SSL_CTX_sess_connect(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_connect_good"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_connect_good"]
     pub fn SSL_CTX_sess_connect_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_connect_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_connect_renegotiate"]
     pub fn SSL_CTX_sess_connect_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_accept"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_accept"]
     pub fn SSL_CTX_sess_accept(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_accept_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_accept_renegotiate"]
     pub fn SSL_CTX_sess_accept_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_accept_good"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_accept_good"]
     pub fn SSL_CTX_sess_accept_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_hits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_hits"]
     pub fn SSL_CTX_sess_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_cb_hits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_cb_hits"]
     pub fn SSL_CTX_sess_cb_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_misses"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_misses"]
     pub fn SSL_CTX_sess_misses(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_timeouts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_timeouts"]
     pub fn SSL_CTX_sess_timeouts(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_sess_cache_full"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_sess_cache_full"]
     pub fn SSL_CTX_sess_cache_full(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_cutthrough_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_cutthrough_complete"]
     pub fn SSL_cutthrough_complete(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_num_renegotiations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_num_renegotiations"]
     pub fn SSL_num_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_need_tmp_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_need_tmp_RSA"]
     pub fn SSL_CTX_need_tmp_RSA(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_need_tmp_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_need_tmp_RSA"]
     pub fn SSL_need_tmp_RSA(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tmp_rsa"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tmp_rsa"]
     pub fn SSL_CTX_set_tmp_rsa(ctx: *mut SSL_CTX, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tmp_rsa"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tmp_rsa"]
     pub fn SSL_set_tmp_rsa(ssl: *mut SSL, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_read_ahead"]
     pub fn SSL_CTX_get_read_ahead(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_read_ahead"]
     pub fn SSL_CTX_set_read_ahead(
         ctx: *mut SSL_CTX,
         yes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_read_ahead"]
     pub fn SSL_get_read_ahead(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_read_ahead"]
     pub fn SSL_set_read_ahead(ssl: *mut SSL, yes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_state"]
     pub fn SSL_set_state(ssl: *mut SSL, state: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_shared_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_shared_ciphers"]
     pub fn SSL_get_shared_ciphers(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_char,
@@ -32156,7 +32156,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_shared_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_shared_sigalgs"]
     pub fn SSL_get_shared_sigalgs(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -32168,11 +32168,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_SSL_SESSION"]
     pub fn i2d_SSL_SESSION(in_: *mut SSL_SESSION, pp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_SSL_SESSION"]
     pub fn d2i_SSL_SESSION(
         a: *mut *mut SSL_SESSION,
         pp: *mut *const u8,
@@ -32180,61 +32180,61 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_i2d_SSL_SESSION_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_i2d_SSL_SESSION_bio"]
     pub fn i2d_SSL_SESSION_bio(bio: *mut BIO, session: *const SSL_SESSION)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_d2i_SSL_SESSION_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_d2i_SSL_SESSION_bio"]
     pub fn d2i_SSL_SESSION_bio(bio: *mut BIO, out: *mut *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_ERR_load_SSL_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_ERR_load_SSL_strings"]
     pub fn ERR_load_SSL_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_load_error_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_load_error_strings"]
     pub fn SSL_load_error_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_use_srtp"]
     pub fn SSL_CTX_set_tlsext_use_srtp(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tlsext_use_srtp"]
     pub fn SSL_set_tlsext_use_srtp(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_current_compression"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_current_compression"]
     pub fn SSL_get_current_compression(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_current_expansion"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_current_expansion"]
     pub fn SSL_get_current_expansion(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_server_tmp_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_server_tmp_key"]
     pub fn SSL_get_server_tmp_key(
         ssl: *mut SSL,
         out_key: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tmp_dh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tmp_dh"]
     pub fn SSL_CTX_set_tmp_dh(ctx: *mut SSL_CTX, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tmp_dh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tmp_dh"]
     pub fn SSL_set_tmp_dh(ssl: *mut SSL, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tmp_dh_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tmp_dh_callback"]
     pub fn SSL_CTX_set_tmp_dh_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32247,7 +32247,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tmp_dh_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tmp_dh_callback"]
     pub fn SSL_set_tmp_dh_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32260,7 +32260,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_sigalgs"]
     pub fn SSL_CTX_set1_sigalgs(
         ctx: *mut SSL_CTX,
         values: *const ::std::os::raw::c_int,
@@ -32268,7 +32268,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_sigalgs"]
     pub fn SSL_set1_sigalgs(
         ssl: *mut SSL,
         values: *const ::std::os::raw::c_int,
@@ -32276,25 +32276,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set1_sigalgs_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set1_sigalgs_list"]
     pub fn SSL_CTX_set1_sigalgs_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set1_sigalgs_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set1_sigalgs_list"]
     pub fn SSL_set1_sigalgs_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_get_security_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_get_security_level"]
     pub fn SSL_CTX_get_security_level(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_security_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_security_level"]
     pub fn SSL_CTX_set_security_level(ctx: *const SSL_CTX, level: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -32374,26 +32374,26 @@ pub type sk_SSL_COMP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_cache_hit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_cache_hit"]
     pub fn SSL_cache_hit(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_default_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_default_timeout"]
     pub fn SSL_get_default_timeout(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_version"]
     pub fn SSL_get_version(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_cipher_list"]
     pub fn SSL_get_cipher_list(
         ssl: *const SSL,
         n: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_client_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_client_cert_cb"]
     pub fn SSL_CTX_set_client_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32406,11 +32406,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_want"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_want"]
     pub fn SSL_want(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_finished"]
     pub fn SSL_get_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32418,7 +32418,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_peer_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_peer_finished"]
     pub fn SSL_get_peer_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32426,15 +32426,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_alert_type_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_alert_type_string"]
     pub fn SSL_alert_type_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_alert_desc_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_alert_desc_string"]
     pub fn SSL_alert_desc_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_state_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_state_string"]
     pub fn SSL_state_string(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 #[repr(C)]
@@ -32444,42 +32444,42 @@ pub struct ssl_conf_ctx_st {
 }
 pub type SSL_CONF_CTX = ssl_conf_ctx_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_state"]
     pub fn SSL_state(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_shutdown"]
     pub fn SSL_set_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tmp_ecdh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tmp_ecdh"]
     pub fn SSL_CTX_set_tmp_ecdh(ctx: *mut SSL_CTX, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tmp_ecdh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tmp_ecdh"]
     pub fn SSL_set_tmp_ecdh(ssl: *mut SSL, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_add_dir_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_add_dir_cert_subjects_to_stack"]
     pub fn SSL_add_dir_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         dir: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_enable_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_enable_tls_channel_id"]
     pub fn SSL_CTX_enable_tls_channel_id(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_enable_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_enable_tls_channel_id"]
     pub fn SSL_enable_tls_channel_id(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_f_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_f_ssl"]
     pub fn BIO_f_ssl() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_BIO_set_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_BIO_set_ssl"]
     pub fn BIO_set_ssl(
         bio: *mut BIO,
         ssl: *mut SSL,
@@ -32487,33 +32487,33 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_session"]
     pub fn SSL_get_session(ssl: *const SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get1_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get1_session"]
     pub fn SSL_get1_session(ssl: *mut SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_OPENSSL_init_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_OPENSSL_init_ssl"]
     pub fn OPENSSL_init_ssl(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tlsext_status_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tlsext_status_type"]
     pub fn SSL_set_tlsext_status_type(
         ssl: *mut SSL,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_tlsext_status_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_tlsext_status_type"]
     pub fn SSL_get_tlsext_status_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_set_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_set_tlsext_status_ocsp_resp"]
     pub fn SSL_set_tlsext_status_ocsp_resp(
         ssl: *mut SSL,
         resp: *mut u8,
@@ -32521,11 +32521,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_get_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_get_tlsext_status_ocsp_resp"]
     pub fn SSL_get_tlsext_status_ocsp_resp(ssl: *const SSL, out: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_status_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_status_cb"]
     pub fn SSL_CTX_set_tlsext_status_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -32537,18 +32537,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CTX_set_tlsext_status_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CTX_set_tlsext_status_arg"]
     pub fn SSL_CTX_set_tlsext_status_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_SSL_CIPHER_get_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_SSL_CIPHER_get_value"]
     pub fn SSL_CIPHER_get_value(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_6_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_7_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,


### PR DESCRIPTION
### Issues:
* Update aws-lc-fips-sys to v0.12.7
* Bindings generated by this run: https://github.com/aws/aws-lc-rs/actions/runs/8529121080

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
