### PR TITLE
Support build for aarch64-pc-windows-msvc

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -123,3 +123,21 @@ jobs:
         run: cargo test -p aws-lc-rs --target x86_64-pc-windows-gnu --features bindgen
       - name: Release test on `x86_64-pc-windows-gnu`
         run: cargo test -p aws-lc-rs --release --target x86_64-pc-windows-gnu --features bindgen
+
+  aws-lc-rs-windows-arm64:
+    if: github.repository_owner == 'aws'
+    name: aarch64-pc-windows-msvc
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Install ninja-build tool
+        uses: seanmiddleditch/gha-setup-ninja@v4
+      - uses: dtolnay/rust-toolchain@master
+        id: toolchain
+        with:
+          toolchain: stable
+          target: aarch64-pc-windows-msvc
+      - name: Build for `aarch64-pc-windows-msvc`
+        run: cargo build -p aws-lc-rs --target aarch64-pc-windows-msvc --features bindgen


### PR DESCRIPTION
### Issues:
Resolves:
* #376

### Description of changes: 
* Fixes build for `aarch64-pc-windows-msvc `. It requires that [clang-cl](https://learn.microsoft.com/en-us/cpp/build/clang-support-msbuild?view=msvc-170) and [ninja](https://github.com/ninja-build/ninja/releases) be installed.

### Testing:
* Verified locally that tests pass on a Windows/ARM64 host.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
