### PR TITLE
Cleanup CI and build configs

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -46,14 +46,17 @@ jobs:
         with:
           submodules: 'recursive'
       - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 'stable'
+      - name: Install cross
+        run: cargo install cross ${{ (matrix.target == 'riscv64gc-unknown-linux-gnu'  && '--locked') || '' }} --git https://github.com/cross-rs/cross
+      - uses: dtolnay/rust-toolchain@master
         id: toolchain
         with:
           toolchain: ${{ (matrix.target == 'riscv64gc-unknown-linux-gnu'  && '1.72.1') || 'stable' }}
           target: ${{ matrix.target }}
       - name: Set Rust toolchain override
         run: rustup override set ${{ steps.toolchain.outputs.name }}
-      - name: Install cross
-        run: cargo install cross ${{ (matrix.target == 'riscv64gc-unknown-linux-gnu'  && '--locked') || '' }} --git https://github.com/cross-rs/cross
       - if: ${{ matrix.target == 'riscv64gc-unknown-linux-gnu' }}
         run: |
           cargo update

--- a/.github/workflows/fips.yml
+++ b/.github/workflows/fips.yml
@@ -63,7 +63,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [ stable ]
         os: [ windows-2019, windows-latest ]
         args:
           - --all-targets --features fips,unstable
@@ -78,11 +77,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
-      - uses: actions-rs/toolchain@v1.0.7
+      - uses: dtolnay/rust-toolchain@master
         id: toolchain
         with:
-          toolchain: ${{ matrix.rust }}
-          override: true
+          toolchain: stable
+      - name: Set Rust toolchain override
+        run: rustup override set ${{ steps.toolchain.outputs.name }}
       - name: Install ninja-build tool
         uses: seanmiddleditch/gha-setup-ninja@v4
       - name: Run cargo test

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -164,8 +164,8 @@ jobs:
       - name: Install MSRV Rust version
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.61.0 # TODO: dynamically identify MSRV
+          toolchain: 1.63.0 # TODO: dynamically identify MSRV
 
       - name: Verify msrv
         working-directory: ./aws-lc-rs
-        run: cargo +1.61.0 check --features bindgen
+        run: cargo +1.63.0 check --features bindgen

--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["AWS-LC"]
 edition = "2021"
 repository = "https://github.com/aws/aws-lc-rs"
 license = "ISC AND (Apache-2.0 OR ISC) AND OpenSSL"
