### PR TITLE
fix(build): armv7a and x86_64's ohos should set asm args

### DIFF
--- a/aws-lc-fips-sys/builder/cmake_builder.rs
+++ b/aws-lc-fips-sys/builder/cmake_builder.rs
@@ -144,15 +144,23 @@ impl CmakeBuilder {
             return cmake_cfg;
         }
 
-        if target_vendor() == "apple" {
-            if target_os().trim() == "ios" {
-                cmake_cfg.define("CMAKE_SYSTEM_NAME", "iOS");
-                if target().trim().ends_with("-ios-sim") {
-                    cmake_cfg.define("CMAKE_OSX_SYSROOT", "iphonesimulator");
-                }
-            }
-            if target_arch().trim() == "aarch64" {
+        // If the build environment vendor is Apple
+        #[cfg(target_vendor = "apple")]
+        {
+            if target_arch() == "aarch64" {
                 cmake_cfg.define("CMAKE_OSX_ARCHITECTURES", "arm64");
+                cmake_cfg.define("CMAKE_SYSTEM_PROCESSOR", "arm64");
+            }
+            if target_arch() == "x86_64" {
+                cmake_cfg.define("CMAKE_OSX_ARCHITECTURES", "x86_64");
+                cmake_cfg.define("CMAKE_SYSTEM_PROCESSOR", "x86_64");
+            }
+        }
+
+        if target_vendor() == "apple" && target_os().trim() == "ios" {
+            cmake_cfg.define("CMAKE_SYSTEM_NAME", "iOS");
+            if target().trim().ends_with("-ios-sim") {
+                cmake_cfg.define("CMAKE_OSX_SYSROOT", "iphonesimulator");
             }
         }
 
@@ -168,43 +176,51 @@ impl CmakeBuilder {
         }
 
         if target_env() == "ohos" {
-            const OHOS_NDK_HOME: &str = "OHOS_NDK_HOME";
-            if let Ok(ndk) = env::var(OHOS_NDK_HOME) {
-                cmake_cfg.define(
-                    "CMAKE_TOOLCHAIN_FILE",
-                    format!("{ndk}/native/build/cmake/ohos.toolchain.cmake"),
-                );
-                match target().as_str() {
-                    "aarch64-unknown-linux-ohos" => {
-                        cmake_cfg
-                            .cflag("-Wno-unused-command-line-argument")
-                            .cxxflag("-Wno-unused-command-line-argument");
-                    }
-                    "armv7-unknown-linux-ohos" => {
-                        cmake_cfg
-                        .cflag("-Wno-unused-command-line-argument -march=armv7-a -mfloat-abi=softfp -mtune=generic-armv7-a -mthumb -mfpu=neon -DHAVE_NEON")
-                        .cxxflag("-Wno-unused-command-line-argument -march=armv7-a -mfloat-abi=softfp -mtune=generic-armv7-a -mthumb -mfpu=neon -DHAVE_NEON")
-                        .asmflag("-march=armv7-a -mfloat-abi=softfp -mtune=generic-armv7-a -mthumb -mfpu=neon -DHAVE_NEON");
-                    }
-                    "x86_64-unknown-linux-ohos" => {
-                        cmake_cfg
-                            .cflag("-Wno-unused-command-line-argument -msse4.1 -DHAVE_NEON_X86 -DHAVE_NEON")
-                            .cxxflag("-Wno-unused-command-line-argument -msse4.1 -DHAVE_NEON_X86 -DHAVE_NEON")
-                            .asmflag("-msse4.1 -DHAVE_NEON_X86 -DHAVE_NEON");
-                        // we must set those env for cross-build in apple silicon machine
-                        cmake_cfg.define("CMAKE_SYSTEM_PROCESSOR", "x86_64");
-                        cmake_cfg.define("CMAKE_OSX_ARCHITECTURES", "x86_64");
-                    }
-                    ohos_target => {
-                        emit_warning(format!("{ohos_target} is not support yet!").as_str());
-                    }
-                }
-            } else {
-                emit_warning(format!("{OHOS_NDK_HOME} not set!").as_str());
-            }
+            Self::configure_open_harmony(&mut cmake_cfg);
         }
 
         cmake_cfg
+    }
+
+    fn configure_open_harmony(cmake_cfg: &mut cmake::Config) {
+        const OHOS_NDK_HOME: &str = "OHOS_NDK_HOME";
+        if let Ok(ndk) = env::var(OHOS_NDK_HOME) {
+            cmake_cfg.define(
+                "CMAKE_TOOLCHAIN_FILE",
+                format!("{ndk}/native/build/cmake/ohos.toolchain.cmake"),
+            );
+            let mut cflags = vec!["-Wno-unused-command-line-argument"];
+            let mut asmflags = vec![];
+            match target().as_str() {
+                "aarch64-unknown-linux-ohos" => {}
+                "armv7-unknown-linux-ohos" => {
+                    const ARM7_FLAGS: [&str; 6] = [
+                        "-march=armv7-a",
+                        "-mfloat-abi=softfp",
+                        "-mtune=generic-armv7-a",
+                        "-mthumb",
+                        "-mfpu=neon",
+                        "-DHAVE_NEON",
+                    ];
+                    cflags.extend(ARM7_FLAGS);
+                    asmflags.extend(ARM7_FLAGS);
+                }
+                "x86_64-unknown-linux-ohos" => {
+                    const X86_64_FLAGS: [&str; 3] = ["-msse4.1", "-DHAVE_NEON_X86", "-DHAVE_NEON"];
+                    cflags.extend(X86_64_FLAGS);
+                    asmflags.extend(X86_64_FLAGS);
+                }
+                ohos_target => {
+                    emit_warning(format!("Target: {ohos_target} is not support yet!").as_str());
+                }
+            }
+            cmake_cfg
+                .cflag(cflags.join(" ").as_str())
+                .cxxflag(cflags.join(" ").as_str())
+                .asmflag(asmflags.join(" ").as_str());
+        } else {
+            emit_warning(format!("{OHOS_NDK_HOME} not set!").as_str());
+        }
     }
 
     fn build_rust_wrapper(&self) -> PathBuf {

--- a/aws-lc-fips-sys/builder/cmake_builder.rs
+++ b/aws-lc-fips-sys/builder/cmake_builder.rs
@@ -174,20 +174,30 @@ impl CmakeBuilder {
                     "CMAKE_TOOLCHAIN_FILE",
                     format!("{ndk}/native/build/cmake/ohos.toolchain.cmake"),
                 );
-                cmake_cfg.define("CMAKE_C_FLAGS", "-Wno-unused-command-line-argument");
-                cmake_cfg.define("CMAKE_CXX_FLAGS", "-Wno-unused-command-line-argument");
-
-                match target_underscored().as_str() {
-                    "armv7_unknown_linux_ohos" => {
-                        cmake_cfg.cflag("-march=armv7-a -mfloat-abi=softfp -mtune=generic-armv7-a -mthumb -mfpu=neon -DHAVE_NEON")
-                            .cxxflag("-march=armv7-a -mfloat-abi=softfp -mtune=generic-armv7-a -mthumb -mfpu=neon -DHAVE_NEON");
-                    }
-                    "x86_64_unknown_linux_ohos" => {
+                match target().as_str() {
+                    "aarch64-unknown-linux-ohos" => {
                         cmake_cfg
-                            .cflag("-msse4.1 -DHAVE_NEON_X86 -DHAVE_NEON")
-                            .cxxflag("-msse4.1 -DHAVE_NEON_X86 -DHAVE_NEON");
+                            .cflag("-Wno-unused-command-line-argument")
+                            .cxxflag("-Wno-unused-command-line-argument");
                     }
-                    _ => {}
+                    "armv7-unknown-linux-ohos" => {
+                        cmake_cfg
+                        .cflag("-Wno-unused-command-line-argument -march=armv7-a -mfloat-abi=softfp -mtune=generic-armv7-a -mthumb -mfpu=neon -DHAVE_NEON")
+                        .cxxflag("-Wno-unused-command-line-argument -march=armv7-a -mfloat-abi=softfp -mtune=generic-armv7-a -mthumb -mfpu=neon -DHAVE_NEON")
+                        .asmflag("-march=armv7-a -mfloat-abi=softfp -mtune=generic-armv7-a -mthumb -mfpu=neon -DHAVE_NEON");
+                    }
+                    "x86_64-unknown-linux-ohos" => {
+                        cmake_cfg
+                            .cflag("-Wno-unused-command-line-argument -msse4.1 -DHAVE_NEON_X86 -DHAVE_NEON")
+                            .cxxflag("-Wno-unused-command-line-argument -msse4.1 -DHAVE_NEON_X86 -DHAVE_NEON")
+                            .asmflag("-msse4.1 -DHAVE_NEON_X86 -DHAVE_NEON");
+                        // we must set those env for cross-build in apple silicon machine
+                        cmake_cfg.define("CMAKE_SYSTEM_PROCESSOR", "x86_64");
+                        cmake_cfg.define("CMAKE_OSX_ARCHITECTURES", "x86_64");
+                    }
+                    ohos_target => {
+                        emit_warning(format!("{ohos_target} is not support yet!").as_str());
+                    }
                 }
             } else {
                 emit_warning(format!("{OHOS_NDK_HOME} not set!").as_str());

--- a/aws-lc-fips-sys/builder/cmake_builder.rs
+++ b/aws-lc-fips-sys/builder/cmake_builder.rs
@@ -176,6 +176,19 @@ impl CmakeBuilder {
                 );
                 cmake_cfg.define("CMAKE_C_FLAGS", "-Wno-unused-command-line-argument");
                 cmake_cfg.define("CMAKE_CXX_FLAGS", "-Wno-unused-command-line-argument");
+
+                match target_underscored().as_str() {
+                    "armv7_unknown_linux_ohos" => {
+                        cmake_cfg.cflag("-march=armv7-a -mfloat-abi=softfp -mtune=generic-armv7-a -mthumb -mfpu=neon -DHAVE_NEON")
+                            .cxxflag("-march=armv7-a -mfloat-abi=softfp -mtune=generic-armv7-a -mthumb -mfpu=neon -DHAVE_NEON");
+                    }
+                    "x86_64_unknown_linux_ohos" => {
+                        cmake_cfg
+                            .cflag("-msse4.1 -DHAVE_NEON_X86 -DHAVE_NEON")
+                            .cxxflag("-msse4.1 -DHAVE_NEON_X86 -DHAVE_NEON");
+                    }
+                    _ => {}
+                }
             } else {
                 emit_warning(format!("{OHOS_NDK_HOME} not set!").as_str());
             }

--- a/aws-lc-sys/builder/cmake_builder.rs
+++ b/aws-lc-sys/builder/cmake_builder.rs
@@ -181,20 +181,30 @@ impl CmakeBuilder {
                     "CMAKE_TOOLCHAIN_FILE",
                     format!("{ndk}/native/build/cmake/ohos.toolchain.cmake"),
                 );
-                cmake_cfg.define("CMAKE_C_FLAGS", "-Wno-unused-command-line-argument");
-                cmake_cfg.define("CMAKE_CXX_FLAGS", "-Wno-unused-command-line-argument");
-
-                match target_underscored().as_str() {
-                    "armv7_unknown_linux_ohos" => {
-                        cmake_cfg.cflag("-march=armv7-a -mfloat-abi=softfp -mtune=generic-armv7-a -mthumb -mfpu=neon -DHAVE_NEON")
-                            .cxxflag("-march=armv7-a -mfloat-abi=softfp -mtune=generic-armv7-a -mthumb -mfpu=neon -DHAVE_NEON");
-                    }
-                    "x86_64_unknown_linux_ohos" => {
+                match target().as_str() {
+                    "aarch64-unknown-linux-ohos" => {
                         cmake_cfg
-                            .cflag("-msse4.1 -DHAVE_NEON_X86 -DHAVE_NEON")
-                            .cxxflag("-msse4.1 -DHAVE_NEON_X86 -DHAVE_NEON");
+                            .cflag("-Wno-unused-command-line-argument")
+                            .cxxflag("-Wno-unused-command-line-argument");
                     }
-                    _ => {}
+                    "armv7-unknown-linux-ohos" => {
+                        cmake_cfg
+                        .cflag("-Wno-unused-command-line-argument -march=armv7-a -mfloat-abi=softfp -mtune=generic-armv7-a -mthumb -mfpu=neon -DHAVE_NEON")
+                        .cxxflag("-Wno-unused-command-line-argument -march=armv7-a -mfloat-abi=softfp -mtune=generic-armv7-a -mthumb -mfpu=neon -DHAVE_NEON")
+                        .asmflag("-march=armv7-a -mfloat-abi=softfp -mtune=generic-armv7-a -mthumb -mfpu=neon -DHAVE_NEON");
+                    }
+                    "x86_64-unknown-linux-ohos" => {
+                        cmake_cfg
+                            .cflag("-Wno-unused-command-line-argument -msse4.1 -DHAVE_NEON_X86 -DHAVE_NEON")
+                            .cxxflag("-Wno-unused-command-line-argument -msse4.1 -DHAVE_NEON_X86 -DHAVE_NEON")
+                            .asmflag("-msse4.1 -DHAVE_NEON_X86 -DHAVE_NEON");
+                        // we must set those env for cross-build in apple silicon machine
+                        cmake_cfg.define("CMAKE_SYSTEM_PROCESSOR", "x86_64");
+                        cmake_cfg.define("CMAKE_OSX_ARCHITECTURES", "x86_64");
+                    }
+                    ohos_target => {
+                        emit_warning(format!("Target: {ohos_target} is not support yet!").as_str());
+                    }
                 }
             } else {
                 emit_warning(format!("{OHOS_NDK_HOME} not set!").as_str());

--- a/aws-lc-sys/builder/cmake_builder.rs
+++ b/aws-lc-sys/builder/cmake_builder.rs
@@ -183,6 +183,19 @@ impl CmakeBuilder {
                 );
                 cmake_cfg.define("CMAKE_C_FLAGS", "-Wno-unused-command-line-argument");
                 cmake_cfg.define("CMAKE_CXX_FLAGS", "-Wno-unused-command-line-argument");
+
+                match target_underscored().as_str() {
+                    "armv7_unknown_linux_ohos" => {
+                        cmake_cfg.cflag("-march=armv7-a -mfloat-abi=softfp -mtune=generic-armv7-a -mthumb -mfpu=neon -DHAVE_NEON")
+                            .cxxflag("-march=armv7-a -mfloat-abi=softfp -mtune=generic-armv7-a -mthumb -mfpu=neon -DHAVE_NEON");
+                    }
+                    "x86_64_unknown_linux_ohos" => {
+                        cmake_cfg
+                            .cflag("-msse4.1 -DHAVE_NEON_X86 -DHAVE_NEON")
+                            .cxxflag("-msse4.1 -DHAVE_NEON_X86 -DHAVE_NEON");
+                    }
+                    _ => {}
+                }
             } else {
                 emit_warning(format!("{OHOS_NDK_HOME} not set!").as_str());
             }

--- a/aws-lc-sys/builder/cmake_builder.rs
+++ b/aws-lc-sys/builder/cmake_builder.rs
@@ -134,16 +134,9 @@ impl CmakeBuilder {
             return cmake_cfg;
         }
 
-        if target_vendor() == "apple" {
-            if target_os().to_lowercase() == "ios" {
-                cmake_cfg.define("CMAKE_SYSTEM_NAME", "iOS");
-                if target().ends_with("-ios-sim") || target_arch() == "x86_64" {
-                    cmake_cfg.define("CMAKE_OSX_SYSROOT", "iphonesimulator");
-                } else {
-                    cmake_cfg.define("CMAKE_OSX_SYSROOT", "iphoneos");
-                }
-                cmake_cfg.define("CMAKE_THREAD_LIBS_INIT", "-lpthread");
-            }
+        // If the build environment vendor is Apple
+        #[cfg(target_vendor = "apple")]
+        {
             if target_arch() == "aarch64" {
                 cmake_cfg.define("CMAKE_OSX_ARCHITECTURES", "arm64");
                 cmake_cfg.define("CMAKE_SYSTEM_PROCESSOR", "arm64");
@@ -152,6 +145,16 @@ impl CmakeBuilder {
                 cmake_cfg.define("CMAKE_OSX_ARCHITECTURES", "x86_64");
                 cmake_cfg.define("CMAKE_SYSTEM_PROCESSOR", "x86_64");
             }
+        }
+
+        if target_vendor() == "apple" && target_os().to_lowercase() == "ios" {
+            cmake_cfg.define("CMAKE_SYSTEM_NAME", "iOS");
+            if target().ends_with("-ios-sim") || target_arch() == "x86_64" {
+                cmake_cfg.define("CMAKE_OSX_SYSROOT", "iphonesimulator");
+            } else {
+                cmake_cfg.define("CMAKE_OSX_SYSROOT", "iphoneos");
+            }
+            cmake_cfg.define("CMAKE_THREAD_LIBS_INIT", "-lpthread");
         }
 
         if (target_env() != "msvc") && test_ninja_command() {
@@ -175,43 +178,51 @@ impl CmakeBuilder {
         }
 
         if target_env() == "ohos" {
-            const OHOS_NDK_HOME: &str = "OHOS_NDK_HOME";
-            if let Ok(ndk) = env::var(OHOS_NDK_HOME) {
-                cmake_cfg.define(
-                    "CMAKE_TOOLCHAIN_FILE",
-                    format!("{ndk}/native/build/cmake/ohos.toolchain.cmake"),
-                );
-                match target().as_str() {
-                    "aarch64-unknown-linux-ohos" => {
-                        cmake_cfg
-                            .cflag("-Wno-unused-command-line-argument")
-                            .cxxflag("-Wno-unused-command-line-argument");
-                    }
-                    "armv7-unknown-linux-ohos" => {
-                        cmake_cfg
-                        .cflag("-Wno-unused-command-line-argument -march=armv7-a -mfloat-abi=softfp -mtune=generic-armv7-a -mthumb -mfpu=neon -DHAVE_NEON")
-                        .cxxflag("-Wno-unused-command-line-argument -march=armv7-a -mfloat-abi=softfp -mtune=generic-armv7-a -mthumb -mfpu=neon -DHAVE_NEON")
-                        .asmflag("-march=armv7-a -mfloat-abi=softfp -mtune=generic-armv7-a -mthumb -mfpu=neon -DHAVE_NEON");
-                    }
-                    "x86_64-unknown-linux-ohos" => {
-                        cmake_cfg
-                            .cflag("-Wno-unused-command-line-argument -msse4.1 -DHAVE_NEON_X86 -DHAVE_NEON")
-                            .cxxflag("-Wno-unused-command-line-argument -msse4.1 -DHAVE_NEON_X86 -DHAVE_NEON")
-                            .asmflag("-msse4.1 -DHAVE_NEON_X86 -DHAVE_NEON");
-                        // we must set those env for cross-build in apple silicon machine
-                        cmake_cfg.define("CMAKE_SYSTEM_PROCESSOR", "x86_64");
-                        cmake_cfg.define("CMAKE_OSX_ARCHITECTURES", "x86_64");
-                    }
-                    ohos_target => {
-                        emit_warning(format!("Target: {ohos_target} is not support yet!").as_str());
-                    }
-                }
-            } else {
-                emit_warning(format!("{OHOS_NDK_HOME} not set!").as_str());
-            }
+            Self::configure_open_harmony(&mut cmake_cfg);
         }
 
         cmake_cfg
+    }
+
+    fn configure_open_harmony(cmake_cfg: &mut cmake::Config) {
+        const OHOS_NDK_HOME: &str = "OHOS_NDK_HOME";
+        if let Ok(ndk) = env::var(OHOS_NDK_HOME) {
+            cmake_cfg.define(
+                "CMAKE_TOOLCHAIN_FILE",
+                format!("{ndk}/native/build/cmake/ohos.toolchain.cmake"),
+            );
+            let mut cflags = vec!["-Wno-unused-command-line-argument"];
+            let mut asmflags = vec![];
+            match target().as_str() {
+                "aarch64-unknown-linux-ohos" => {}
+                "armv7-unknown-linux-ohos" => {
+                    const ARM7_FLAGS: [&str; 6] = [
+                        "-march=armv7-a",
+                        "-mfloat-abi=softfp",
+                        "-mtune=generic-armv7-a",
+                        "-mthumb",
+                        "-mfpu=neon",
+                        "-DHAVE_NEON",
+                    ];
+                    cflags.extend(ARM7_FLAGS);
+                    asmflags.extend(ARM7_FLAGS);
+                }
+                "x86_64-unknown-linux-ohos" => {
+                    const X86_64_FLAGS: [&str; 3] = ["-msse4.1", "-DHAVE_NEON_X86", "-DHAVE_NEON"];
+                    cflags.extend(X86_64_FLAGS);
+                    asmflags.extend(X86_64_FLAGS);
+                }
+                ohos_target => {
+                    emit_warning(format!("Target: {ohos_target} is not support yet!").as_str());
+                }
+            }
+            cmake_cfg
+                .cflag(cflags.join(" ").as_str())
+                .cxxflag(cflags.join(" ").as_str())
+                .asmflag(asmflags.join(" ").as_str());
+        } else {
+            emit_warning(format!("{OHOS_NDK_HOME} not set!").as_str());
+        }
     }
 
     fn build_rust_wrapper(&self) -> PathBuf {


### PR DESCRIPTION
### Issues:
So sorry that we must update cmake config for openharmony armv7a & x86_64.



### Description of changes: 
Before: 
we will get some errors
<img width="1307" alt="image" src="https://github.com/aws/aws-lc-rs/assets/32590310/508b6d3b-e05f-476b-90a9-56fe02291bce">


### Call-outs:
Point out areas that need special attention or support during the review process. Discuss architecture or design changes.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
