### PR TITLE
Include s390x in CI

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -40,6 +40,7 @@ jobs:
           - powerpc-unknown-linux-gnu
           - x86_64-unknown-linux-musl
           - aarch64-unknown-linux-musl
+          - s390x-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v3
         with:

--- a/aws-lc-fips-sys/builder/cmake_builder.rs
+++ b/aws-lc-fips-sys/builder/cmake_builder.rs
@@ -75,13 +75,6 @@ impl CmakeBuilder {
     fn prepare_cmake_build(&self) -> cmake::Config {
         let mut cmake_cfg = self.get_cmake_config();
 
-        if ["powerpc64", "powerpc"]
-            .iter()
-            .any(|arch| target_arch().eq_ignore_ascii_case(arch))
-        {
-            cmake_cfg.define("ENABLE_EXPERIMENTAL_BIG_ENDIAN_SUPPORT", "1");
-        }
-
         if OutputLibType::default() == OutputLibType::Dynamic {
             cmake_cfg.define("BUILD_SHARED_LIBS", "1");
         } else {

--- a/aws-lc-sys/builder/cmake_builder.rs
+++ b/aws-lc-sys/builder/cmake_builder.rs
@@ -57,13 +57,6 @@ impl CmakeBuilder {
     fn prepare_cmake_build(&self) -> cmake::Config {
         let mut cmake_cfg = self.get_cmake_config();
 
-        if ["powerpc64", "powerpc"]
-            .iter()
-            .any(|arch| target_arch().eq_ignore_ascii_case(arch))
-        {
-            cmake_cfg.define("ENABLE_EXPERIMENTAL_BIG_ENDIAN_SUPPORT", "1");
-        }
-
         if OutputLibType::default() == OutputLibType::Dynamic {
             cmake_cfg.define("BUILD_SHARED_LIBS", "1");
         } else {


### PR DESCRIPTION
### Description of changes: 
* Add `s390x-unknown-linux-gnu` target to our CI.
* Removes no longer needed `ENABLE_EXPERIMENTAL_BIG_ENDIAN_SUPPORT` build flag.

### Call-outs:
* s390x listed [here](https://github.com/aws/aws-lc?tab=readme-ov-file#other-platforms).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
