### PR TITLE
Fix bindgen include file allowlist

### DIFF
--- a/aws-lc-sys/builder/bindgen.rs
+++ b/aws-lc-sys/builder/bindgen.rs
@@ -62,7 +62,7 @@ fn prepare_bindings_builder(manifest_dir: &Path, options: &BindingOptions) -> bi
         .derive_debug(true)
         .derive_default(true)
         .derive_eq(true)
-        .allowlist_file(r".*(/|\\)openssl(/|\\)[^/\\]+\.h")
+        .allowlist_file(r".*(/|\\)openssl((/|\\)[^/\\]+)+\.h")
         .allowlist_file(r".*(/|\\)rust_wrapper\.h")
         .rustified_enum(r"point_conversion_form_t")
         .default_macro_constant_type(bindgen::MacroTypeVariation::Signed)

--- a/aws-lc-sys/builder/cc_builder/aarch64_apple_darwin.rs
+++ b/aws-lc-sys/builder/cc_builder/aarch64_apple_darwin.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
-// Mon Jul 15 16:39:13 UTC 2024
+// Wed Jul 17 13:42:43 UTC 2024
 
 use crate::cc_builder::Library;
 

--- a/aws-lc-sys/builder/cc_builder/aarch64_unknown_linux_gnu.rs
+++ b/aws-lc-sys/builder/cc_builder/aarch64_unknown_linux_gnu.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
-// Mon Jul 15 16:42:58 UTC 2024
+// Wed Jul 17 13:47:15 UTC 2024
 
 use crate::cc_builder::Library;
 

--- a/aws-lc-sys/builder/cc_builder/aarch64_unknown_linux_musl.rs
+++ b/aws-lc-sys/builder/cc_builder/aarch64_unknown_linux_musl.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
-// Mon Jul 15 16:44:00 UTC 2024
+// Wed Jul 17 13:48:44 UTC 2024
 
 use crate::cc_builder::Library;
 

--- a/aws-lc-sys/builder/cc_builder/i686_unknown_linux_gnu.rs
+++ b/aws-lc-sys/builder/cc_builder/i686_unknown_linux_gnu.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
-// Mon Jul 15 16:42:50 UTC 2024
+// Wed Jul 17 13:47:36 UTC 2024
 
 use crate::cc_builder::Library;
 

--- a/aws-lc-sys/builder/cc_builder/x86_64_apple_darwin.rs
+++ b/aws-lc-sys/builder/cc_builder/x86_64_apple_darwin.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
-// Mon Jul 15 16:41:31 UTC 2024
+// Wed Jul 17 13:45:33 UTC 2024
 
 use crate::cc_builder::Library;
 

--- a/aws-lc-sys/builder/cc_builder/x86_64_unknown_linux_gnu.rs
+++ b/aws-lc-sys/builder/cc_builder/x86_64_unknown_linux_gnu.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
-// Mon Jul 15 16:39:13 UTC 2024
+// Wed Jul 17 13:43:23 UTC 2024
 
 use crate::cc_builder::Library;
 

--- a/aws-lc-sys/builder/cc_builder/x86_64_unknown_linux_musl.rs
+++ b/aws-lc-sys/builder/cc_builder/x86_64_unknown_linux_musl.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
-// Mon Jul 15 16:43:43 UTC 2024
+// Wed Jul 17 13:49:36 UTC 2024
 
 use crate::cc_builder::Library;
 

--- a/aws-lc-sys/src/aarch64_apple_darwin_crypto.rs
+++ b/aws-lc-sys/src/aarch64_apple_darwin_crypto.rs
@@ -27306,6 +27306,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[link_name = "\u{1}_aws_lc_0_20_0_EVP_PKEY_keygen_deterministic"]
+    pub fn EVP_PKEY_keygen_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        out_pkey: *mut *mut EVP_PKEY,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}_aws_lc_0_20_0_EVP_PKEY_encapsulate_deterministic"]
+    pub fn EVP_PKEY_encapsulate_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        ciphertext: *mut u8,
+        ciphertext_len: *mut usize,
+        shared_secret: *mut u8,
+        shared_secret_len: *mut usize,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
     #[link_name = "\u{1}_aws_lc_0_20_0_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }

