### PR TITLE
Support target x86_64-apple-ios

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -71,8 +71,6 @@ jobs:
         with:
           toolchain: stable
           target: aarch64-apple-ios-sim
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
       - name: Install bash
         run: brew install bash
       - name: iOS Simulator Runner
@@ -91,7 +89,5 @@ jobs:
         with:
           toolchain: stable
           target: x86_64-apple-ios
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
       - name: Build for `x86_64-apple-ios`
-        run: cargo build -p aws-lc-rs --features bindgen
+        run: cargo build -p aws-lc-rs --target x86_64-apple-ios --features bindgen

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -58,15 +58,10 @@ jobs:
       - name: Cross-compilation w/ bindgen
         run: cross test -p aws-lc-rs --release --features bindgen,unstable --target ${{ matrix.target }}
 
-  aws-lc-rs-platform-build:
+  aws-lc-rs-ios-aarch64:
     if: github.repository == 'aws/aws-lc-rs'
-    name: Cross-platform build
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        rust: [ stable ]
-        os: [ macos-13-xlarge ]
+    name: iOS aarch64 cross-platform build
+    runs-on: macos-13-xlarge
     steps:
       - uses: actions/checkout@v3
         with:
@@ -74,7 +69,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         id: toolchain
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
           target: aarch64-apple-ios-sim
       - name: Set Rust toolchain override
         run: rustup override set ${{ steps.toolchain.outputs.name }}
@@ -82,3 +77,21 @@ jobs:
         run: brew install bash
       - name: iOS Simulator Runner
         run: ./scripts/ci/ios-simulator-runner.sh
+
+  aws-lc-rs-ios-x86_64:
+    if: github.repository == 'aws/aws-lc-rs'
+    name: iOS x86-64 cross-platform build
+    runs-on: macos-13-xlarge
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - uses: dtolnay/rust-toolchain@master
+        id: toolchain
+        with:
+          toolchain: stable
+          target: x86_64-apple-ios
+      - name: Set Rust toolchain override
+        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Build for `x86_64-apple-ios`
+        run: cargo build -p aws-lc-rs --features bindgen

--- a/aws-lc-sys/builder/cmake_builder.rs
+++ b/aws-lc-sys/builder/cmake_builder.rs
@@ -102,14 +102,22 @@ impl CmakeBuilder {
         cmake_cfg.define("DISABLE_GO", "ON");
 
         if target_vendor() == "apple" {
-            if target_os().trim() == "ios" {
+            if target_os().to_lowercase() == "ios" {
                 cmake_cfg.define("CMAKE_SYSTEM_NAME", "iOS");
-                if target().trim().ends_with("-ios-sim") {
+                if target().ends_with("-ios-sim") || target_arch() == "x86_64" {
                     cmake_cfg.define("CMAKE_OSX_SYSROOT", "iphonesimulator");
+                } else {
+                    cmake_cfg.define("CMAKE_OSX_SYSROOT", "iphoneos");
                 }
+                cmake_cfg.define("CMAKE_THREAD_LIBS_INIT", "-lpthread");
             }
-            if target_arch().trim() == "aarch64" {
+            if target_arch() == "aarch64" {
                 cmake_cfg.define("CMAKE_OSX_ARCHITECTURES", "arm64");
+                cmake_cfg.define("CMAKE_SYSTEM_PROCESSOR", "arm64");
+            }
+            if target_arch() == "x86_64" {
+                cmake_cfg.define("CMAKE_OSX_ARCHITECTURES", "x86_64");
+                cmake_cfg.define("CMAKE_SYSTEM_PROCESSOR", "x86_64");
             }
         }
 


### PR DESCRIPTION
### Issues:
Resolves #373 

### Description of changes: 
* Fixes CMake build when compiling to `x86_64-apple-ios`.
* Adds CI step for this build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
