### PR TITLE
Latest cc requires Rust 1.67.0

### DIFF
--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -69,6 +69,8 @@ regex-automata = "~0.3.9"
 regex-syntax = "~0.7.5"
 # Pinned to avoid build failure in older versions
 proc-macro2 = "1.0.60"
+# Pinned dependency to preserve MSRV: 1.63.0 <= rust-version < 1.67.0
+cc = "=1.0.105"
 
 [package.metadata.cargo-udeps.ignore]
 development = ["which", "home", "regex", "regex-automata", "regex-syntax", "proc-macro2", "jobserver"]

--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -73,4 +73,4 @@ proc-macro2 = "1.0.60"
 cc = "=1.0.105"
 
 [package.metadata.cargo-udeps.ignore]
-development = ["which", "home", "regex", "regex-automata", "regex-syntax", "proc-macro2", "jobserver"]
+development = ["which", "home", "regex", "regex-automata", "regex-syntax", "proc-macro2", "jobserver", "cc"]


### PR DESCRIPTION
### Description of changes: 
* Fix our MSRV CI check due to latest cc changing its MSRV to 1.67.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
