### PR TITLE
hkdf: increase MAX_HKDF_INFO_LEN

### DIFF
--- a/aws-lc-rs/src/hkdf.rs
+++ b/aws-lc-rs/src/hkdf.rs
@@ -75,10 +75,17 @@ pub static HKDF_SHA512: Algorithm = Algorithm(hmac::HMAC_SHA512);
 /// We set the limit to something tolerable, so that the Salt structure can be stack allocatable.
 const MAX_HKDF_SALT_LEN: usize = 80;
 
+// This is needed so that the precise value can be provided in the documentation.
+macro_rules! max_hkdf_info_len {
+    () => {
+        102
+    };
+}
+
 /// General Info length's for HKDF don't normally exceed 256 bits.
 /// We set the limit to something tolerable, so that the memory passed into |`HKDF_expand`| is
 /// allocated on the stack.
-const MAX_HKDF_INFO_LEN: usize = 102;
+const MAX_HKDF_INFO_LEN: usize = max_hkdf_info_len!();
 
 /// The maximum output size of a PRK computed by |`HKDF_extract`| is the maximum digest
 /// size that can be outputted by *AWS-LC*.
@@ -343,8 +350,9 @@ impl Prk {
     /// [HKDF-Expand]: https://tools.ietf.org/html/rfc5869#section-2.3
     ///
     /// # Errors
-    /// `error::Unspecified` if (and only if) `len` is too large.
-    ///
+    /// Returns `error::Unspecified` if either:
+    ///   * `len` is more than 255 times the digest algorithm's output length.
+    #[doc = concat!("  * the combined lengths of the `info` slices is more than ", max_hkdf_info_len!(), " bytes.")]
     // # FIPS
     // The following conditions must be met:
     // * `Prk` must be constructed using `Salt::extract` prior to calling

--- a/aws-lc-rs/src/hkdf.rs
+++ b/aws-lc-rs/src/hkdf.rs
@@ -78,7 +78,7 @@ const MAX_HKDF_SALT_LEN: usize = 80;
 /// General Info length's for HKDF don't normally exceed 256 bits.
 /// We set the limit to something tolerable, so that the memory passed into |`HKDF_expand`| is
 /// allocated on the stack.
-const MAX_HKDF_INFO_LEN: usize = 80;
+const MAX_HKDF_INFO_LEN: usize = 102;
 
 /// The maximum output size of a PRK computed by |`HKDF_extract`| is the maximum digest
 /// size that can be outputted by *AWS-LC*.


### PR DESCRIPTION
Hi there,

I've been working on [encrypted client hello (ECH)](https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-18) support [in Rustls](https://github.com/rustls/rustls/pull/1718). As part of that we're using aws-lc-rs for the HKDF operations the draft calls for.

In particular, ECH offer confirmation is determined by [computing an 8 byte confirmation value](https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-18#section-7.2):

```
   accept_confirmation = HKDF-Expand-Label(
      HKDF-Extract(0, ClientHelloInner.random),
      "ech accept confirmation",
      transcript_ech_conf,
      8)
```

Similarly, in the [hello-retry request confirmation case](https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-18#section-7.2.1) we compute:
```
   hrr_accept_confirmation = HKDF-Expand-Label(
      HKDF-Extract(0, ClientHelloInner1.random),
      "hrr ech accept confirmation",
      transcript_hrr_ech_conf,
      8)
```

The HKDF-Expand-Label and HKDF-Extract algorithms are unmodified from RFC 8446.

For a handshake using SHA-384 for the digest algorithm when we confirm ECH acceptance we perform an HKDF expand operation with the `info`:

```
    let label = b"ech accept confirmation"; // or b"hrr ech accept confirmation";
    let n = 8;
    const LABEL_PREFIX: &[u8] = b"tls13 ";

    let output_len = u16::to_be_bytes(n as u16);
    let label_len = u8::to_be_bytes((LABEL_PREFIX.len() + label.len()) as u8);
    let context_len = u8::to_be_bytes(context.len() as u8);

    let info = &[
        &output_len[..],
        &label_len[..],
        LABEL_PREFIX,
        label,
        &context_len[..],
        context,
    ];
```

This works out to be:

```
  2 bytes for the output len
  1 byte for the label len
  6 bytes for the label prefix
 23 bytes for the ECH confirmation label (or 27 bytes for HRR ECH confirmation label)
  1 byte for the context len
 48 bytes for the context
------------------------------------------
= 81 bytes total
```

This exceeds the existing `MAX_HKDF_INFO_LEN` limit of 80 bytes, and so produces an `Unspecified` error. Equivalent inputs do not cause an error with `*ring*`, where there doesn't seem to be a limit imposed on the `info` parameter for HKDF.

The only point of variability in the input is the context length, which in the ECH case is always a transcript digest and so the length is dependent on the hash algorithm in use. If we assume HRR confirmation (for the longer 27 byte label), and SHA512 for the digest, then the context could be as large as 64 bytes, so I think the largest `info` that would be required to be supported for ECH confirmation is 101 bytes. (2 + 1 + 6 + 27 + 1 + 64 = 101).

This PR increase the limit to 102 bytes (it seemed a nicer value than 101), and experimentally all of my ECH confirmation tests using aws-lc-rs for the HKDF operations pass with this limit where previously they resulted in a panic from exceeding the info limit.
