### PR TITLE
Fix recent change to rust-script syntax

### DIFF
--- a/aws-lc-rs/util/process-criterion-csv.rs
+++ b/aws-lc-rs/util/process-criterion-csv.rs
@@ -1,4 +1,9 @@
-#!/usr/bin/env rust-script
+#!/usr/bin/env -S cargo +nightly -Zscript
+---cargo
+[dependencies]
+clap = { version = "4.0.29", features = ["derive"] }
+itertools = "0.10.5"
+---
 //! Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //! SPDX-License-Identifier: Apache-2.0 OR ISC
 //! To run, you will need to install rust-script:
@@ -11,11 +16,7 @@
 //! $ find ./target/criterion -name "raw.csv" | xargs cat | sort | egrep -v "^group" > bench-aarch64-AL2.csv
 //! ```
 //!
-//! ```cargo
-//! [dependencies]
-//! clap = { version = "4.0.29", features = ["derive"] }
-//! itertools = "0.10.5"
-//! ```
+
 
 use std::cmp::Ordering;
 use std::collections::HashMap;

--- a/scripts/tools/cargo-dig.rs
+++ b/scripts/tools/cargo-dig.rs
@@ -1,9 +1,9 @@
 #!/usr/bin/env -S cargo +nightly -Zscript
-```cargo
+---cargo
 [dependencies]
 toml = "0.8"
 clap = { version = "4", features = ["derive"] }
-```
+---
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 

--- a/scripts/tools/semver.rs
+++ b/scripts/tools/semver.rs
@@ -1,10 +1,10 @@
 #!/usr/bin/env -S cargo +nightly -Zscript
-```cargo
+---cargo
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 regex = "1"
 semver = "1"
-```
+---
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 


### PR DESCRIPTION
### Description of changes: 
* Recent change in (unstable) rust-script syntax is causing CI to fail in AWS-LC: https://github.com/aws/aws-lc/actions/runs/9018402921/job/24778943885?pr=1569
* This was apparently cause by this recent change: https://github.com/rust-lang/cargo/pull/13861

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
