### PR TITLE
Fill gaps in documentation

### DIFF
--- a/aws-lc-rs/src/agreement.rs
+++ b/aws-lc-rs/src/agreement.rs
@@ -562,6 +562,9 @@ impl Debug for PublicKey {
 }
 
 impl AsRef<[u8]> for PublicKey {
+    /// Serializes the public key in an uncompressed form (X9.62) using the
+    /// Octet-String-to-Elliptic-Curve-Point algorithm in
+    /// [SEC 1: Elliptic Curve Cryptography, Version 2.0].
     fn as_ref(&self) -> &[u8] {
         &self.public_key[0..self.len]
     }

--- a/aws-lc-rs/src/ed25519.rs
+++ b/aws-lc-rs/src/ed25519.rs
@@ -130,6 +130,7 @@ pub struct PublicKey([u8; ED25519_PUBLIC_KEY_LEN]);
 
 impl AsRef<[u8]> for PublicKey {
     #[inline]
+    /// Returns the "raw" bytes of the ED25519 public key
     fn as_ref(&self) -> &[u8] {
         &self.0
     }

--- a/aws-lc-rs/src/rsa/key.rs
+++ b/aws-lc-rs/src/rsa/key.rs
@@ -343,6 +343,7 @@ impl Debug for PublicKey {
 }
 
 impl AsRef<[u8]> for PublicKey {
+    /// DER encode a RSA public key to (RFC 8017) `RSAPublicKey` structure.
     fn as_ref(&self) -> &[u8] {
         self.key.as_ref()
     }

--- a/book/src/requirements/windows.md
+++ b/book/src/requirements/windows.md
@@ -4,7 +4,7 @@
 |---------------------------|--------------------------------------------|-----------------------------------------|-------------------|
 | `x86_64-pc-windows-msvc`  | C/C++ Compiler, CMake & NASM               | C/C++ Compiler, CMake, NASM, Go & Ninja | **_Yes_**         | 
 | `x86_64-pc-windows-gnu`   | C/C++ Compiler, CMake & NASM               | **Not Supported**                       | **_Yes_**         |
-| `aarch64-pc-windows-msvc` | C/C++ Compiler (`clang-cl`), CMake & Ninja | **Not Supported**                       | **_Yes_**         |
+| `aarch64-pc-windows-msvc` | C/C++ Compiler (MSVC's `clang-cl`) & CMake | **Not Supported**                       | **_Yes_**         |
 | _Other_                   | **Not Supported**                          | **Not Supported**                       | N/A               |
 
 ## C/C++ Compiler


### PR DESCRIPTION
### Description of changes: 
* Update docs for `as_ref` functions of keys to indicate the encoding being used.
* Update User Guide now that Ninja is no longer required for Windows/ARM64 builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