--- a/aws-lc-sys/src/aarch64_apple_darwin_crypto_ssl.rs
+++ b/aws-lc-sys/src/aarch64_apple_darwin_crypto_ssl.rs
@@ -28326,6 +28326,27 @@ extern "C" {
         encrypted_bit: u8,
     ) -> ::std::os::raw::c_int;
 }
+extern "C" {
+    #[link_name = "\u{1}_aws_lc_0_20_0_EVP_PKEY_keygen_deterministic"]
+    pub fn EVP_PKEY_keygen_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        out_pkey: *mut *mut EVP_PKEY,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}_aws_lc_0_20_0_EVP_PKEY_encapsulate_deterministic"]
+    pub fn EVP_PKEY_encapsulate_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        ciphertext: *mut u8,
+        ciphertext_len: *mut usize,
+        shared_secret: *mut u8,
+        shared_secret_len: *mut usize,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
 #[repr(C)]
 #[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]

--- a/aws-lc-sys/src/aarch64_unknown_linux_gnu_crypto.rs
+++ b/aws-lc-sys/src/aarch64_unknown_linux_gnu_crypto.rs
@@ -27341,6 +27341,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[link_name = "\u{1}aws_lc_0_20_0_EVP_PKEY_keygen_deterministic"]
+    pub fn EVP_PKEY_keygen_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        out_pkey: *mut *mut EVP_PKEY,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}aws_lc_0_20_0_EVP_PKEY_encapsulate_deterministic"]
+    pub fn EVP_PKEY_encapsulate_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        ciphertext: *mut u8,
+        ciphertext_len: *mut usize,
+        shared_secret: *mut u8,
+        shared_secret_len: *mut usize,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
     #[link_name = "\u{1}aws_lc_0_20_0_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }

--- a/aws-lc-sys/src/aarch64_unknown_linux_gnu_crypto_ssl.rs
+++ b/aws-lc-sys/src/aarch64_unknown_linux_gnu_crypto_ssl.rs
@@ -28360,6 +28360,27 @@ extern "C" {
         encrypted_bit: u8,
     ) -> ::std::os::raw::c_int;
 }
+extern "C" {
+    #[link_name = "\u{1}aws_lc_0_20_0_EVP_PKEY_keygen_deterministic"]
+    pub fn EVP_PKEY_keygen_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        out_pkey: *mut *mut EVP_PKEY,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}aws_lc_0_20_0_EVP_PKEY_encapsulate_deterministic"]
+    pub fn EVP_PKEY_encapsulate_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        ciphertext: *mut u8,
+        ciphertext_len: *mut usize,
+        shared_secret: *mut u8,
+        shared_secret_len: *mut usize,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
 #[repr(C)]
 #[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]

--- a/aws-lc-sys/src/aarch64_unknown_linux_musl_crypto.rs
+++ b/aws-lc-sys/src/aarch64_unknown_linux_musl_crypto.rs
@@ -27031,6 +27031,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[link_name = "\u{1}aws_lc_0_20_0_EVP_PKEY_keygen_deterministic"]
+    pub fn EVP_PKEY_keygen_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        out_pkey: *mut *mut EVP_PKEY,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}aws_lc_0_20_0_EVP_PKEY_encapsulate_deterministic"]
+    pub fn EVP_PKEY_encapsulate_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        ciphertext: *mut u8,
+        ciphertext_len: *mut usize,
+        shared_secret: *mut u8,
+        shared_secret_len: *mut usize,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
     #[link_name = "\u{1}aws_lc_0_20_0_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }

--- a/aws-lc-sys/src/aarch64_unknown_linux_musl_crypto_ssl.rs
+++ b/aws-lc-sys/src/aarch64_unknown_linux_musl_crypto_ssl.rs
@@ -28050,6 +28050,27 @@ extern "C" {
         encrypted_bit: u8,
     ) -> ::std::os::raw::c_int;
 }