-rust-version = "1.61.0"
+rust-version = "1.63.0"
 include = [
     "LICENSE",
     "/aws-lc/**/*.c",

--- a/aws-lc-fips-sys/builder/main.rs
+++ b/aws-lc-fips-sys/builder/main.rs
@@ -338,8 +338,24 @@ fn has_pregenerated() -> bool {
     unsafe { PREGENERATED }
 }
 
+fn prepare_cargo_cfg() {
+    // This is supported in Rust >= 1.77.0
+    // Also remove `#![allow(unexpected_cfgs)]` from src/lib.rs
+    /*
+    println!("cargo::rustc-check-cfg=cfg(use_bindgen_generated)");
+    println!("cargo::rustc-check-cfg=cfg(i686_unknown_linux_gnu)");
+    println!("cargo::rustc-check-cfg=cfg(x86_64_unknown_linux_gnu)");
+    println!("cargo::rustc-check-cfg=cfg(aarch64_unknown_linux_gnu)");
+    println!("cargo::rustc-check-cfg=cfg(x86_64_unknown_linux_musl)");
+    println!("cargo::rustc-check-cfg=cfg(aarch64_unknown_linux_musl)");
+    println!("cargo::rustc-check-cfg=cfg(x86_64_apple_darwin)");
+    println!("cargo::rustc-check-cfg=cfg(aarch64_apple_darwin)");
+     */
+}
+
 fn main() {
     initialize();
+    prepare_cargo_cfg();
 
     let manifest_dir = current_dir();
     let manifest_dir = dunce::canonicalize(Path::new(&manifest_dir)).unwrap();

--- a/aws-lc-fips-sys/src/lib.rs
+++ b/aws-lc-fips-sys/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
+#![allow(unexpected_cfgs)]
+
 use paste::paste;
 use std::os::raw::{c_char, c_long, c_void};
 

--- a/aws-lc-rs-testing/Cargo.toml
+++ b/aws-lc-rs-testing/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [features]
 ring-benchmarks = []
 openssl-benchmarks = []
+ring-sig-verify = ["aws-lc-rs/ring-sig-verify"]
 bindgen = ["aws-lc-rs/bindgen"]
 fips = ["aws-lc-rs/fips"]
 asan = ["aws-lc-rs/asan"]

--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -5,7 +5,7 @@ version = "1.7.1"
 # this crate re-exports whatever sys crate that was selected
 links = "aws_lc_rs_1_7_1_sys"
 edition = "2021"
-rust-version = "1.61.0"
+rust-version = "1.63.0"
 keywords = ["crypto", "cryptography", "security"]
 license = "ISC AND (Apache-2.0 OR ISC)"
 description = "aws-lc-rs is a cryptographic library using AWS-LC for its cryptographic operations. This library strives to be API-compatible with the popular Rust library named ring."
@@ -57,8 +57,8 @@ lazy_static = "1.4.0"
 clap = { version = "4.1.8", features = ["derive"] }
 hex = "0.4.3"
 
-# Pinned dependency to preserve MSRV: ??? <= rust-version < 1.63.0
-which = "=4.4.0"
+# Pinned dependency to preserve MSRV: 1.63.0 <= rust-version < 1.70.0
+which = "5.0.0"
 # Pinned dependency to preserve MSRV: ??? <= rust-version < 1.70.0
 home = "=0.5.5"
 # Pinned dependency to preserve MSRV: 1.60.0  <= rust-version < 1.65.0
@@ -69,8 +69,6 @@ regex-automata = "~0.3.9"
 regex-syntax = "~0.7.5"
 # Pinned to avoid build failure in older versions
 proc-macro2 = "1.0.60"
-# Pinned dependency to preserve MSRV: ???  <= rust-version < 1.63.0
-jobserver = "=0.1.26"
 
 [package.metadata.cargo-udeps.ignore]
 development = ["which", "home", "regex", "regex-automata", "regex-syntax", "proc-macro2", "jobserver"]

--- a/aws-lc-rs/src/agreement/ephemeral.rs
+++ b/aws-lc-rs/src/agreement/ephemeral.rs
@@ -158,15 +158,14 @@ mod tests {
             &mut k,
             &mut u,
         );
-
-        if cfg!(feature = "slow_tests") {
-            expect_iterated_x25519(
-                "7c3911e0ab2586fd864497297e575e6f3bc601c0883c30df5f4dd2d24f665424",
-                10_000..1_000_000,
-                &mut k,
-                &mut u,
-            );
-        }
+        /*
+               expect_iterated_x25519(
+                   "7c3911e0ab2586fd864497297e575e6f3bc601c0883c30df5f4dd2d24f665424",
+                   10_000..1_000_000,
+                   &mut k,
+                   &mut u,
+               );
+        */
     }
 
     #[test]

--- a/aws-lc-rs/tests/hmac_test.rs
+++ b/aws-lc-rs/tests/hmac_test.rs
@@ -16,11 +16,8 @@ fn hmac_tests() {
         let output = test_case.consume_bytes("Output");
 
         let algorithm = {
-            let digest_alg = match digest_alg {
-                Some(digest_alg) => digest_alg,
-                None => {
-                    return Ok(());
-                } // Unsupported digest algorithm
+            let Some(digest_alg) = digest_alg else {
+                return Ok(());
             };
             if digest_alg == &digest::SHA1_FOR_LEGACY_USE_ONLY {
                 hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY

--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["AWS-LC"]
 edition = "2021"
 repository = "https://github.com/aws/aws-lc-rs"
 license = "ISC AND (Apache-2.0 OR ISC) AND OpenSSL"
-rust-version = "1.61.0"
+rust-version = "1.63.0"
 include = [
     "LICENSE",
     "/aws-lc/**/*.c",
@@ -56,10 +56,10 @@ dunce = "1.0"
 fs_extra = "1.3"
 cc = { version = "1.0.83", features = ["parallel"] }
 
-[target.'cfg(any(all(any(target_arch = "x86_64", target_arch = "aarch64"), any(target_os = "linux", target_os = "macos"), any(target_env = "gnu", target_env = "musl", target_env = "")), all(target_arch = "i686", target_os = "linux", target_env = "gnu")))'.build-dependencies]
+[target.'cfg(any(all(any(target_arch = "x86_64", target_arch = "aarch64"), any(target_os = "linux", target_os = "macos"), any(target_env = "gnu", target_env = "musl", target_env = "")), all(target_arch = "x86", target_os = "linux", target_env = "gnu")))'.build-dependencies]
 bindgen = { version = "0.69.2", optional = true }
 
-[target.'cfg(not(any(all(any(target_arch = "x86_64", target_arch = "aarch64"), any(target_os = "linux", target_os = "macos"), any(target_env = "gnu", target_env = "musl", target_env = "")), all(target_arch = "i686", target_os = "linux", target_env = "gnu"))))'.build-dependencies]
+[target.'cfg(not(any(all(any(target_arch = "x86_64", target_arch = "aarch64"), any(target_os = "linux", target_os = "macos"), any(target_env = "gnu", target_env = "musl", target_env = "")), all(target_arch = "x86", target_os = "linux", target_env = "gnu"))))'.build-dependencies]
 bindgen = { version = "0.69.2" }
 
 [dependencies]

--- a/aws-lc-sys/builder/main.rs
+++ b/aws-lc-sys/builder/main.rs
@@ -18,7 +18,7 @@ use cmake_builder::CmakeBuilder;
             any(target_os = "linux", target_os = "macos"),
             any(target_env = "gnu", target_env = "musl", target_env = "")
         ),
-        all(target_arch = "i686", target_os = "linux", target_env = "gnu")
+        all(target_arch = "x86", target_os = "linux", target_env = "gnu")
     ))
 ))]
 mod bindgen;
