### PR TITLE
Cleanup use of mut ptr

### DIFF
--- a/aws-lc-rs/src/cbb.rs
+++ b/aws-lc-rs/src/cbb.rs
@@ -31,7 +31,7 @@ impl LcCBB<'static> {
             return Err(Unspecified);
         };
 
-        let out_data = LcPtr::new(out_data)?;
+        let mut out_data = LcPtr::new(out_data)?;
 
         // TODO: Need a type to just hold the owned pointer from CBB rather then copying
         Ok(Buffer::take_from_slice(unsafe {

--- a/aws-lc-rs/src/ptr.rs
+++ b/aws-lc-rs/src/ptr.rs
@@ -42,7 +42,7 @@ impl<P: Pointer> ManagedPointer<P> {
     }
 
     #[allow(clippy::mut_from_ref)]
-    pub unsafe fn as_slice_mut(&self, len: usize) -> &mut [P::T] {
+    pub unsafe fn as_slice_mut(&mut self, len: usize) -> &mut [P::T] {
         core::slice::from_raw_parts_mut(self.pointer.as_mut_ptr(), len)
     }
 }
@@ -150,7 +150,7 @@ pub(crate) trait Pointer {
 
     fn free(&mut self);
     fn as_const_ptr(&self) -> *const Self::T;
-    fn as_mut_ptr(&self) -> *mut Self::T;
+    fn as_mut_ptr(&mut self) -> *mut Self::T;
 }
 
 pub(crate) trait IntoPointer<P> {
@@ -187,7 +187,7 @@ macro_rules! create_pointer {
             }
 
             #[inline]
-            fn as_mut_ptr(&self) -> *mut Self::T {
+            fn as_mut_ptr(&mut self) -> *mut Self::T {
                 *self
             }
         }


### PR DESCRIPTION
### Description of changes: 
* Ensuring we have a `mut` reference when providing a `mut` pointer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