+extern "C" {
+    #[link_name = "\u{1}aws_lc_0_20_0_EVP_PKEY_keygen_deterministic"]
+    pub fn EVP_PKEY_keygen_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        out_pkey: *mut *mut EVP_PKEY,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}aws_lc_0_20_0_EVP_PKEY_encapsulate_deterministic"]
+    pub fn EVP_PKEY_encapsulate_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        ciphertext: *mut u8,
+        ciphertext_len: *mut usize,
+        shared_secret: *mut u8,
+        shared_secret_len: *mut usize,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
 #[repr(C)]
 #[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]

--- a/aws-lc-sys/src/i686_unknown_linux_gnu_crypto.rs
+++ b/aws-lc-sys/src/i686_unknown_linux_gnu_crypto.rs
@@ -27342,6 +27342,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[link_name = "\u{1}aws_lc_0_20_0_EVP_PKEY_keygen_deterministic"]
+    pub fn EVP_PKEY_keygen_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        out_pkey: *mut *mut EVP_PKEY,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}aws_lc_0_20_0_EVP_PKEY_encapsulate_deterministic"]
+    pub fn EVP_PKEY_encapsulate_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        ciphertext: *mut u8,
+        ciphertext_len: *mut usize,
+        shared_secret: *mut u8,
+        shared_secret_len: *mut usize,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
     #[link_name = "\u{1}aws_lc_0_20_0_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }

--- a/aws-lc-sys/src/i686_unknown_linux_gnu_crypto_ssl.rs
+++ b/aws-lc-sys/src/i686_unknown_linux_gnu_crypto_ssl.rs
@@ -28361,6 +28361,27 @@ extern "C" {
         encrypted_bit: u8,
     ) -> ::std::os::raw::c_int;
 }
+extern "C" {
+    #[link_name = "\u{1}aws_lc_0_20_0_EVP_PKEY_keygen_deterministic"]
+    pub fn EVP_PKEY_keygen_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        out_pkey: *mut *mut EVP_PKEY,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}aws_lc_0_20_0_EVP_PKEY_encapsulate_deterministic"]
+    pub fn EVP_PKEY_encapsulate_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        ciphertext: *mut u8,
+        ciphertext_len: *mut usize,
+        shared_secret: *mut u8,
+        shared_secret_len: *mut usize,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
 #[repr(C)]
 #[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]

--- a/aws-lc-sys/src/x86_64_apple_darwin_crypto.rs
+++ b/aws-lc-sys/src/x86_64_apple_darwin_crypto.rs
@@ -27306,6 +27306,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[link_name = "\u{1}_aws_lc_0_20_0_EVP_PKEY_keygen_deterministic"]
+    pub fn EVP_PKEY_keygen_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        out_pkey: *mut *mut EVP_PKEY,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}_aws_lc_0_20_0_EVP_PKEY_encapsulate_deterministic"]
+    pub fn EVP_PKEY_encapsulate_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        ciphertext: *mut u8,
+        ciphertext_len: *mut usize,
+        shared_secret: *mut u8,
+        shared_secret_len: *mut usize,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
     #[link_name = "\u{1}_aws_lc_0_20_0_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }

--- a/aws-lc-sys/src/x86_64_apple_darwin_crypto_ssl.rs
+++ b/aws-lc-sys/src/x86_64_apple_darwin_crypto_ssl.rs
@@ -28326,6 +28326,27 @@ extern "C" {
         encrypted_bit: u8,
     ) -> ::std::os::raw::c_int;
 }
+extern "C" {
+    #[link_name = "\u{1}_aws_lc_0_20_0_EVP_PKEY_keygen_deterministic"]
+    pub fn EVP_PKEY_keygen_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        out_pkey: *mut *mut EVP_PKEY,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}_aws_lc_0_20_0_EVP_PKEY_encapsulate_deterministic"]
+    pub fn EVP_PKEY_encapsulate_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        ciphertext: *mut u8,
+        ciphertext_len: *mut usize,
+        shared_secret: *mut u8,
+        shared_secret_len: *mut usize,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
 #[repr(C)]
 #[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]

