### PR TITLE
Align GitHub workflow/job run conditions

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -2,10 +2,15 @@ name: analysis
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - '*'
+      - '!generate/aws-lc-*'
   pull_request:
     branches:
       - '*'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 env:
   RUST_BACKTRACE: 1
@@ -19,6 +24,7 @@ env:
 
 jobs:
   rustfmt:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -36,6 +42,7 @@ jobs:
         run: cargo fmt -- --check --verbose
 
   clippy:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -62,7 +69,7 @@ jobs:
         run: cargo clippy ${{ matrix.features }} --all-targets -- -W clippy::all -W clippy::pedantic -D warnings
 
   apidiff:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -96,6 +103,7 @@ jobs:
           cargo public-api diff --deny changed --deny removed "${CRATE_VERSION}"
 
   dependency-review:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
@@ -108,7 +116,7 @@ jobs:
           allow-licenses: Apache-2.0, ISC, MIT, MIT-0
 
   udeps:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -133,7 +141,7 @@ jobs:
           RUSTC_WRAPPER: ""
 
   bindgen-dependency:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -164,7 +172,7 @@ jobs:
           }
 
   bindgen-fips-dependency:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -195,7 +203,7 @@ jobs:
           }
 
   mirai-analysis:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -229,7 +237,7 @@ jobs:
           cargo mirai
 
   minimal-versions:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     name: Resolve the dependencies to the minimum SemVer version
     runs-on: ubuntu-latest
     steps:
@@ -249,6 +257,7 @@ jobs:
         run: cargo --locked check
 
   copyright:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -258,6 +267,7 @@ jobs:
           ./scripts/tools/copyright_check.sh
 
   semver-checks:
+    if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -2,10 +2,15 @@ name: cross
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - '*'
+      - '!generate/aws-lc-*'
   pull_request:
     branches:
       - '*'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 env:
   RUST_BACKTRACE: 1
@@ -15,7 +20,7 @@ env:
 
 jobs:
   aws-lc-rs-cross-test:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     name: aws-lc-rs cross tests
     runs-on: ${{ matrix.os }}
     strategy:
@@ -59,7 +64,7 @@ jobs:
         run: cross test -p aws-lc-rs --release --features bindgen,unstable --target ${{ matrix.target }}
 
   aws-lc-rs-ios-aarch64:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     name: iOS aarch64 cross-platform build
     runs-on: macos-13-xlarge
     steps:
@@ -77,7 +82,7 @@ jobs:
         run: ./scripts/ci/ios-simulator-runner.sh
 
   aws-lc-rs-ios-x86_64:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     name: iOS x86-64 cross-platform build
     runs-on: macos-13-xlarge
     steps:

--- a/.github/workflows/fips.yml
+++ b/.github/workflows/fips.yml
@@ -2,10 +2,15 @@ name: fips
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - '*'
+      - '!generate/aws-lc-*'
   pull_request:
     branches:
       - '*'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 env:
   RUST_BACKTRACE: 1
@@ -15,7 +20,7 @@ env:
 
 jobs:
   fips-test:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     name: aws-lc-rs fips-tests
     runs-on: ${{ matrix.os }}
     env:
@@ -52,7 +57,7 @@ jobs:
         # See: https://github.com/rust-lang/cargo/issues/8531
         run: cargo test --tests ${{ matrix.args }}
   windows-fips-test:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     name: aws-lc-rs windows-fips-tests
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,10 +2,15 @@ name: integration
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - '*'
+      - '!generate/aws-lc-*'
   pull_request:
     branches:
       - '*'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 env:
   RUST_BACKTRACE: 1
@@ -15,7 +20,7 @@ env:
 
 jobs:
   s2n-quic-integration:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     name: s2n-quic-integration
     runs-on: ${{ matrix.os }}
     strategy:
@@ -36,7 +41,7 @@ jobs:
           ./scripts/run-s2n-quic-integration.sh
 
   rustls-integration:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     name: rustls-integration
     runs-on: ${{ matrix.os }}
     strategy:
@@ -59,7 +64,7 @@ jobs:
           ./scripts/run-rustls-integration.sh
 
   links-crate-tests:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     name: sys crate tests
     runs-on: ${{ matrix.os }}
     strategy:
@@ -92,7 +97,7 @@ jobs:
         run: cargo run --features ${{ matrix.features }} --no-default-features
 
   publish-dry-run:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     name: publish dry-run
     runs-on: ${{ matrix.os }}
     strategy:
@@ -136,7 +141,7 @@ jobs:
 
   msrv:
     name: Minimum Supported Rust Version
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,10 +2,15 @@ name: tests
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - '*'
+      - '!generate/aws-lc-*'
   pull_request:
     branches:
       - '*'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 env:
   RUST_BACKTRACE: 1
@@ -16,7 +21,7 @@ env:
 jobs:
 
   aws-lc-rs-test:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     name: aws-lc-rs tests
     runs-on: ${{ matrix.os }}
     strategy:
@@ -49,7 +54,7 @@ jobs:
         run: cargo test --all-targets
 
   bindgen-test:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     name: aws-lc-rs bindgen-tests
     runs-on: ${{ matrix.os }}
     strategy:
@@ -75,7 +80,7 @@ jobs:
         run: cargo test ${{ matrix.args }}
 
   windows-test:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     name: aws-lc-rs windows-tests
     runs-on: ${{ matrix.os }}
     strategy:
@@ -140,7 +145,7 @@ jobs:
           files: ${{ runner.temp }}/lcov.info,${{ runner.temp }}/lcov-fips.info
 
   aws-lc-rs-asan:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     name: aws-lc-rs asan
     strategy:
       matrix:
@@ -170,7 +175,7 @@ jobs:
         run: cargo test ${{ matrix.args }} --lib --bins --tests --examples --target x86_64-unknown-linux-gnu --features asan
 
   build-env-test:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     name: aws-lc-rs build-env-test
     runs-on: ${{ matrix.os }}
     strategy:
@@ -193,7 +198,7 @@ jobs:
         run: AWS_LC_SYS_STATIC=${{ matrix.static }}  cargo test --tests
 
   build-env-fips-test:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     name: aws-lc-rs build-env-fips-test
     runs-on: ${{ matrix.os }}
     strategy:
@@ -220,7 +225,7 @@ jobs:
         run: AWS_LC_FIPS_SYS_STATIC=${{ matrix.static }} cargo test --tests --features fips
 
   careful:
-    if: github.repository == 'aws/aws-lc-rs'
+    if: github.repository_owner == 'aws'
     name: Run carefully
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
### Description of changes: 
* Align our GitHub workflows/jobs so that they all run on the same conditions.
* Avoid costly CI runs when on non-"aws" repos.
  * The "aws-ls-rs coverage" job will still run on any repo that has GitHub actions enabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
