### PR TITLE
Allow cmake toolchain env

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -117,7 +117,9 @@ jobs:
     if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
-      - uses: ilammy/setup-nasm@v1
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install --assume-yes nasm clang ninja-build llvm
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -113,6 +113,29 @@ jobs:
         run: cargo build -p aws-lc-rs --release --target x86_64-apple-ios --features bindgen
 
 
+  cargo-xwin:
+    if: github.repository_owner == 'aws'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ilammy/setup-nasm@v1
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          target: x86_64-pc-windows-msvc
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          target: aarch64-pc-windows-msvc
+      - name: Install cargo-xwin and bindgen-cli
+        run: cargo install cargo-xwin bindgen-cli
+      - name: cargo xwin build for `x86_64-pc-windows-msvc`
+        run: cargo xwin build -p aws-lc-rs --release --target x86_64-pc-windows-msvc
+      - name: cargo xwin build for `aarch64-pc-windows-msvc`
+        run: cargo xwin build -p aws-lc-rs --release --target aarch64-pc-windows-msvc
+
   aws-lc-rs-windows-mingw:
     if: github.repository_owner == 'aws'
     name: x86_64-pc-windows-gnu


### PR DESCRIPTION
### Issues:
Resolves #376

### Description of changes: 
* [cargo-xwin](https://github.com/rust-cross/cargo-xwin) is a build tool for "Cross compil[ing a] Cargo project to Windows msvc target with ease".
* cargo-xwin sets a `CMAKE_TOOLCHAIN_FILE_*_pc_windows_msvc` environment variable to provide CMake guidance on the compiler setup. We should avoid overriding the configuration it provides.

### Testing:
* Adds a CI job to verify that we can build for the `*_pc_windows_msvc` targets from an Ubuntu host.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
