### PR TITLE
vcvarsall.bat can make very large env

### DIFF
--- a/aws-lc-fips-sys/builder/main.rs
+++ b/aws-lc-fips-sys/builder/main.rs
@@ -144,7 +144,7 @@ pub(crate) struct TestCommandResult {
     status: bool,
 }
 
-const MAX_CMD_OUTPUT_SIZE: usize = 1 << 12;
+const MAX_CMD_OUTPUT_SIZE: usize = 1 << 14;
 fn execute_command(executable: &OsStr, args: &[&OsStr]) -> TestCommandResult {
     if let Ok(mut result) = Command::new(executable).args(args).output() {
         result.stderr.truncate(MAX_CMD_OUTPUT_SIZE);


### PR DESCRIPTION
### Description of changes: 
* Windows/FIPS builds invoke `vcvarsall.bat` to acquire the environment variables required for a build.  The environment is parsed from the output of [printenv.bat](https://github.com/aws/aws-lc-rs/blob/main/aws-lc-fips-sys/builder/printenv.bat).
* On some hosts the output of `printenv.bat` can be larger than 4kb. This changes the buffer size to 16k.

### Testing:
* I was having this problem on a local Windows box. The FIPS build would fail, and I could see that the output from `printenv.bat` was being cutoff early.  With this change the build succeeds.
```
> cargo build -p aws-lc-rs --no-default-features --features fips
   Compiling cc v1.0.92
   Compiling aws-lc-rs v1.7.2 (C:\Users\justi\repos\aws-lc-rs\aws-lc-rs)
   Compiling cmake v0.1.50
   Compiling aws-lc-fips-sys v0.12.8 (C:\Users\justi\repos\aws-lc-rs\aws-lc-fips-sys)
The following warnings were emitted during compilation:

warning: aws-lc-fips-sys@0.12.8: Generating bindings - internal bindgen. Platform: x86_64-pc-windows-msvc

error: failed to run custom build command for `aws-lc-fips-sys v0.12.8 (C:\Users\justi\repos\aws-lc-rs\aws-lc-fips-sys)`
...
  --- stderr
  VS Installation: "C:\Program Files\Microsoft Visual Studio\2022\Professional"
  FOUND in Installation: "C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\"
  **********************************************************************
  ** Visual Studio 2022 Developer Command Prompt v17.8.9
  ** Copyright (c) 2022 Microsoft Corporation
  **********************************************************************
  [vcvarsall.bat] Environment initialized for: 'x64'
  Visual Studio environment variables set for x64.
...
  HOMEDRIVE=C:
  HOMEPATH=\Users\justi
  HOST=x86_64-pc-windows-msvc
  INCLUDE=C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.38.33130\include;C:\Program Files\Microsoft Visual
  CMake Deprecation Warning at CMakeLists.txt:4 (cmake_minimum_required):
    Compatibility with CMake < 3.5 will be removed from a future version of
    CMake.
...
  thread 'main' panicked at C:\Users\justi\.cargo\registry\src\index.crates.io-6f17d22bba15001f\cmake-0.1.50\src\lib.rs:1098:5:

  command did not execute successfully, got: exit code: 1

  build script failed, must exit now
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
