### PR TITLE
Remove arbitrary HKDF info length limit

### DIFF
--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -48,7 +48,7 @@ fips = ["dep:aws-lc-fips-sys"]
 untrusted = { version = "0.7.1", optional = true }
 aws-lc-sys = { version = "0.17.0", path = "../aws-lc-sys", optional = true }
 aws-lc-fips-sys = { version = "0.12.0", path = "../aws-lc-fips-sys", optional = true }
-zeroize = "1.7"
+zeroize = { version = "1.7", features = ["zeroize_derive"] }
 mirai-annotations = "1.12.0"
 paste = "1.0.11"
 

--- a/aws-lc-rs/src/hkdf.rs
+++ b/aws-lc-rs/src/hkdf.rs
@@ -395,6 +395,7 @@ enum InfoBytes {
     Stack([u8; MAX_HKDF_INFO_STACK_LEN]),
     Heap(Box<[u8]>),
 }
+
 impl InfoBytes {
     fn new(info: &[u8]) -> Self {
         if info.len() <= MAX_HKDF_INFO_STACK_LEN {
@@ -405,6 +406,7 @@ impl InfoBytes {
             Self::Heap(info.into())
         }
     }
+
     fn as_slice(&self) -> &[u8] {
         match self {
             Self::Stack(ary_bytes) => ary_bytes.as_slice(),

--- a/aws-lc-rs/src/hkdf.rs
+++ b/aws-lc-rs/src/hkdf.rs
@@ -76,9 +76,9 @@ pub static HKDF_SHA512: Algorithm = Algorithm(hmac::HMAC_SHA512);
 const MAX_HKDF_SALT_LEN: usize = 80;
 
 /// General Info length's for HKDF don't normally exceed 256 bits.
-/// We set the limit to something tolerable, so that the memory passed into |`HKDF_expand`| is
-/// allocated on the stack.
-const MAX_HKDF_INFO_STACK_LEN: usize = 102;
+/// We set the default capacity to a value larger than should be needed
+/// so that the value passed to |`HKDF_expand`| is only allocated once.
+const HKDF_INFO_DEFAULT_CAPACITY_LEN: usize = 300;
 
 /// The maximum output size of a PRK computed by |`HKDF_extract`| is the maximum digest
 /// size that can be outputted by *AWS-LC*.
@@ -360,7 +360,7 @@ impl Prk {
         if len_cached > 255 * self.algorithm.0.digest_algorithm().output_len {
             return Err(Unspecified);
         }
-        let mut info_bytes: Vec<u8> = Vec::with_capacity(3 * MAX_HKDF_INFO_STACK_LEN);
+        let mut info_bytes: Vec<u8> = Vec::with_capacity(HKDF_INFO_DEFAULT_CAPACITY_LEN);
         let mut info_len = 0;
         for &byte_ary in info {
             info_bytes.extend_from_slice(byte_ary);

--- a/aws-lc-rs/src/hkdf.rs
+++ b/aws-lc-rs/src/hkdf.rs
@@ -364,7 +364,7 @@ impl Prk {
         let mut info_len = 0;
         for &byte_ary in info {
             info_bytes.extend_from_slice(byte_ary);
-            info_len = info_len + byte_ary.len();
+            info_len += byte_ary.len();
         }
         let info_bytes = InfoBytes::new(info_bytes.as_slice());
         Ok(Okm {

--- a/aws-lc-rs/tests/hkdf_test.rs
+++ b/aws-lc-rs/tests/hkdf_test.rs
@@ -95,8 +95,7 @@ fn hkdf_output_len_tests() {
 #[test]
 fn hkdf_info_len_tests() {
     for &alg in &[hkdf::HKDF_SHA256, hkdf::HKDF_SHA384, hkdf::HKDF_SHA512] {
-        let special_lengths: [usize; 6] = [101, 102, 103, 3 * 102 - 1, 3 * 102, 3 * 102 + 1];
-        for info_length in (50..300).step_by(7).chain(special_lengths) {
+        for info_length in (50..300).step_by(7) {
             let salt = hkdf::Salt::new(alg, &[]);
             let prk = salt.extract(&[]); // TODO: enforce minimum length.
             let info = vec![1u8; info_length];

--- a/aws-lc-rs/tests/hkdf_test.rs
+++ b/aws-lc-rs/tests/hkdf_test.rs
@@ -93,6 +93,25 @@ fn hkdf_output_len_tests() {
 }
 
 #[test]
+fn hkdf_info_len_tests() {
+    for &alg in &[hkdf::HKDF_SHA256, hkdf::HKDF_SHA384, hkdf::HKDF_SHA512] {
+        let special_lengths: [usize; 6] = [101, 102, 103, 3 * 102 - 1, 3 * 102, 3 * 102 + 1];
+        for info_length in (50..300).step_by(7).chain(special_lengths) {
+            let salt = hkdf::Salt::new(alg, &[]);
+            let prk = salt.extract(&[]); // TODO: enforce minimum length.
+            let info = vec![1u8; info_length];
+            let info = &[info.as_slice()];
+
+            {
+                let okm = prk.expand(info, My(2)).unwrap();
+                let mut buf = [0u8; 2];
+                assert_eq!(okm.fill(&mut buf), Ok(()));
+            }
+        }
+    }
+}
+
+#[test]
 /// Try creating various key types via HKDF.
 fn hkdf_key_types() {
     for &alg in &[


### PR DESCRIPTION
### Description of changes: 
* Remove arbitrary HKDF limit on the number of info bytes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