--- a/aws-lc-sys/src/x86_64_unknown_linux_gnu_crypto.rs
+++ b/aws-lc-sys/src/x86_64_unknown_linux_gnu_crypto.rs
@@ -27341,6 +27341,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[link_name = "\u{1}aws_lc_0_20_0_EVP_PKEY_keygen_deterministic"]
+    pub fn EVP_PKEY_keygen_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        out_pkey: *mut *mut EVP_PKEY,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}aws_lc_0_20_0_EVP_PKEY_encapsulate_deterministic"]
+    pub fn EVP_PKEY_encapsulate_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        ciphertext: *mut u8,
+        ciphertext_len: *mut usize,
+        shared_secret: *mut u8,
+        shared_secret_len: *mut usize,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
     #[link_name = "\u{1}aws_lc_0_20_0_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }

--- a/aws-lc-sys/src/x86_64_unknown_linux_gnu_crypto_ssl.rs
+++ b/aws-lc-sys/src/x86_64_unknown_linux_gnu_crypto_ssl.rs
@@ -28360,6 +28360,27 @@ extern "C" {
         encrypted_bit: u8,
     ) -> ::std::os::raw::c_int;
 }
+extern "C" {
+    #[link_name = "\u{1}aws_lc_0_20_0_EVP_PKEY_keygen_deterministic"]
+    pub fn EVP_PKEY_keygen_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        out_pkey: *mut *mut EVP_PKEY,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}aws_lc_0_20_0_EVP_PKEY_encapsulate_deterministic"]
+    pub fn EVP_PKEY_encapsulate_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        ciphertext: *mut u8,
+        ciphertext_len: *mut usize,
+        shared_secret: *mut u8,
+        shared_secret_len: *mut usize,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
 #[repr(C)]
 #[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]

--- a/aws-lc-sys/src/x86_64_unknown_linux_musl_crypto.rs
+++ b/aws-lc-sys/src/x86_64_unknown_linux_musl_crypto.rs
@@ -27031,6 +27031,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[link_name = "\u{1}aws_lc_0_20_0_EVP_PKEY_keygen_deterministic"]
+    pub fn EVP_PKEY_keygen_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        out_pkey: *mut *mut EVP_PKEY,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}aws_lc_0_20_0_EVP_PKEY_encapsulate_deterministic"]
+    pub fn EVP_PKEY_encapsulate_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        ciphertext: *mut u8,
+        ciphertext_len: *mut usize,
+        shared_secret: *mut u8,
+        shared_secret_len: *mut usize,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
     #[link_name = "\u{1}aws_lc_0_20_0_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }

--- a/aws-lc-sys/src/x86_64_unknown_linux_musl_crypto_ssl.rs
+++ b/aws-lc-sys/src/x86_64_unknown_linux_musl_crypto_ssl.rs
@@ -28050,6 +28050,27 @@ extern "C" {
         encrypted_bit: u8,
     ) -> ::std::os::raw::c_int;
 }
+extern "C" {
+    #[link_name = "\u{1}aws_lc_0_20_0_EVP_PKEY_keygen_deterministic"]
+    pub fn EVP_PKEY_keygen_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        out_pkey: *mut *mut EVP_PKEY,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}aws_lc_0_20_0_EVP_PKEY_encapsulate_deterministic"]
+    pub fn EVP_PKEY_encapsulate_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        ciphertext: *mut u8,
+        ciphertext_len: *mut usize,
+        shared_secret: *mut u8,
+        shared_secret_len: *mut usize,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
 #[repr(C)]
 #[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]


### PR DESCRIPTION
### Description of changes: 
* Bindgen was ignoring the `#include "openssl/experimental/kem_deterministic_api.h"` that we added to the "rust_wrapper.h".
* Bindgen's "allowlist pattern" was updated to allow include files in subdirectories.
* Workflow run is here: https://github.com/aws/aws-lc-rs/actions/runs/9975128440

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
