### PR TITLE
Cross-compile using bindgen-cli

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -28,20 +28,21 @@ jobs:
       matrix:
         os: [ ubuntu-22.04 ]
         target:
-          - arm-unknown-linux-gnueabihf
+          - aarch64-linux-android
           - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
+          - arm-linux-androideabi
+          - arm-unknown-linux-gnueabihf
+          - armv7-linux-androideabi
+          - armv7-unknown-linux-gnueabihf
           - i686-unknown-linux-gnu
+          - powerpc-unknown-linux-gnu
+          - powerpc64-unknown-linux-gnu
           - powerpc64le-unknown-linux-gnu
           - riscv64gc-unknown-linux-gnu
-          - arm-linux-androideabi
-          - armv7-linux-androideabi
-          - aarch64-linux-android
-          - powerpc64-unknown-linux-gnu
-          - powerpc-unknown-linux-gnu
-          - x86_64-unknown-linux-musl
-          - aarch64-unknown-linux-musl
           - s390x-unknown-linux-gnu
           - x86_64-pc-windows-gnu
+          - x86_64-unknown-linux-musl
     steps:
       - uses: actions/checkout@v3
         with:
@@ -62,11 +63,10 @@ jobs:
         run: |
           cargo update
           cargo update -p clap --precise 4.4.18
-      - name: Cross-compilation
-        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'i686-unknown-linux-gnu' || matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-musl'}}
-        run: cross test -p aws-lc-rs --features unstable --target ${{ matrix.target }}
-      - name: Cross-compilation w/ bindgen
-        run: cross test -p aws-lc-rs --release --features bindgen,unstable --target ${{ matrix.target }}
+      - name: Cross-compilation (build debug)
+        run: cross build -p aws-lc-rs --features unstable --target ${{ matrix.target }}
+      - name: Cross-compilation (test release)
+        run: cross test -p aws-lc-rs --release --features unstable --target ${{ matrix.target }}
 
   aws-lc-rs-ios-aarch64:
     if: github.repository_owner == 'aws'

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,12 +1,23 @@
 [build]
 dockerfile = "./docker/linux-cross/Dockerfile"
+pre-build = [
+    "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable",
+    ". $HOME/.cargo/env",
+    "cargo install --force --locked bindgen-cli && mv $HOME/.cargo/bin/bindgen /usr/bin",
+    "rm -rf $HOME/.cargo"
+]
+
 
 [target.x86_64-pc-windows-gnu]
 pre-build = [
-    "apt-get update && apt-get install --assume-yes nasm clang wget",
+    "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable",
+    ". $HOME/.cargo/env",
+    "cargo install --force --locked bindgen-cli && mv $HOME/.cargo/bin/bindgen /usr/bin",
+    "rm -rf $HOME/.cargo",
+    "apt-get update && apt-get install --assume-yes nasm wget",
     "mkdir -pm755 /etc/apt/keyrings",
     "wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources",
-    "apt install --assume-yes --install-recommends winehq-stable"
+    "apt install --assume-yes --install-recommends winehq-stable",
 ]
 
 [build.env]

--- a/docker/linux-cross/Dockerfile
+++ b/docker/linux-cross/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     apt-get install --assume-yes --no-install-recommends  software-properties-common && \
     add-apt-repository --yes ppa:longsleep/golang-backports && \
     apt-get update && \
-    apt-get install --assume-yes --no-install-recommends build-essential cmake golang-go && \
+    apt-get install --assume-yes --no-install-recommends build-essential cmake golang-go clang && \
     git config --global --add safe.directory '*' && \
     rm -rf /tmp/*
 


### PR DESCRIPTION
### Issues:
Resolves #428

### Description of changes: 
* Install/Use bindgen-cli inside container when cross-compiling with cross-rs.
* Added target `armv7-unknown-linux-gnueabihf`

### Call-out
* I changed the order of the CI targets to be sorted by name.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