@@ -176,7 +176,7 @@ fn execute_command(executable: &OsStr, args: &[&OsStr]) -> TestCommandResult {
             any(target_os = "linux", target_os = "macos"),
             any(target_env = "gnu", target_env = "musl", target_env = "")
         ),
-        all(target_arch = "i686", target_os = "linux", target_env = "gnu")
+        all(target_arch = "x86", target_os = "linux", target_env = "gnu")
     ))
 ))]
 fn generate_bindings(manifest_dir: &Path, prefix: &Option<String>, bindings_path: &PathBuf) {
@@ -372,8 +372,24 @@ fn has_pregenerated() -> bool {
     unsafe { PREGENERATED }
 }
 
+fn prepare_cargo_cfg() {
+    // This is supported in Rust >= 1.77.0
+    // Also remove `#![allow(unexpected_cfgs)]` from src/lib.rs
+    /*
+    println!("cargo::rustc-check-cfg=cfg(use_bindgen_generated)");
+    println!("cargo::rustc-check-cfg=cfg(i686_unknown_linux_gnu)");
+    println!("cargo::rustc-check-cfg=cfg(x86_64_unknown_linux_gnu)");
+    println!("cargo::rustc-check-cfg=cfg(aarch64_unknown_linux_gnu)");
+    println!("cargo::rustc-check-cfg=cfg(x86_64_unknown_linux_musl)");
+    println!("cargo::rustc-check-cfg=cfg(aarch64_unknown_linux_musl)");
+    println!("cargo::rustc-check-cfg=cfg(x86_64_apple_darwin)");
+    println!("cargo::rustc-check-cfg=cfg(aarch64_apple_darwin)");
+     */
+}
+
 fn main() {
     initialize();
+    prepare_cargo_cfg();
 
     let manifest_dir = current_dir();
     let manifest_dir = dunce::canonicalize(Path::new(&manifest_dir)).unwrap();
@@ -407,7 +423,7 @@ fn main() {
                     any(target_os = "linux", target_os = "macos"),
                     any(target_env = "gnu", target_env = "musl", target_env = "")
                 ),
-                all(target_arch = "i686", target_os = "linux", target_env = "gnu")
+                all(target_arch = "x86", target_os = "linux", target_env = "gnu")
             ))
         ))]
         if !is_external_bindgen() {

--- a/aws-lc-sys/src/lib.rs
+++ b/aws-lc-sys/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
+#![allow(unexpected_cfgs)]
+
 use paste::paste;
 use std::os::raw::{c_char, c_long, c_void};
 


### PR DESCRIPTION
### Description of changes: 
* Remove last remaining usage of `actions-rs` GitHub action.
* Fix riscv cross-compilation -- download latest to build cross, then download toolchain for target.
* Bump MSRV to 1.63 -- [Rustls is now at 1.63](https://github.com/rustls/rustls/blob/main/rustls/Cargo.toml#L5) as well.
* Ignoring the `unexpected_cfgs`. We can't properly handle these until we're at MSRV 1.77.
* Remove various erroneous reference to non-existent `cfg` values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
