### PR TITLE
Drop unused `zeroize_derive` feature dependency

### DIFF
--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -48,7 +48,7 @@ fips = ["dep:aws-lc-fips-sys"]
 untrusted = { version = "0.7.1", optional = true }
 aws-lc-sys = { version = "0.20.0", path = "../aws-lc-sys", optional = true }
 aws-lc-fips-sys = { version = "0.12.0", path = "../aws-lc-fips-sys", optional = true }
-zeroize = { version = "1.7", features = ["zeroize_derive"] }
+zeroize = "1.7"
 mirai-annotations = "1.12.0"
 paste = "1.0.11"
 


### PR DESCRIPTION
This seems to be unused, and has the effect of removing several large proc macro dependencies from the dependency tree:

```
--- before	2024-07-29 11:07:47.128726312 +0100
+++ after	2024-07-29 11:08:01.911637253 +0100
@@ -24,15 +24,6 @@
 ├── paste v1.0.15 (proc-macro)
 ├── untrusted v0.7.1
 └── zeroize v1.8.1
-    └── zeroize_derive v1.4.2 (proc-macro)
-        ├── proc-macro2 v1.0.86
-        │   └── unicode-ident v1.0.12
-        ├── quote v1.0.36
-        │   └── proc-macro2 v1.0.86 (*)
-        └── syn v2.0.72
-            ├── proc-macro2 v1.0.86 (*)
-            ├── quote v1.0.36 (*)
-            └── unicode-ident v1.0.12
```

According to `cargo build --timings` the eliminated dependencies account for 3.95s of the build time, which compares unfavourably with the entire aws-lc-sys build time (5.75s).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
