### PR TITLE
Prepare release v1.8.0

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -17,6 +17,7 @@ env:
   # We can pin the version if nightly is too unstable.
   # Otherwise, we test against the latest version.
   RUST_NIGHTLY_TOOLCHAIN: nightly-2024-06-07
+  RUST_SCRIPT_NIGHTLY_TOOLCHAIN: nightly-2024-05-22
   # Mirai version tag, updates this whenever a new version
   # is released.
   MIRAI_TOOLCHAIN: nightly-2023-05-09
@@ -287,3 +288,22 @@ jobs:
           package: aws-lc-rs
           feature-group: only-explicit-features
           features: fips
+  metadata-checks:
+    if: github.repository_owner == 'aws'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dtolnay/rust-toolchain@master
+        id: toolchain
+        with:
+          toolchain: ${{ env.RUST_SCRIPT_NIGHTLY_TOOLCHAIN }}
+      - name: Set Rust toolchain override
+        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: aws-lc-rs links
+        run: |
+          VERSION=$(scripts/tools/cargo-dig.rs aws-lc-rs/Cargo.toml -v)
+          LINKS_LINE=$(echo links = \"aws_lc_rs_${VERSION//./_}_sys\")
+          grep "${LINKS_LINE}" aws-lc-rs/Cargo.toml

--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "aws-lc-rs"
 authors = ["AWS-LibCrypto"]
-version = "1.7.3"
+version = "1.8.0"
 # this crate re-exports whatever sys crate that was selected
-links = "aws_lc_rs_1_7_1_sys"
+links = "aws_lc_rs_1_8_0_sys"
 edition = "2021"
 rust-version = "1.63.0"
 keywords = ["crypto", "cryptography", "security"]


### PR DESCRIPTION
### Description of changes: 
* Prepare for release v1.8.0

### Testing:
* Added CI test for metadata values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
